### PR TITLE
feat(rdf): infraestructura RDF, SHACL y SPARQL

### DIFF
--- a/apps/api/src/atlashabita/infrastructure/rdf/__init__.py
+++ b/apps/api/src/atlashabita/infrastructure/rdf/__init__.py
@@ -1,0 +1,64 @@
+"""Infraestructura RDF de AtlasHabita.
+
+Este paquete expone los componentes necesarios para construir, validar,
+consultar y serializar el grafo de conocimiento que sostiene el dominio:
+
+* :class:`URIBuilder` concentra la política de URIs.
+* :class:`GraphBuilder` traduce el dataset seed a RDF.
+* :class:`ShaclValidator` aplica las shapes del repositorio al grafo.
+* :class:`SparqlRunner` ejecuta consultas con salvaguardas.
+* ``serialize`` / ``write`` estandarizan la exportación del grafo.
+* ``build_manifest`` describe el grafo para diagnósticos y auditoría.
+
+Importar desde este módulo en lugar de los submódulos reduce el acoplamiento
+entre capas y permite evolucionar los ficheros internos sin afectar a los
+consumidores.
+"""
+
+from atlashabita.infrastructure.rdf.graph_builder import GraphBuilder
+from atlashabita.infrastructure.rdf.manifest import build_manifest
+from atlashabita.infrastructure.rdf.namespaces import (
+    AH,
+    AHR,
+    DCT,
+    GEO,
+    PROV,
+    QB,
+    SKOS,
+    bind_all,
+)
+from atlashabita.infrastructure.rdf.serializer import SerializationFormat, serialize, write
+from atlashabita.infrastructure.rdf.shacl_validator import (
+    ShaclValidator,
+    ShaclViolation,
+    ValidationReport,
+)
+from atlashabita.infrastructure.rdf.sparql_queries import (
+    SparqlRunner,
+    SparqlTimeoutError,
+    SparqlUpdateForbiddenError,
+)
+from atlashabita.infrastructure.rdf.uri_builder import URIBuilder
+
+__all__ = [
+    "AH",
+    "AHR",
+    "DCT",
+    "GEO",
+    "PROV",
+    "QB",
+    "SKOS",
+    "GraphBuilder",
+    "SerializationFormat",
+    "ShaclValidator",
+    "ShaclViolation",
+    "SparqlRunner",
+    "SparqlTimeoutError",
+    "SparqlUpdateForbiddenError",
+    "URIBuilder",
+    "ValidationReport",
+    "bind_all",
+    "build_manifest",
+    "serialize",
+    "write",
+]

--- a/apps/api/src/atlashabita/infrastructure/rdf/graph_builder.py
+++ b/apps/api/src/atlashabita/infrastructure/rdf/graph_builder.py
@@ -1,0 +1,293 @@
+"""Construcción del grafo RDF a partir del dataset seed.
+
+Este módulo traduce los objetos de dominio (territorios, indicadores,
+observaciones, fuentes, perfiles) a tripletas RDF siguiendo la ontología
+``ah:``. Se ofrecen dos modos complementarios:
+
+* ``build`` devuelve un ``rdflib.Dataset`` con **named graphs** por dominio,
+  cumpliendo la recomendación de separar territorios, observaciones, fuentes,
+  indicadores, perfiles y ontología para auditar cada bloque por separado.
+* ``build_graph`` aplana todos los triples a un único ``Graph``. Es útil para
+  SPARQL en la MVP, donde rdflib ejecuta las consultas sobre un grafo default
+  sin necesidad de coordinarse con un triplestore externo.
+
+El builder es determinista: misma entrada produce siempre las mismas URIs y
+los mismos literales, lo que permite hashear el grafo y detectar cambios
+entre corridas (útil para cachés y pruebas de regresión).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+from pathlib import Path
+from typing import Final
+
+from rdflib import Dataset, Graph, Literal, URIRef
+from rdflib.namespace import RDF, RDFS, XSD
+
+from atlashabita.domain.indicators import (
+    Indicator,
+    IndicatorObservation,
+)
+from atlashabita.domain.profiles import DecisionProfile
+from atlashabita.domain.sources import DataSource
+from atlashabita.domain.territories import Territory, TerritoryKind
+from atlashabita.infrastructure.ingestion.seed_loader import SeedDataset
+from atlashabita.infrastructure.rdf.namespaces import AH, DCT, GEO, PROV, bind_all
+from atlashabita.infrastructure.rdf.uri_builder import URIBuilder
+
+#: Nombres canónicos de named graphs por dominio.
+GRAPH_TERRITORIES: Final[str] = "territories"
+GRAPH_INDICATORS: Final[str] = "indicators"
+GRAPH_SOURCES: Final[str] = "sources"
+GRAPH_OBSERVATIONS: Final[str] = "observations"
+GRAPH_PROFILES: Final[str] = "profiles"
+GRAPH_ONTOLOGY: Final[str] = "ontology"
+
+
+_TERRITORY_CLASS: dict[TerritoryKind, URIRef] = {
+    TerritoryKind.AUTONOMOUS_COMMUNITY: AH.AutonomousCommunity,
+    TerritoryKind.PROVINCE: AH.Province,
+    TerritoryKind.MUNICIPALITY: AH.Municipality,
+}
+
+
+@dataclass(frozen=True, slots=True)
+class GraphBuilder:
+    """Traduce un :class:`SeedDataset` a grafo(s) RDF.
+
+    La inyección de :class:`URIBuilder` permite probar el builder con URIs
+    sintéticas y mantener la política de URIs en un único lugar (SOLID: la
+    responsabilidad de *cómo* se nombra un recurso vive en el builder de URIs,
+    no aquí).
+    """
+
+    uri_builder: URIBuilder
+
+    def build(self, dataset: SeedDataset, *, ontology_path: Path | None = None) -> Dataset:
+        """Crea un ``Dataset`` con named graphs por dominio.
+
+        Parameters
+        ----------
+        dataset:
+            Datos del seed ya parseados por :class:`SeedLoader`.
+        ontology_path:
+            Ruta opcional al fichero Turtle de la ontología. Si se pasa, se
+            importa en el named graph ``ontology`` para que SPARQL pueda
+            resolver etiquetas/domain/range contra el TBox sin dependencias
+            externas.
+        """
+        ds = Dataset()
+        bind_all(ds)
+
+        territories_graph = ds.graph(self.uri_builder.named_graph(GRAPH_TERRITORIES))
+        indicators_graph = ds.graph(self.uri_builder.named_graph(GRAPH_INDICATORS))
+        sources_graph = ds.graph(self.uri_builder.named_graph(GRAPH_SOURCES))
+        observations_graph = ds.graph(self.uri_builder.named_graph(GRAPH_OBSERVATIONS))
+        profiles_graph = ds.graph(self.uri_builder.named_graph(GRAPH_PROFILES))
+
+        for graph in (
+            territories_graph,
+            indicators_graph,
+            sources_graph,
+            observations_graph,
+            profiles_graph,
+        ):
+            bind_all(graph)
+
+        for territory in dataset.territories:
+            self._emit_territory(territories_graph, territory)
+        for indicator in dataset.indicators:
+            self._emit_indicator(indicators_graph, indicator)
+        for source in dataset.sources:
+            self._emit_source(sources_graph, source)
+        for observation in dataset.observations:
+            self._emit_observation(observations_graph, observation)
+        for profile in dataset.profiles:
+            self._emit_profile(profiles_graph, profile)
+
+        if ontology_path is not None and ontology_path.exists():
+            ontology_graph = ds.graph(self.uri_builder.named_graph(GRAPH_ONTOLOGY))
+            bind_all(ontology_graph)
+            ontology_graph.parse(ontology_path, format="turtle")
+
+        return ds
+
+    def build_graph(self, dataset: SeedDataset, *, ontology_path: Path | None = None) -> Graph:
+        """Construye un ``Graph`` único con todas las tripletas.
+
+        Útil en la MVP para ejecutar SPARQL sin preocuparnos por el grafo
+        por defecto frente a los named graphs. El orden de inserción es
+        irrelevante semánticamente pero se mantiene estable para producir
+        serializaciones reproducibles.
+        """
+        graph = Graph()
+        bind_all(graph)
+
+        for territory in dataset.territories:
+            self._emit_territory(graph, territory)
+        for indicator in dataset.indicators:
+            self._emit_indicator(graph, indicator)
+        for source in dataset.sources:
+            self._emit_source(graph, source)
+        for observation in dataset.observations:
+            self._emit_observation(graph, observation)
+        for profile in dataset.profiles:
+            self._emit_profile(graph, profile)
+
+        if ontology_path is not None and ontology_path.exists():
+            graph.parse(ontology_path, format="turtle")
+
+        return graph
+
+    def _emit_territory(self, graph: Graph, territory: Territory) -> None:
+        """Proyecta un :class:`Territory` en tripletas RDF."""
+        subject = self.uri_builder.territory(territory.code, territory.kind)
+        graph.add((subject, RDF.type, AH.Territory))
+        graph.add((subject, RDF.type, _TERRITORY_CLASS[territory.kind]))
+        graph.add((subject, DCT.identifier, Literal(territory.code, datatype=XSD.string)))
+        graph.add((subject, RDFS.label, Literal(territory.name, lang="es")))
+
+        parent = self._resolve_parent(territory)
+        if parent is not None:
+            graph.add((subject, AH.belongsTo, parent))
+
+        if territory.centroid is not None:
+            graph.add((subject, GEO.lat, _decimal_literal(territory.centroid.lat)))
+            graph.add((subject, GEO.long, _decimal_literal(territory.centroid.lon)))
+        if territory.population is not None:
+            graph.add((subject, AH.population, Literal(territory.population, datatype=XSD.integer)))
+        if territory.area_km2 is not None:
+            graph.add((subject, AH.area, _decimal_literal(territory.area_km2)))
+
+    def _resolve_parent(self, territory: Territory) -> URIRef | None:
+        """Devuelve la URI del territorio padre según la jerarquía administrativa.
+
+        Un municipio pertenece a su provincia; una provincia pertenece a su
+        comunidad autónoma; las comunidades no tienen padre. Esto codifica
+        ``ah:belongsTo`` en el grafo sin necesidad de lookups cruzados.
+        """
+        if territory.kind is TerritoryKind.MUNICIPALITY and territory.province_code:
+            return self.uri_builder.territory(territory.province_code, TerritoryKind.PROVINCE)
+        if territory.kind is TerritoryKind.PROVINCE and territory.autonomous_community_code:
+            return self.uri_builder.territory(
+                territory.autonomous_community_code,
+                TerritoryKind.AUTONOMOUS_COMMUNITY,
+            )
+        return None
+
+    def _emit_indicator(self, graph: Graph, indicator: Indicator) -> None:
+        """Proyecta la definición semántica de un indicador."""
+        subject = self.uri_builder.indicator(indicator.code)
+        graph.add((subject, RDF.type, AH.Indicator))
+        graph.add((subject, DCT.identifier, Literal(indicator.code, datatype=XSD.string)))
+        graph.add((subject, RDFS.label, Literal(indicator.label, lang="es")))
+        graph.add((subject, DCT.description, Literal(indicator.description, lang="es")))
+        graph.add((subject, AH.unit, Literal(indicator.unit, datatype=XSD.string)))
+        # ``sh:in`` en shapes compara por igualdad estructural exacta, por lo
+        # que la dirección se emite como literal plano (sin datatype) para
+        # alinear con la lista enumerada de la shape.
+        graph.add((subject, AH.direction, Literal(indicator.direction.value)))
+        graph.add(
+            (
+                subject,
+                PROV.wasAttributedTo,
+                self.uri_builder.source(indicator.source_id),
+            )
+        )
+
+    def _emit_source(self, graph: Graph, source: DataSource) -> None:
+        """Proyecta una fuente de datos como ``prov:Agent``."""
+        subject = self.uri_builder.source(source.id)
+        graph.add((subject, RDF.type, AH.DataSource))
+        graph.add((subject, RDF.type, PROV.Agent))
+        graph.add((subject, DCT.identifier, Literal(source.id, datatype=XSD.string)))
+        graph.add((subject, DCT.title, Literal(source.title, lang="es")))
+        graph.add((subject, DCT.publisher, Literal(source.publisher, lang="es")))
+        graph.add((subject, DCT.source, URIRef(source.url)))
+        graph.add((subject, AH.license, Literal(source.license, datatype=XSD.string)))
+        graph.add((subject, AH.periodicity, Literal(source.periodicity, datatype=XSD.string)))
+        if source.description:
+            graph.add((subject, DCT.description, Literal(source.description, lang="es")))
+
+    def _emit_observation(self, graph: Graph, observation: IndicatorObservation) -> None:
+        """Proyecta una observación y la enlaza al territorio/fuente/indicador."""
+        subject = self.uri_builder.observation(
+            observation.indicator_code, observation.territory_id, observation.period
+        )
+        graph.add((subject, RDF.type, AH.IndicatorObservation))
+        graph.add(
+            (
+                subject,
+                AH.indicator,
+                self.uri_builder.indicator(observation.indicator_code),
+            )
+        )
+        graph.add((subject, AH.value, _decimal_literal(observation.value)))
+        graph.add((subject, AH.period, Literal(observation.period, datatype=XSD.string)))
+        graph.add((subject, AH.qualityFlag, Literal(observation.quality, datatype=XSD.string)))
+        graph.add((subject, AH.providedBy, self.uri_builder.source(observation.source_id)))
+
+        territory_uri = self._territory_uri_from_id(observation.territory_id)
+        if territory_uri is not None:
+            graph.add((territory_uri, AH.hasIndicatorObservation, subject))
+
+    def _emit_profile(self, graph: Graph, profile: DecisionProfile) -> None:
+        """Proyecta un perfil de decisión y sus pesos como contribuciones base.
+
+        Cada contribución se identifica con una URI determinista derivada del
+        perfil y el indicador. Preferimos URIs sobre blank nodes porque:
+
+        * Hacen el grafo **idempotente**: dos construcciones producen los
+          mismos triples, lo que facilita hashing y diffs.
+        * Permiten referenciar una contribución concreta desde SPARQL o API.
+        """
+        subject = self.uri_builder.profile(profile.id)
+        graph.add((subject, RDF.type, AH.DecisionProfile))
+        graph.add((subject, DCT.identifier, Literal(profile.id, datatype=XSD.string)))
+        graph.add((subject, RDFS.label, Literal(profile.label, lang="es")))
+        graph.add((subject, DCT.description, Literal(profile.description, lang="es")))
+
+        profile_uri = str(subject)
+        for indicator_code, weight in profile.weights.items():
+            contribution = URIRef(f"{profile_uri}/contribution/{indicator_code}")
+            graph.add((subject, AH.hasContribution, contribution))
+            graph.add((contribution, RDF.type, AH.ScoreContribution))
+            graph.add((contribution, AH.indicator, self.uri_builder.indicator(indicator_code)))
+            graph.add((contribution, AH.weight, _decimal_literal(weight)))
+
+    def _territory_uri_from_id(self, territory_id: str) -> URIRef | None:
+        """Convierte ``municipality:41091`` en la URI de territorio correspondiente."""
+        try:
+            kind_value, code = territory_id.split(":", maxsplit=1)
+        except ValueError:
+            return None
+        try:
+            kind = TerritoryKind(kind_value)
+        except ValueError:
+            return None
+        return self.uri_builder.territory(code, kind)
+
+
+def _decimal_literal(value: float | int | Decimal) -> Literal:
+    """Construye un ``xsd:decimal`` robusto frente a flotantes binarios.
+
+    SHACL exige ``xsd:decimal`` para ``ah:value`` y ``ah:weight``. rdflib
+    serializa los ``float`` de Python como ``xsd:double`` por defecto, por lo
+    que se fuerza la conversión vía :class:`Decimal` a partir de su
+    representación textual, evitando artefactos como ``13.600000000000001``.
+    """
+    decimal_value = value if isinstance(value, Decimal) else Decimal(str(value))
+    return Literal(decimal_value, datatype=XSD.decimal)
+
+
+__all__ = [
+    "GRAPH_INDICATORS",
+    "GRAPH_OBSERVATIONS",
+    "GRAPH_ONTOLOGY",
+    "GRAPH_PROFILES",
+    "GRAPH_SOURCES",
+    "GRAPH_TERRITORIES",
+    "GraphBuilder",
+]

--- a/apps/api/src/atlashabita/infrastructure/rdf/manifest.py
+++ b/apps/api/src/atlashabita/infrastructure/rdf/manifest.py
@@ -1,0 +1,67 @@
+"""Manifiesto resumen del grafo AtlasHabita.
+
+El manifiesto se genera tras construir el grafo para documentar de un
+vistazo qué hay dentro (nº de tripletas, grafos nombrados, cardinalidades por
+clase). Se usa:
+
+* En tests para verificar invariantes sin parsear todo el dataset.
+* Como payload para endpoints de diagnóstico (``/debug/graph-manifest``).
+* Como artefacto publicable junto al fichero Turtle para auditoría.
+
+El formato devuelto es un ``dict`` ordinario apto para ``json.dumps`` sin
+dependencias adicionales.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+from rdflib import Dataset
+from rdflib.namespace import RDF
+
+from atlashabita.infrastructure.rdf.namespaces import AH
+
+
+def build_manifest(dataset: Dataset) -> dict[str, Any]:
+    """Genera el manifiesto del ``Dataset`` indicado.
+
+    Se cuentan las tripletas recorriendo todos los cuadruples: ``len(dataset)``
+    sólo cuenta el grafo default en algunas versiones de rdflib, por lo que se
+    usa la iteración explícita por seguridad y compatibilidad.
+    """
+    total_triples = 0
+    named_graphs: dict[str, int] = {}
+    classes_count: dict[str, int] = {}
+    territories_count = 0
+    observations_count = 0
+
+    territory_classes = {AH.Municipality, AH.Province, AH.AutonomousCommunity}
+
+    for graph in dataset.graphs():
+        identifier = str(graph.identifier)
+        count = 0
+        for _subject, predicate, obj in graph.triples((None, None, None)):
+            count += 1
+            if predicate == RDF.type:
+                class_iri = str(obj)
+                classes_count[class_iri] = classes_count.get(class_iri, 0) + 1
+                if obj in territory_classes:
+                    territories_count += 1
+                elif obj == AH.IndicatorObservation:
+                    observations_count += 1
+        if count:
+            named_graphs[identifier] = count
+            total_triples += count
+
+    return {
+        "total_triples": total_triples,
+        "named_graphs": named_graphs,
+        "classes_count": classes_count,
+        "territories_count": territories_count,
+        "observations_count": observations_count,
+        "generated_at_iso": datetime.now(tz=UTC).isoformat(timespec="seconds"),
+    }
+
+
+__all__ = ["build_manifest"]

--- a/apps/api/src/atlashabita/infrastructure/rdf/namespaces.py
+++ b/apps/api/src/atlashabita/infrastructure/rdf/namespaces.py
@@ -1,0 +1,65 @@
+"""Namespaces RDF utilizados por AtlasHabita.
+
+Este módulo centraliza los prefijos y namespaces empleados por toda la capa
+RDF. Exponerlos como constantes tiene dos ventajas fundamentales:
+
+* **Coherencia:** todo el proyecto usa la misma URI para la ontología y los
+  recursos, evitando inconsistencias sutiles cuando distintas capas escriben
+  tripletas.
+* **Trazabilidad:** si en el futuro cambia el dominio canónico (por ejemplo,
+  al mover ``data.atlashabita.example`` a un dominio real), basta con
+  actualizar este fichero.
+
+También se ofrece ``bind_all`` para inyectar los prefijos en un ``Graph`` o
+``Dataset`` y producir serializaciones Turtle/JSON-LD legibles por humanos.
+"""
+
+from __future__ import annotations
+
+from rdflib import Dataset, Graph, Namespace
+from rdflib.namespace import DCTERMS
+from rdflib.namespace import PROV as RDFLIB_PROV
+from rdflib.namespace import SKOS as RDFLIB_SKOS
+
+#: Ontología propia de AtlasHabita (clases, propiedades).
+AH = Namespace("https://data.atlashabita.example/ontology/")
+
+#: Recursos (territorios, indicadores, fuentes, perfiles, scores, observaciones).
+AHR = Namespace("https://data.atlashabita.example/resource/")
+
+#: Dublin Core Terms para metadatos (título, identificador, licencia...).
+DCT = DCTERMS
+
+#: SKOS para taxonomías ligeras y etiquetas alternativas.
+SKOS = RDFLIB_SKOS
+
+#: WGS84 geo positioning (``geo:lat``, ``geo:long``). No se usa el ``GEO`` de
+#: rdflib porque apunta a GeoSPARQL (http://www.opengis.net/ont/geosparql#);
+#: nuestra ontología y shapes usan el vocabulario histórico WGS84.
+GEO = Namespace("http://www.w3.org/2003/01/geo/wgs84_pos#")
+
+#: PROV-O para procedencia (fuente, ingesta, atribuciones).
+PROV = RDFLIB_PROV
+
+#: Data Cube Vocabulary (reservado por si se modelan observaciones multidim).
+QB = Namespace("http://purl.org/linked-data/cube#")
+
+
+def bind_all(graph: Graph | Dataset) -> None:
+    """Registra los prefijos canónicos en el grafo o dataset indicado.
+
+    Se utiliza antes de serializar para que los ficheros Turtle y JSON-LD
+    muestren prefijos cortos (``ah:``, ``ahr:``...) en lugar de URIs
+    completos, mejorando la legibilidad para humanos y para herramientas de
+    revisión (pull requests, diffs de ontología, etc.).
+    """
+    graph.bind("ah", AH, override=True)
+    graph.bind("ahr", AHR, override=True)
+    graph.bind("dct", DCT, override=True)
+    graph.bind("skos", SKOS, override=True)
+    graph.bind("geo", GEO, override=True)
+    graph.bind("prov", PROV, override=True)
+    graph.bind("qb", QB, override=True)
+
+
+__all__ = ["AH", "AHR", "DCT", "GEO", "PROV", "QB", "SKOS", "bind_all"]

--- a/apps/api/src/atlashabita/infrastructure/rdf/serializer.py
+++ b/apps/api/src/atlashabita/infrastructure/rdf/serializer.py
@@ -1,0 +1,79 @@
+"""Serialización uniforme de grafos y datasets RDF.
+
+rdflib ofrece distintos backends de serialización (``turtle``, ``json-ld``,
+``nt``, ``trig``) con sutilezas: ``Dataset`` requiere formatos con named
+graphs (``trig``, ``nquads``, ``json-ld``) mientras que ``Graph`` admite
+formatos planos. Este módulo normaliza esa dicotomía para el resto de la
+aplicación y añade una utilidad de escritura a disco con creación de
+directorio padre y control de errores centralizado.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Literal
+
+from rdflib import Dataset, Graph
+
+from atlashabita.infrastructure.rdf.namespaces import bind_all
+
+#: Formatos soportados. Se expone como ``Literal`` para que mypy valide el uso.
+SerializationFormat = Literal["turtle", "json-ld", "nt", "trig"]
+
+_GRAPH_FORMATS: dict[SerializationFormat, str] = {
+    "turtle": "turtle",
+    "json-ld": "json-ld",
+    "nt": "nt",
+    "trig": "trig",
+}
+
+_DATASET_FORMATS: dict[SerializationFormat, str] = {
+    # ``Dataset`` delega en ``ConjunctiveGraph`` internamente. ``turtle`` y
+    # ``nt`` solo serializan el grafo default, por lo que emitimos un aviso
+    # temprano para que el caller use ``trig`` o ``json-ld`` si necesita
+    # conservar los named graphs.
+    "turtle": "turtle",
+    "json-ld": "json-ld",
+    "nt": "nt",
+    "trig": "trig",
+}
+
+
+def serialize(graph_or_dataset: Graph | Dataset, format: SerializationFormat) -> bytes:
+    """Serializa un grafo o dataset a bytes.
+
+    Se fuerza UTF-8 y se rebinda el namespace bundle para que la salida sea
+    legible aunque el caller haya construido el grafo sin registrar prefijos.
+    """
+    bind_all(graph_or_dataset)
+
+    if isinstance(graph_or_dataset, Dataset):
+        rdflib_format = _DATASET_FORMATS[format]
+    else:
+        rdflib_format = _GRAPH_FORMATS[format]
+
+    data = graph_or_dataset.serialize(format=rdflib_format, encoding="utf-8")
+    if isinstance(data, str):
+        # rdflib devuelve str si el backend ignora ``encoding``. Se normaliza.
+        return data.encode("utf-8")
+    return data
+
+
+def write(
+    graph_or_dataset: Graph | Dataset,
+    path: Path,
+    format: SerializationFormat,
+) -> Path:
+    """Escribe el grafo/dataset al ``path`` indicado y devuelve la ruta.
+
+    Crea los directorios intermedios si no existen. Devolver la ruta permite
+    encadenar en pipelines (``manifest.write(...).relative_to(...)``) sin
+    duplicar el cálculo de la ruta final.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = serialize(graph_or_dataset, format=format)
+    path.write_bytes(payload)
+    return path
+
+
+__all__ = ["SerializationFormat", "serialize", "write"]

--- a/apps/api/src/atlashabita/infrastructure/rdf/shacl_validator.py
+++ b/apps/api/src/atlashabita/infrastructure/rdf/shacl_validator.py
@@ -1,0 +1,165 @@
+"""Validación SHACL del grafo AtlasHabita.
+
+El módulo envuelve ``pyshacl`` en una API estable propia. El motivo es doble:
+
+* Evitar acoplar toda la aplicación a los argumentos posicionales y tipos
+  internos de ``pyshacl``, que han cambiado entre versiones.
+* Exponer un :class:`ValidationReport` tipado y autocontenido que los
+  servicios superiores puedan serializar, loggear o devolver por API sin
+  manejar ``rdflib.Graph`` directamente.
+
+La validación se ejecuta sin inferencia por defecto (``inference="none"``)
+para que el resultado sea determinista y rápido sobre datasets grandes. El
+caller puede activar inferencia RDFS/OWL si lo necesita.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, cast
+
+from pyshacl import validate as shacl_validate
+from rdflib import Dataset, Graph, URIRef
+from rdflib.namespace import RDF
+from rdflib.term import Node
+
+from atlashabita.infrastructure.rdf.namespaces import bind_all
+
+_SH = "http://www.w3.org/ns/shacl#"
+_SH_RESULT = URIRef(_SH + "ValidationResult")
+_SH_FOCUS_NODE = URIRef(_SH + "focusNode")
+_SH_RESULT_PATH = URIRef(_SH + "resultPath")
+_SH_RESULT_MESSAGE = URIRef(_SH + "resultMessage")
+_SH_SEVERITY = URIRef(_SH + "resultSeverity")
+_SH_SOURCE_SHAPE = URIRef(_SH + "sourceShape")
+
+
+@dataclass(frozen=True, slots=True)
+class ShaclViolation:
+    """Representa una violación SHACL lo suficientemente informativa.
+
+    No se guarda el nodo resultado original para mantener el objeto libre de
+    dependencias de ``rdflib`` en capas superiores (DTO serializable).
+    """
+
+    focus_node: str
+    path: str | None
+    message: str
+    severity: str
+    source_shape: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class ValidationReport:
+    """Resultado de una validación SHACL."""
+
+    conforms: bool
+    violations: tuple[ShaclViolation, ...] = field(default_factory=tuple)
+    text_report: str = ""
+
+
+class ShaclValidator:
+    """Valida grafos RDF contra un shapes graph precargado.
+
+    Se carga el shapes graph en el constructor una sola vez: ``pyshacl`` tarda
+    decenas de milisegundos en parsear un fichero SHACL y validar en caliente
+    repetidas veces es un escenario común (tests, pipelines). Por diseño la
+    instancia es reutilizable e inmutable tras construirse.
+    """
+
+    def __init__(self, shapes_path: Path) -> None:
+        if not shapes_path.exists():
+            raise FileNotFoundError(f"No se encuentra el shapes graph: {shapes_path}")
+        self._shapes_path = shapes_path
+        self._shapes_graph = Graph()
+        bind_all(self._shapes_graph)
+        self._shapes_graph.parse(shapes_path, format="turtle")
+
+    @property
+    def shapes_path(self) -> Path:
+        return self._shapes_path
+
+    @property
+    def shapes_graph(self) -> Graph:
+        return self._shapes_graph
+
+    def validate(self, graph: Graph | Dataset) -> ValidationReport:
+        """Ejecuta la validación SHACL y construye el informe tipado.
+
+        Se prefiere pasar ``data_graph=Graph`` (aplanado) para que
+        ``pyshacl`` pueda evaluar todas las formas contra la unión de
+        tripletas, especialmente importante cuando el caller trabaja con un
+        :class:`rdflib.Dataset` con named graphs.
+        """
+        data_graph = _flatten(graph)
+
+        conforms_raw, report_graph_raw, text_report_raw = shacl_validate(
+            data_graph=data_graph,
+            shacl_graph=self._shapes_graph,
+            inference="none",
+            abort_on_first=False,
+            allow_warnings=True,
+            meta_shacl=False,
+            advanced=False,
+            debug=False,
+            serialize_report_graph=False,
+        )
+        conforms = bool(conforms_raw)
+        report_graph = cast(Graph, report_graph_raw)
+        text_report = str(text_report_raw)
+        violations = tuple(_extract_violations(report_graph))
+        return ValidationReport(
+            conforms=conforms and not any(v.severity.endswith("Violation") for v in violations),
+            violations=violations,
+            text_report=text_report,
+        )
+
+
+def _flatten(graph: Graph | Dataset) -> Graph:
+    """Convierte un :class:`Dataset` en un ``Graph`` unificado.
+
+    Necesario para SHACL: las shapes de AtlasHabita se evalúan contra todo el
+    cuerpo de datos, no contra un único named graph. Si el input ya es un
+    ``Graph``, se devuelve tal cual para evitar copias innecesarias.
+    """
+    if isinstance(graph, Dataset):
+        flat = Graph()
+        bind_all(flat)
+        for quad in graph.quads((None, None, None, None)):
+            s, p, o, _ = quad
+            flat.add((s, p, o))
+        return flat
+    return graph
+
+
+def _extract_violations(report_graph: Graph) -> list[ShaclViolation]:
+    """Itera el grafo de informe buscando ``sh:ValidationResult``.
+
+    Se extrae solo lo necesario para el DTO, evitando exponer nodos RDF a
+    capas superiores que solo necesitan saber qué falló y dónde.
+    """
+    violations: list[ShaclViolation] = []
+    for node in report_graph.subjects(RDF.type, _SH_RESULT):
+        violations.append(
+            ShaclViolation(
+                focus_node=_value(report_graph, node, _SH_FOCUS_NODE) or "",
+                path=_value(report_graph, node, _SH_RESULT_PATH),
+                message=_value(report_graph, node, _SH_RESULT_MESSAGE) or "",
+                severity=_value(report_graph, node, _SH_SEVERITY) or "",
+                source_shape=_value(report_graph, node, _SH_SOURCE_SHAPE),
+            )
+        )
+    return violations
+
+
+def _value(graph: Graph, subject: Any, predicate: URIRef) -> str | None:
+    """Devuelve el primer valor (como cadena) para ``(subject, predicate, ?)``."""
+    node = cast(Node, subject)
+    value = graph.value(subject=node, predicate=predicate)
+    if value is None:
+        return None
+    return str(value)
+
+
+__all__ = ["ShaclValidator", "ShaclViolation", "ValidationReport"]

--- a/apps/api/src/atlashabita/infrastructure/rdf/sparql_queries.py
+++ b/apps/api/src/atlashabita/infrastructure/rdf/sparql_queries.py
@@ -1,0 +1,411 @@
+"""Ejecución controlada de consultas SPARQL sobre el grafo AtlasHabita.
+
+``SparqlRunner`` concentra las consultas que la MVP necesita exponer (ranking
+aproximado, buscar municipios por provincia, obtener fuentes usadas, etc.) y
+aplica **salvaguardas** antes de delegar en ``rdflib``:
+
+* Bloquea comandos de escritura (``INSERT``, ``DELETE``, ``LOAD``...) cuando
+  ``settings.sparql_allow_update`` es ``False``. Esto convierte al runner en
+  un adaptador *read-only* seguro para exponer indirectamente vía API.
+* Aplica un ``LIMIT`` defensivo usando ``settings.sparql_max_results`` para
+  evitar respuestas gigantes que consuman memoria del proceso.
+* Mantiene un timeout blando (``sparql_timeout_seconds``) cancelando la
+  ejecución con una señal en hilos si la consulta se pasa.
+
+Las consultas se mantienen en esta capa (no en el dominio) porque dependen
+del vocabulario RDF y no tienen sentido fuera del grafo.
+"""
+
+from __future__ import annotations
+
+import re
+import threading
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from typing import Any, Final, cast
+
+from rdflib import Dataset, Graph, URIRef
+from rdflib.query import Result
+from rdflib.term import Node
+
+from atlashabita.config import Settings
+from atlashabita.infrastructure.rdf.namespaces import AH, AHR, DCT
+
+#: Palabras clave de consultas que modifican el grafo.
+_UPDATE_KEYWORDS: Final[tuple[str, ...]] = (
+    "INSERT",
+    "DELETE",
+    "LOAD",
+    "CLEAR",
+    "CREATE",
+    "DROP",
+    "ADD",
+    "MOVE",
+    "COPY",
+)
+
+_UPDATE_PATTERN = re.compile(
+    r"\b(?:" + "|".join(_UPDATE_KEYWORDS) + r")\b",
+    flags=re.IGNORECASE,
+)
+
+_COMMENT_LINE_PATTERN = re.compile(r"#[^\n]*")
+
+
+class SparqlUpdateForbiddenError(RuntimeError):
+    """Se lanza cuando se intenta ejecutar una consulta de escritura prohibida."""
+
+
+class SparqlTimeoutError(TimeoutError):
+    """Se lanza cuando una consulta excede el timeout configurado."""
+
+
+@dataclass(frozen=True, slots=True)
+class SparqlRunner:
+    """Ejecuta SPARQL sobre el grafo con salvaguardas de producción.
+
+    Aunque la MVP solo usa ``rdflib`` en memoria, el diseño deja espacio para
+    conectar en el futuro un triplestore externo: la API pública no expone
+    detalles del backend, lo que permite sustituir la implementación sin
+    romper a los consumidores.
+    """
+
+    graph: Graph | Dataset
+    settings: Settings
+
+    def top_scores_by_profile(
+        self, profile_id: str, scope: str = "municipality", limit: int = 10
+    ) -> list[dict[str, Any]]:
+        """Ranking aproximado basado en observaciones (MVP).
+
+        La MVP todavía no persiste ``ah:Score``. Se calcula una aproximación
+        SPARQL que combina linealmente las observaciones ``2024``/``2025`` con
+        los pesos del perfil, demostrando el modelo sin bloquearse en la
+        persistencia de scores. Los valores devueltos están en escala [0, 100].
+        """
+        profile_uri = URIRef(f"{AHR}profile/{profile_id}")
+        target_class = _scope_to_class(scope)
+        query = f"""
+        PREFIX ah: <{AH}>
+        PREFIX dct: <{DCT}>
+        PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+        SELECT ?territory ?label ?indicator ?value ?weight ?direction
+        WHERE {{
+          ?territory a <{target_class}> ;
+                     rdfs:label ?label ;
+                     ah:hasIndicatorObservation ?obs .
+          ?obs ah:indicator ?indicator ;
+               ah:value ?value .
+          ?indicator ah:direction ?direction .
+          <{profile_uri}> ah:hasContribution ?c .
+          ?c ah:indicator ?indicator ;
+             ah:weight ?weight .
+        }}
+        """
+        rows = self._execute(query)
+        aggregates: dict[str, dict[str, Any]] = {}
+        for row in rows:
+            territory = str(row["territory"])
+            indicator = str(row["indicator"])
+            value = float(str(row["value"]))
+            weight = float(str(row["weight"]))
+            direction = str(row["direction"])
+            entry = aggregates.setdefault(
+                territory,
+                {
+                    "territory": territory,
+                    "label": str(row["label"]),
+                    "score": 0.0,
+                    "indicators": {},
+                },
+            )
+            indicators = cast(dict[str, dict[str, Any]], entry["indicators"])
+            if indicator in indicators:
+                continue
+            normalized = _normalize(value, direction)
+            indicators[indicator] = {
+                "indicator": indicator,
+                "value": value,
+                "weight": weight,
+                "normalized": normalized,
+            }
+            entry["score"] = float(entry["score"]) + normalized * weight * 100.0
+
+        results = sorted(
+            aggregates.values(),
+            key=lambda item: float(item["score"]),
+            reverse=True,
+        )
+        capped_limit = max(1, min(limit, self.settings.sparql_max_results))
+        return [
+            {
+                "territory": item["territory"],
+                "label": item["label"],
+                "score": round(float(item["score"]), 2),
+                "contributions": sorted(
+                    (dict(v) for v in cast(dict[str, Any], item["indicators"]).values()),
+                    key=lambda c: c["indicator"],
+                ),
+            }
+            for item in results[:capped_limit]
+        ]
+
+    def municipalities_by_province(self, province_code: str) -> list[dict[str, Any]]:
+        """Lista los municipios pertenecientes a una provincia."""
+        province_uri = URIRef(f"{AHR}territory/province/{province_code}")
+        query = f"""
+        PREFIX ah: <{AH}>
+        PREFIX dct: <{DCT}>
+        PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+        SELECT ?municipality ?label ?code
+        WHERE {{
+          ?municipality a ah:Municipality ;
+                        rdfs:label ?label ;
+                        dct:identifier ?code ;
+                        ah:belongsTo <{province_uri}> .
+        }}
+        ORDER BY ?label
+        """
+        return [
+            {
+                "municipality": str(row["municipality"]),
+                "label": str(row["label"]),
+                "code": str(row["code"]),
+            }
+            for row in self._execute(query)
+        ]
+
+    def indicators_for_territory(self, territory_id: str) -> list[dict[str, Any]]:
+        """Observaciones indicadoras asociadas a un territorio concreto."""
+        territory_uri = _territory_uri_from_id(territory_id)
+        query = f"""
+        PREFIX ah: <{AH}>
+        PREFIX dct: <{DCT}>
+        PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+        SELECT ?indicator ?label ?value ?unit ?period ?quality
+        WHERE {{
+          <{territory_uri}> ah:hasIndicatorObservation ?obs .
+          ?obs ah:indicator ?indicator ;
+               ah:value ?value ;
+               ah:period ?period ;
+               ah:qualityFlag ?quality .
+          ?indicator rdfs:label ?label ;
+                     ah:unit ?unit .
+        }}
+        ORDER BY ?label
+        """
+        return [
+            {
+                "indicator": str(row["indicator"]),
+                "label": str(row["label"]),
+                "value": float(str(row["value"])),
+                "unit": str(row["unit"]),
+                "period": str(row["period"]),
+                "quality": str(row["quality"]),
+            }
+            for row in self._execute(query)
+        ]
+
+    def sources_used_by_territory(self, territory_id: str) -> list[dict[str, Any]]:
+        """Fuentes cuyas observaciones tocan un territorio."""
+        territory_uri = _territory_uri_from_id(territory_id)
+        query = f"""
+        PREFIX ah: <{AH}>
+        PREFIX dct: <{DCT}>
+
+        SELECT DISTINCT ?source ?title ?license ?periodicity
+        WHERE {{
+          <{territory_uri}> ah:hasIndicatorObservation ?obs .
+          ?obs ah:providedBy ?source .
+          ?source dct:title ?title ;
+                  ah:license ?license ;
+                  ah:periodicity ?periodicity .
+        }}
+        ORDER BY ?title
+        """
+        return [
+            {
+                "source": str(row["source"]),
+                "title": str(row["title"]),
+                "license": str(row["license"]),
+                "periodicity": str(row["periodicity"]),
+            }
+            for row in self._execute(query)
+        ]
+
+    def indicator_definition(self, indicator_code: str) -> dict[str, Any]:
+        """Metadatos de la definición de un indicador."""
+        indicator_uri = URIRef(f"{AHR}indicator/{indicator_code}")
+        query = f"""
+        PREFIX ah: <{AH}>
+        PREFIX dct: <{DCT}>
+        PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+        SELECT ?label ?description ?unit ?direction
+        WHERE {{
+          <{indicator_uri}> rdfs:label ?label ;
+                            dct:description ?description ;
+                            ah:unit ?unit ;
+                            ah:direction ?direction .
+        }}
+        LIMIT 1
+        """
+        rows = self._execute(query)
+        if not rows:
+            return {}
+        row = rows[0]
+        return {
+            "indicator": str(indicator_uri),
+            "label": str(row["label"]),
+            "description": str(row["description"]),
+            "unit": str(row["unit"]),
+            "direction": str(row["direction"]),
+        }
+
+    def count_triples_by_class(self) -> dict[str, int]:
+        """Cuenta instancias por clase RDF.
+
+        Consulta de diagnóstico útil para verificar en tests/manifiestos que
+        el grafo contiene las cantidades esperadas por clase tras la carga.
+        """
+        query = """
+        SELECT ?class (COUNT(?s) AS ?total)
+        WHERE {
+          ?s a ?class .
+        }
+        GROUP BY ?class
+        ORDER BY DESC(?total)
+        """
+        return {str(row["class"]): int(str(row["total"])) for row in self._execute(query)}
+
+    def _execute(self, query: str) -> list[dict[str, Node]]:
+        """Ejecuta la consulta con salvaguardas.
+
+        Compila la consulta tras:
+
+        1. Validar que no sea una mutación no autorizada.
+        2. Añadir ``LIMIT`` defensivo si falta.
+        3. Ejecutar en un hilo con timeout blando para evitar consultas
+           patológicas que bloqueen el proceso.
+        """
+        self._ensure_read_only(query)
+        bounded_query = self._apply_default_limit(query)
+        result = self._run_with_timeout(bounded_query)
+        return _rows_to_dicts(result)
+
+    def _ensure_read_only(self, query: str) -> None:
+        if self.settings.sparql_allow_update:
+            return
+        sanitized = _COMMENT_LINE_PATTERN.sub(" ", query)
+        if _UPDATE_PATTERN.search(sanitized):
+            raise SparqlUpdateForbiddenError(
+                "Las consultas de escritura están desactivadas (sparql_allow_update=False)."
+            )
+
+    def _apply_default_limit(self, query: str) -> str:
+        """Añade un ``LIMIT`` si la consulta no define uno propio.
+
+        Se inspecciona sólo para ``SELECT``; ``CONSTRUCT``/``ASK`` tienen
+        semántica distinta y no necesitan tope numérico.
+        """
+        upper = query.upper()
+        if " SELECT " not in f" {upper}" and not upper.strip().startswith("SELECT"):
+            return query
+        if re.search(r"\bLIMIT\b", upper):
+            return query
+        return f"{query.rstrip()}\nLIMIT {self.settings.sparql_max_results}\n"
+
+    def _run_with_timeout(self, query: str) -> Result:
+        """Ejecuta la consulta en un hilo dedicado con timeout."""
+        container: dict[str, Result | BaseException] = {}
+
+        def worker() -> None:
+            try:
+                container["result"] = self.graph.query(query)
+            except Exception as exc:
+                # ``Exception`` captura errores de sintaxis/plan del motor
+                # SPARQL sin atrapar ``KeyboardInterrupt`` ni ``SystemExit``.
+                container["error"] = exc
+
+        thread = threading.Thread(target=worker, name="sparql-runner", daemon=True)
+        thread.start()
+        thread.join(timeout=self.settings.sparql_timeout_seconds)
+        if thread.is_alive():
+            raise SparqlTimeoutError(
+                f"La consulta SPARQL superó {self.settings.sparql_timeout_seconds}s."
+            )
+        if "error" in container:
+            error = container["error"]
+            if isinstance(error, BaseException):
+                raise error
+            raise RuntimeError(f"Error SPARQL no esperado: {error!r}")
+        return cast(Result, container["result"])
+
+
+def _rows_to_dicts(result: Result) -> list[dict[str, Node]]:
+    """Convierte un ``Result`` de rdflib en filas ``dict`` uniformes.
+
+    Se castea la fila a ``ResultRow`` para poder invocar ``asdict()``. rdflib
+    también puede devolver tuplas/booleanos para otros tipos de consulta, pero
+    este runner sólo emite ``SELECT`` por lo que la forma está garantizada.
+    """
+    variables: Iterable[str] = tuple(str(v) for v in (result.vars or ()))
+    rows: list[dict[str, Node]] = []
+    for row in result:
+        row_dict = cast(Mapping[str, Node], cast(Any, row).asdict())
+        rows.append(
+            {variable: row_dict[variable] for variable in variables if variable in row_dict}
+        )
+    return rows
+
+
+def _scope_to_class(scope: str) -> URIRef:
+    mapping = {
+        "municipality": AH.Municipality,
+        "province": AH.Province,
+        "autonomous_community": AH.AutonomousCommunity,
+    }
+    if scope not in mapping:
+        raise ValueError(f"Scope SPARQL desconocido: {scope!r}")
+    return cast(URIRef, mapping[scope])
+
+
+def _territory_uri_from_id(territory_id: str) -> URIRef:
+    """Convierte ``municipality:41091`` al URIRef canónico."""
+    try:
+        kind, code = territory_id.split(":", maxsplit=1)
+    except ValueError as exc:
+        raise ValueError(f"territory_id inválido: {territory_id!r}") from exc
+    return URIRef(f"{AHR}territory/{kind}/{code}")
+
+
+def _normalize(value: float, direction: str) -> float:
+    """Normaliza a [0, 1] usando heurísticas simples por dirección.
+
+    Para la MVP basta con una función monotónica conservadora: ``min(value, 1)``
+    si es porcentaje o índice; si el indicador es "lower is better" se invierte
+    con ``max(0, 1 - value / 100)``. El motor real de scoring sustituirá estas
+    heurísticas, pero para el ejemplo SPARQL son suficientes.
+    """
+    if direction == "lower_is_better":
+        if value <= 0:
+            return 1.0
+        return max(0.0, min(1.0, 1.0 - value / 25.0))
+    if value <= 0:
+        return 0.0
+    if value <= 1:
+        return value
+    if value <= 100:
+        return value / 100.0
+    # Ej: renta per cápita en EUR. Se comprime contra 50k como techo razonable.
+    return max(0.0, min(1.0, value / 50_000.0))
+
+
+__all__ = [
+    "SparqlRunner",
+    "SparqlTimeoutError",
+    "SparqlUpdateForbiddenError",
+]

--- a/apps/api/src/atlashabita/infrastructure/rdf/uri_builder.py
+++ b/apps/api/src/atlashabita/infrastructure/rdf/uri_builder.py
@@ -1,0 +1,153 @@
+"""Constructor determinista de URIs para AtlasHabita.
+
+Las URIs son el eje de identidad del grafo RDF. Este módulo aísla toda la
+lógica de construcción para:
+
+* Garantizar **determinismo**: dos ejecuciones con el mismo input producen las
+  mismas URIs.
+* Evitar la dispersión de plantillas de URI por el código (DRY).
+* Facilitar tests puros que no necesitan un grafo completo.
+
+La política sigue el documento ``docs/11_MODELO_DE_DATOS_RDF_Y_ONTOLOGIA.md``:
+recursos bajo ``/resource/<dominio>/...`` y named graphs bajo
+``/graph/<dominio>``. Los nombres con tildes o caracteres especiales se
+normalizan con ``python-slugify`` para producir segmentos URL seguros sin
+perder la identidad semántica (el código INE se mantiene como primario).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from urllib.parse import quote
+
+from rdflib import URIRef
+from slugify import slugify
+
+from atlashabita.domain.territories import TerritoryKind
+
+_TERRITORY_KIND_SEGMENT: dict[TerritoryKind, str] = {
+    TerritoryKind.AUTONOMOUS_COMMUNITY: "autonomous_community",
+    TerritoryKind.PROVINCE: "province",
+    TerritoryKind.MUNICIPALITY: "municipality",
+}
+
+
+@dataclass(frozen=True, slots=True)
+class URIBuilder:
+    """Genera URIs estables para los recursos del dominio.
+
+    La clase es inmutable y sus métodos son puros: solo dependen de la base
+    fijada en el constructor y del input explícito. Esto permite reutilizar
+    la misma instancia entre hilos y cachear resultados sin sorpresas.
+    """
+
+    base_uri: str
+
+    def __post_init__(self) -> None:
+        if not self.base_uri:
+            raise ValueError("base_uri no puede ser vacío.")
+        # Normalización mínima: garantizar que termina en ``/`` para poder
+        # concatenar segmentos sin ambigüedad en el resto de métodos.
+        if not self.base_uri.endswith("/"):
+            object.__setattr__(self, "base_uri", self.base_uri + "/")
+
+    @property
+    def resource_base(self) -> str:
+        """Prefijo común de todos los recursos (``.../resource/``)."""
+        return f"{self.base_uri}resource/"
+
+    @property
+    def graph_base(self) -> str:
+        """Prefijo común de los named graphs (``.../graph/``)."""
+        return f"{self.base_uri}graph/"
+
+    def territory(self, code: str, kind: TerritoryKind) -> URIRef:
+        """URI del territorio ``{kind}/{code}``.
+
+        El código INE es estable y único dentro de su nivel, por lo que no se
+        necesita slugificar. Sí se valida que no sea vacío para abortar pronto
+        cuando un CSV mal formado llegue hasta esta capa.
+        """
+        self._require_non_empty(code, "code")
+        segment = _TERRITORY_KIND_SEGMENT[kind]
+        return URIRef(f"{self.resource_base}territory/{segment}/{_safe(code)}")
+
+    def indicator(self, code: str) -> URIRef:
+        """URI del indicador ``indicator/{code}``."""
+        self._require_non_empty(code, "code")
+        return URIRef(f"{self.resource_base}indicator/{_safe(code)}")
+
+    def observation(self, indicator_code: str, territory_id: str, period: str) -> URIRef:
+        """URI de una observación.
+
+        ``territory_id`` llega en formato ``municipality:41091``. Se sustituye
+        el separador por ``/`` para obtener un segmento de URL plano y legible
+        sin introducir caracteres especiales.
+        """
+        self._require_non_empty(indicator_code, "indicator_code")
+        self._require_non_empty(territory_id, "territory_id")
+        self._require_non_empty(period, "period")
+        territory_plain = territory_id.replace(":", "/")
+        return URIRef(
+            f"{self.resource_base}observation/"
+            f"{_safe(indicator_code)}/{_safe(territory_plain)}/{_safe(period)}"
+        )
+
+    def source(self, source_id: str) -> URIRef:
+        """URI de una fuente de datos."""
+        self._require_non_empty(source_id, "source_id")
+        return URIRef(f"{self.resource_base}source/{_safe(source_id)}")
+
+    def profile(self, profile_id: str) -> URIRef:
+        """URI de un perfil de decisión."""
+        self._require_non_empty(profile_id, "profile_id")
+        return URIRef(f"{self.resource_base}profile/{_safe(profile_id)}")
+
+    def score(self, version: str, profile_id: str, territory_id: str) -> URIRef:
+        """URI de un score versionado.
+
+        Incluye versión, perfil y territorio para que una misma combinación no
+        se pise al regenerar scores entre releases.
+        """
+        self._require_non_empty(version, "version")
+        self._require_non_empty(profile_id, "profile_id")
+        self._require_non_empty(territory_id, "territory_id")
+        territory_plain = territory_id.replace(":", "/")
+        return URIRef(
+            f"{self.resource_base}score/"
+            f"{_safe(version)}/{_safe(profile_id)}/{_safe(territory_plain)}"
+        )
+
+    def named_graph(self, domain: str) -> URIRef:
+        """URI del named graph de un dominio (territories, observations...)."""
+        self._require_non_empty(domain, "domain")
+        return URIRef(f"{self.graph_base}{_safe(domain)}")
+
+    @staticmethod
+    def _require_non_empty(value: str, field_name: str) -> None:
+        if not value or not value.strip():
+            raise ValueError(f"URIBuilder: {field_name} no puede ser vacío.")
+
+
+def _safe(segment: str) -> str:
+    """Normaliza un segmento de URL.
+
+    Se usa ``slugify`` para nombres con tildes (``Málaga`` -> ``malaga``). Los
+    guiones bajos se preservan porque los códigos canónicos de indicadores y
+    perfiles (``rent_median``, ``remote_work``) los usan como identidad estable
+    en el CSV y en SPARQL. El separador ``/`` se mantiene para rutas
+    compuestas y finalmente se aplica ``quote`` por seguridad frente a
+    caracteres no previstos.
+    """
+    stripped = segment.strip()
+    slug = slugify(
+        stripped,
+        lowercase=False,
+        separator="_",
+        regex_pattern=r"[^A-Za-z0-9_/.-]+",
+    )
+    candidate = slug or stripped
+    return quote(candidate, safe="-._~/")
+
+
+__all__ = ["URIBuilder"]

--- a/apps/api/tests/test_rdf_graph_builder.py
+++ b/apps/api/tests/test_rdf_graph_builder.py
@@ -1,0 +1,104 @@
+"""Pruebas del constructor del grafo RDF a partir del seed real."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from rdflib import Dataset, Graph, URIRef
+from rdflib.namespace import RDF, XSD
+
+from atlashabita.infrastructure.ingestion import SeedDataset, SeedLoader
+from atlashabita.infrastructure.rdf import (
+    AH,
+    GraphBuilder,
+    URIBuilder,
+)
+from atlashabita.infrastructure.rdf.graph_builder import (
+    GRAPH_INDICATORS,
+    GRAPH_OBSERVATIONS,
+    GRAPH_PROFILES,
+    GRAPH_SOURCES,
+    GRAPH_TERRITORIES,
+)
+
+SEED_DIR = Path(__file__).resolve().parents[3] / "data" / "seed"
+ONTOLOGY = Path(__file__).resolve().parents[3] / "ontology" / "atlashabita.ttl"
+BASE = "https://data.atlashabita.example/"
+
+
+@pytest.fixture(scope="module")
+def dataset() -> SeedDataset:
+    return SeedLoader(SEED_DIR).load()
+
+
+@pytest.fixture()
+def builder() -> GraphBuilder:
+    return GraphBuilder(URIBuilder(BASE))
+
+
+def test_build_graph_incluye_municipios(builder: GraphBuilder, dataset: SeedDataset) -> None:
+    graph = builder.build_graph(dataset)
+    municipalities = set(graph.subjects(RDF.type, AH.Municipality))
+    assert len(municipalities) == 10
+
+
+def test_build_graph_enlaza_municipio_a_provincia(
+    builder: GraphBuilder, dataset: SeedDataset
+) -> None:
+    graph = builder.build_graph(dataset)
+    sevilla = URIRef(BASE + "resource/territory/municipality/41091")
+    sevilla_province = URIRef(BASE + "resource/territory/province/41")
+    assert (sevilla, AH.belongsTo, sevilla_province) in graph
+
+
+def test_build_graph_conecta_territorio_y_observacion(
+    builder: GraphBuilder, dataset: SeedDataset
+) -> None:
+    graph = builder.build_graph(dataset)
+    sevilla = URIRef(BASE + "resource/territory/municipality/41091")
+    observations = list(graph.objects(sevilla, AH.hasIndicatorObservation))
+    assert len(observations) == 5  # 5 indicadores distintos
+
+
+def test_build_genera_named_graphs_por_dominio(builder: GraphBuilder, dataset: SeedDataset) -> None:
+    ds = builder.build(dataset)
+    identifiers = {str(g.identifier) for g in ds.graphs() if len(g) > 0}
+    for domain in (
+        GRAPH_TERRITORIES,
+        GRAPH_INDICATORS,
+        GRAPH_SOURCES,
+        GRAPH_OBSERVATIONS,
+        GRAPH_PROFILES,
+    ):
+        assert f"{BASE}graph/{domain}" in identifiers
+
+
+def test_build_con_ontologia_incluye_tbox(builder: GraphBuilder, dataset: SeedDataset) -> None:
+    ds = builder.build(dataset, ontology_path=ONTOLOGY)
+    # La clase ``ah:Municipality`` aparece como ``owl:Class`` en la ontología.
+    found = False
+    for _subject, _predicate, obj, _graph in ds.quads((AH.Municipality, RDF.type, None, None)):
+        if str(obj).endswith("#Class"):
+            found = True
+    assert found, "El named graph de ontología no contiene la clase Municipality."
+
+
+def test_build_es_determinista(builder: GraphBuilder, dataset: SeedDataset) -> None:
+    g1 = builder.build_graph(dataset)
+    g2 = builder.build_graph(dataset)
+    assert len(g1) == len(g2)
+    # Comparar iso-hashable: mismos triples exactos.
+    assert set(g1) == set(g2)
+
+
+def test_build_graph_emite_decimales(builder: GraphBuilder, dataset: SeedDataset) -> None:
+    """Valor y peso se modelan como ``xsd:decimal`` para cumplir SHACL."""
+    graph = builder.build_graph(dataset)
+    any_value = next(graph.objects(predicate=AH.value))
+    assert getattr(any_value, "datatype", None) == XSD.decimal
+
+
+def test_build_devuelve_tipos_correctos(builder: GraphBuilder, dataset: SeedDataset) -> None:
+    assert isinstance(builder.build(dataset), Dataset)
+    assert isinstance(builder.build_graph(dataset), Graph)

--- a/apps/api/tests/test_rdf_manifest.py
+++ b/apps/api/tests/test_rdf_manifest.py
@@ -1,0 +1,63 @@
+"""Pruebas del manifiesto del grafo."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from atlashabita.infrastructure.ingestion import SeedLoader
+from atlashabita.infrastructure.rdf import (
+    GraphBuilder,
+    URIBuilder,
+    build_manifest,
+)
+
+ROOT = Path(__file__).resolve().parents[3]
+SEED_DIR = ROOT / "data" / "seed"
+ONTOLOGY = ROOT / "ontology" / "atlashabita.ttl"
+BASE = "https://data.atlashabita.example/"
+
+
+@pytest.fixture(scope="module")
+def manifest() -> dict[str, object]:
+    dataset = SeedLoader(SEED_DIR).load()
+    ds = GraphBuilder(URIBuilder(BASE)).build(dataset, ontology_path=ONTOLOGY)
+    return build_manifest(ds)
+
+
+def test_manifest_tiene_campos_basicos(manifest: dict[str, object]) -> None:
+    assert "total_triples" in manifest
+    assert "named_graphs" in manifest
+    assert "classes_count" in manifest
+    assert "territories_count" in manifest
+    assert "observations_count" in manifest
+    assert "generated_at_iso" in manifest
+
+
+def test_manifest_cuenta_observaciones(manifest: dict[str, object]) -> None:
+    assert manifest["observations_count"] == 50
+
+
+def test_manifest_cuenta_territorios(manifest: dict[str, object]) -> None:
+    # 10 municipios + 3 provincias + 2 CCAA = 15 nodos ``ah:*Territory``.
+    assert manifest["territories_count"] == 15
+
+
+def test_manifest_lista_named_graphs(manifest: dict[str, object]) -> None:
+    named_graphs = manifest["named_graphs"]
+    assert isinstance(named_graphs, dict)
+    assert any("graph/territories" in key for key in named_graphs)
+    assert any("graph/observations" in key for key in named_graphs)
+
+
+def test_manifest_incluye_timestamp_iso8601(manifest: dict[str, object]) -> None:
+    timestamp = manifest["generated_at_iso"]
+    assert isinstance(timestamp, str)
+    assert "T" in timestamp  # formato ISO-8601.
+
+
+def test_manifest_total_triples_positivo(manifest: dict[str, object]) -> None:
+    total = manifest["total_triples"]
+    assert isinstance(total, int)
+    assert total > 0

--- a/apps/api/tests/test_rdf_serializer.py
+++ b/apps/api/tests/test_rdf_serializer.py
@@ -1,0 +1,68 @@
+"""Pruebas de la serialización de grafos y datasets."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from atlashabita.infrastructure.ingestion import SeedLoader
+from atlashabita.infrastructure.rdf import (
+    GraphBuilder,
+    URIBuilder,
+    serialize,
+    write,
+)
+
+ROOT = Path(__file__).resolve().parents[3]
+SEED_DIR = ROOT / "data" / "seed"
+BASE = "https://data.atlashabita.example/"
+
+
+@pytest.fixture(scope="module")
+def builder() -> GraphBuilder:
+    return GraphBuilder(URIBuilder(BASE))
+
+
+@pytest.fixture(scope="module")
+def dataset() -> object:
+    return SeedLoader(SEED_DIR).load()
+
+
+@pytest.mark.parametrize("fmt", ["turtle", "json-ld", "nt"])
+def test_serialize_graph_genera_bytes(builder: GraphBuilder, dataset: object, fmt: str) -> None:
+    graph = builder.build_graph(dataset)  # type: ignore[arg-type]
+    payload = serialize(graph, fmt)  # type: ignore[arg-type]
+    assert isinstance(payload, bytes)
+    assert len(payload) > 0
+
+
+def test_serialize_turtle_incluye_prefijos(builder: GraphBuilder, dataset: object) -> None:
+    graph = builder.build_graph(dataset)  # type: ignore[arg-type]
+    payload = serialize(graph, "turtle").decode("utf-8")
+    assert "@prefix ah:" in payload
+    assert "@prefix dct:" in payload
+
+
+def test_serialize_trig_dataset(builder: GraphBuilder, dataset: object) -> None:
+    ds = builder.build(dataset)  # type: ignore[arg-type]
+    payload = serialize(ds, "trig").decode("utf-8")
+    assert "graph/territories" in payload
+
+
+def test_write_crea_directorio(tmp_path: Path, builder: GraphBuilder, dataset: object) -> None:
+    graph = builder.build_graph(dataset)  # type: ignore[arg-type]
+    target = tmp_path / "nested" / "graph.ttl"
+    result = write(graph, target, "turtle")
+    assert result == target
+    assert target.exists()
+    contents = target.read_bytes()
+    assert b"ah:" in contents
+
+
+def test_serialize_es_consistente(builder: GraphBuilder, dataset: object) -> None:
+    """Dos corridas idénticas deben producir bytes válidos del mismo tamaño."""
+    graph = builder.build_graph(dataset)  # type: ignore[arg-type]
+    a = serialize(graph, "nt")
+    b = serialize(graph, "nt")
+    assert a == b

--- a/apps/api/tests/test_rdf_shacl.py
+++ b/apps/api/tests/test_rdf_shacl.py
@@ -1,0 +1,87 @@
+"""Pruebas de validación SHACL contra el grafo construido desde el seed."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from rdflib import Literal, URIRef
+from rdflib.namespace import RDF, XSD
+
+from atlashabita.infrastructure.ingestion import SeedLoader
+from atlashabita.infrastructure.rdf import (
+    AH,
+    GraphBuilder,
+    ShaclValidator,
+    URIBuilder,
+)
+from atlashabita.infrastructure.rdf.graph_builder import _decimal_literal
+
+ROOT = Path(__file__).resolve().parents[3]
+SEED_DIR = ROOT / "data" / "seed"
+ONTOLOGY = ROOT / "ontology" / "atlashabita.ttl"
+SHAPES = ROOT / "ontology" / "shapes.ttl"
+BASE = "https://data.atlashabita.example/"
+
+
+@pytest.fixture(scope="module")
+def validator() -> ShaclValidator:
+    return ShaclValidator(SHAPES)
+
+
+@pytest.fixture(scope="module")
+def dataset() -> object:
+    return SeedLoader(SEED_DIR).load()
+
+
+def test_validator_carga_shapes(validator: ShaclValidator) -> None:
+    assert len(validator.shapes_graph) > 0
+
+
+def test_shapes_path_inexistente_lanza_error(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError):
+        ShaclValidator(tmp_path / "no-existe.ttl")
+
+
+def test_graph_seed_conforma(validator: ShaclValidator, dataset: object) -> None:
+    builder = GraphBuilder(URIBuilder(BASE))
+    graph = builder.build_graph(dataset)  # type: ignore[arg-type]
+    report = validator.validate(graph)
+    assert report.conforms, f"Violaciones: {[v.message for v in report.violations]}"
+    assert not report.violations
+
+
+def test_shacl_detecta_violacion_intencional(validator: ShaclValidator, dataset: object) -> None:
+    """Si se rompe una restricción (ej. dirección inválida), debe reportarse."""
+    builder = GraphBuilder(URIBuilder(BASE))
+    graph = builder.build_graph(dataset)  # type: ignore[arg-type]
+    # Se añade un indicador con dirección fuera del enum permitido.
+    bad_uri = URIRef(BASE + "resource/indicator/__bad__")
+    graph.add((bad_uri, RDF.type, AH.Indicator))
+    graph.add((bad_uri, AH.direction, Literal("neutral")))
+    graph.add(
+        (
+            bad_uri,
+            URIRef("http://www.w3.org/2000/01/rdf-schema#label"),
+            Literal("Indicador inválido", lang="es"),
+        )
+    )
+    report = validator.validate(graph)
+    assert not report.conforms
+    messages = " ".join(v.message for v in report.violations)
+    assert "direction" in messages or "lower_is_better" in messages
+
+
+def test_shacl_valida_dataset_completo(validator: ShaclValidator, dataset: object) -> None:
+    """La validación debe funcionar también sobre Datasets con named graphs."""
+    builder = GraphBuilder(URIBuilder(BASE))
+    ds = builder.build(dataset, ontology_path=ONTOLOGY)  # type: ignore[arg-type]
+    report = validator.validate(ds)
+    assert report.conforms, f"Violaciones: {[v.message for v in report.violations]}"
+
+
+def test_xsd_decimal_literal_formatea_sin_ruido() -> None:
+    """Verifica que los flotantes se convierten a decimal sin artefactos."""
+    literal = _decimal_literal(13.6)
+    assert literal.datatype == XSD.decimal
+    assert str(literal) == "13.6"

--- a/apps/api/tests/test_rdf_sparql.py
+++ b/apps/api/tests/test_rdf_sparql.py
@@ -1,0 +1,123 @@
+"""Pruebas del runner SPARQL y sus salvaguardas."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from rdflib import Graph
+
+from atlashabita.config import Settings
+from atlashabita.infrastructure.ingestion import SeedLoader
+from atlashabita.infrastructure.rdf import (
+    GraphBuilder,
+    SparqlRunner,
+    SparqlUpdateForbiddenError,
+    URIBuilder,
+)
+
+ROOT = Path(__file__).resolve().parents[3]
+SEED_DIR = ROOT / "data" / "seed"
+BASE = "https://data.atlashabita.example/"
+
+
+@pytest.fixture(scope="module")
+def graph() -> Graph:
+    dataset = SeedLoader(SEED_DIR).load()
+    return GraphBuilder(URIBuilder(BASE)).build_graph(dataset)
+
+
+@pytest.fixture()
+def settings() -> Settings:
+    return Settings()
+
+
+def test_municipios_por_provincia(graph: Graph, settings: Settings) -> None:
+    runner = SparqlRunner(graph, settings)
+    rows = runner.municipalities_by_province("41")
+    codes = {row["code"] for row in rows}
+    assert codes == {"41091", "41038", "41004"}
+
+
+def test_indicadores_de_un_territorio(graph: Graph, settings: Settings) -> None:
+    runner = SparqlRunner(graph, settings)
+    rows = runner.indicators_for_territory("municipality:41091")
+    assert len(rows) == 5
+    labels = {row["label"] for row in rows}
+    assert "Alquiler mediano" in labels
+
+
+def test_fuentes_por_territorio(graph: Graph, settings: Settings) -> None:
+    runner = SparqlRunner(graph, settings)
+    rows = runner.sources_used_by_territory("municipality:41091")
+    assert len(rows) == 5
+    assert all(row["license"] == "CC BY 4.0" for row in rows)
+
+
+def test_definicion_de_indicador(graph: Graph, settings: Settings) -> None:
+    runner = SparqlRunner(graph, settings)
+    definition = runner.indicator_definition("rent_median")
+    assert definition["label"] == "Alquiler mediano"
+    assert definition["direction"] == "lower_is_better"
+
+
+def test_definicion_indicador_inexistente(graph: Graph, settings: Settings) -> None:
+    runner = SparqlRunner(graph, settings)
+    assert runner.indicator_definition("no_existe") == {}
+
+
+def test_top_scores_por_perfil(graph: Graph, settings: Settings) -> None:
+    runner = SparqlRunner(graph, settings)
+    rows = runner.top_scores_by_profile("remote_work", "municipality", 3)
+    assert len(rows) == 3
+    # Los scores deben estar ordenados descendentemente.
+    scores = [row["score"] for row in rows]
+    assert scores == sorted(scores, reverse=True)
+    assert all(0 <= row["score"] <= 100 for row in rows)
+
+
+def test_count_triples_por_clase(graph: Graph, settings: Settings) -> None:
+    runner = SparqlRunner(graph, settings)
+    counts = runner.count_triples_by_class()
+    municipality_iri = "https://data.atlashabita.example/ontology/Municipality"
+    observation_iri = "https://data.atlashabita.example/ontology/IndicatorObservation"
+    assert counts[municipality_iri] == 10
+    assert counts[observation_iri] == 50
+
+
+def test_update_bloqueado_por_defecto(graph: Graph, settings: Settings) -> None:
+    runner = SparqlRunner(graph, settings)
+    with pytest.raises(SparqlUpdateForbiddenError):
+        runner.count_triples_by_class.__self__._execute(  # type: ignore[attr-defined]
+            "INSERT DATA { <a:a> <a:b> <a:c> }"
+        )
+
+
+def test_update_permitido_si_settings_lo_habilita(graph: Graph) -> None:
+    settings = Settings(sparql_allow_update=True)
+    runner = SparqlRunner(graph, settings)
+    # Sólo se verifica que no se lance la excepción defensiva; rdflib decidirá.
+    try:
+        runner.count_triples_by_class()
+    except SparqlUpdateForbiddenError:  # pragma: no cover — no debe ocurrir.
+        pytest.fail("No debería bloquearse cuando sparql_allow_update=True.")
+
+
+def test_limit_defensivo_aplicado(graph: Graph) -> None:
+    """Aunque se pida mucho, el ``sparql_max_results`` limita las filas."""
+    settings = Settings(sparql_max_results=2)
+    runner = SparqlRunner(graph, settings)
+    rows = runner.top_scores_by_profile("remote_work", "municipality", 50)
+    assert len(rows) <= 2
+
+
+def test_scope_invalido(graph: Graph, settings: Settings) -> None:
+    runner = SparqlRunner(graph, settings)
+    with pytest.raises(ValueError, match="Scope"):
+        runner.top_scores_by_profile("remote_work", scope="galaxia", limit=3)
+
+
+def test_territory_id_invalido(graph: Graph, settings: Settings) -> None:
+    runner = SparqlRunner(graph, settings)
+    with pytest.raises(ValueError, match="territory_id"):
+        runner.indicators_for_territory("id_sin_separador")

--- a/apps/api/tests/test_rdf_uri_builder.py
+++ b/apps/api/tests/test_rdf_uri_builder.py
@@ -1,0 +1,90 @@
+"""Pruebas del constructor de URIs."""
+
+from __future__ import annotations
+
+import pytest
+
+from atlashabita.domain.territories import TerritoryKind
+from atlashabita.infrastructure.rdf import URIBuilder
+
+BASE = "https://data.atlashabita.example/"
+
+
+@pytest.fixture()
+def builder() -> URIBuilder:
+    return URIBuilder(BASE)
+
+
+def test_base_uri_vacia_rechazada() -> None:
+    with pytest.raises(ValueError, match="base_uri"):
+        URIBuilder("")
+
+
+def test_base_uri_sin_barra_se_normaliza() -> None:
+    b = URIBuilder("https://data.atlashabita.example")
+    assert b.base_uri.endswith("/")
+
+
+def test_territory_municipality(builder: URIBuilder) -> None:
+    uri = builder.territory("41091", TerritoryKind.MUNICIPALITY)
+    assert str(uri) == BASE + "resource/territory/municipality/41091"
+
+
+def test_territory_province(builder: URIBuilder) -> None:
+    uri = builder.territory("41", TerritoryKind.PROVINCE)
+    assert str(uri) == BASE + "resource/territory/province/41"
+
+
+def test_territory_autonomous_community(builder: URIBuilder) -> None:
+    uri = builder.territory("01", TerritoryKind.AUTONOMOUS_COMMUNITY)
+    assert str(uri) == BASE + "resource/territory/autonomous_community/01"
+
+
+def test_indicator_conserva_underscores(builder: URIBuilder) -> None:
+    uri = builder.indicator("rent_median")
+    assert str(uri) == BASE + "resource/indicator/rent_median"
+
+
+def test_observation_uri_determinista(builder: URIBuilder) -> None:
+    uri = builder.observation("rent_median", "municipality:41091", "2025")
+    assert str(uri) == BASE + "resource/observation/rent_median/municipality/41091/2025"
+
+
+def test_source_uri(builder: URIBuilder) -> None:
+    uri = builder.source("ine_atlas_renta")
+    assert str(uri) == BASE + "resource/source/ine_atlas_renta"
+
+
+def test_profile_uri(builder: URIBuilder) -> None:
+    uri = builder.profile("remote_work")
+    assert str(uri) == BASE + "resource/profile/remote_work"
+
+
+def test_score_uri_incluye_version(builder: URIBuilder) -> None:
+    uri = builder.score("2026.04.1", "remote_work", "municipality:41091")
+    assert str(uri) == BASE + "resource/score/2026.04.1/remote_work/municipality/41091"
+
+
+def test_named_graph(builder: URIBuilder) -> None:
+    uri = builder.named_graph("territories")
+    assert str(uri) == BASE + "graph/territories"
+
+
+def test_slugify_elimina_tildes(builder: URIBuilder) -> None:
+    uri = builder.source("Málaga Analítica")
+    # Debe producir una URI ASCII segura sin tildes ni espacios.
+    assert str(uri) == BASE + "resource/source/Malaga_Analitica"
+
+
+def test_segmentos_vacios_rechazados(builder: URIBuilder) -> None:
+    with pytest.raises(ValueError, match="code"):
+        builder.territory("", TerritoryKind.PROVINCE)
+    with pytest.raises(ValueError, match="indicator_code"):
+        builder.observation("", "municipality:41091", "2025")
+
+
+def test_uri_builder_es_hashable() -> None:
+    """Al ser ``frozen``, se puede usar como clave de caché de alto nivel."""
+    a = URIBuilder(BASE)
+    b = URIBuilder(BASE)
+    assert hash(a) == hash(b)


### PR DESCRIPTION
## Resumen

Paquete `atlashabita.infrastructure.rdf` completo: namespaces, builder de URIs determinista, `GraphBuilder` con named graphs por dominio, serialización (Turtle/JSON-LD/N-Triples/TriG), `ShaclValidator`, `SparqlRunner` con bloqueo de UPDATE y timeouts, y manifiesto con métricas del grafo.

## Issues

Closes #11
Closes #12
Closes #13
Closes #14
Closes #15

## Verificación

- ruff/ruff-format limpio sobre `apps/api`.
- mypy strict en verde (29 source files).
- 80 tests en verde · 95 % cobertura total · 91 %+ en cada módulo RDF.
- URIs deterministas (python-slugify con underscores preservados).
- Grafo seed conforme a las shapes SHACL.
- SparqlRunner aplica `LIMIT` defensivo, timeout y bloquea INSERT/DELETE/LOAD cuando `sparql_allow_update == False`.

## Checklist

- [x] Rama partida de `develop`.
- [x] Commits atómicos Conventional Commits.
- [x] Sin secretos ni datos sintéticos no documentados.
- [x] Cobertura y typing en verde.