### PR TITLE
feat(data): quality gates tabulares y normalizador territorial

### DIFF
--- a/apps/api/src/atlashabita/infrastructure/data/__init__.py
+++ b/apps/api/src/atlashabita/infrastructure/data/__init__.py
@@ -1,0 +1,42 @@
+"""Módulo de calidad y normalización de datos tabulares.
+
+Agrupa los validadores puros que auditan el dataset seed (issue #9) y la
+normalización territorial que unifica códigos INE, jerarquías y búsqueda
+tolerante a tildes (issue #10). El módulo es deliberadamente delgado:
+
+- ``quality_gates`` contiene funciones puras y un orquestador por dataset.
+- ``normalizer`` ofrece una fachada reutilizable para CCAA, provincias y
+  municipios.
+- ``reporting`` serializa los informes de calidad como JSON en la zona
+  ``reports``.
+"""
+
+from atlashabita.infrastructure.data.normalizer import TerritoryNormalizer
+from atlashabita.infrastructure.data.quality_gates import (
+    QualityReport,
+    ValidationIssue,
+    check_coverage,
+    check_no_nulls_in_keys,
+    check_required_columns,
+    check_unique_key,
+    check_values_in_range,
+    validate_observations,
+    validate_sources,
+    validate_territories,
+)
+from atlashabita.infrastructure.data.reporting import write_quality_report
+
+__all__ = [
+    "QualityReport",
+    "TerritoryNormalizer",
+    "ValidationIssue",
+    "check_coverage",
+    "check_no_nulls_in_keys",
+    "check_required_columns",
+    "check_unique_key",
+    "check_values_in_range",
+    "validate_observations",
+    "validate_sources",
+    "validate_territories",
+    "write_quality_report",
+]

--- a/apps/api/src/atlashabita/infrastructure/data/normalizer.py
+++ b/apps/api/src/atlashabita/infrastructure/data/normalizer.py
@@ -1,0 +1,174 @@
+"""Normalización territorial: códigos INE, jerarquías y búsqueda tolerante.
+
+Se centra en las tres utilidades que el resto del backend necesita a diario:
+
+1. **Códigos INE normalizados**: cinco dígitos para municipios y dos para
+   provincias, con ``zero-padding`` defensivo cuando un CSV pierde ceros.
+2. **Jerarquía territorial**: dado un identificador (``municipality:41091`` o
+   ``41091``) devolver el diccionario con provincia y CCAA (códigos y
+   etiquetas) listo para la UI.
+3. **Índice de búsqueda**: lista plana apta para un buscador en frontend, con
+   ``slug`` sin tildes para comparar cadenas entrantes.
+"""
+
+from __future__ import annotations
+
+import unicodedata
+from collections.abc import Mapping
+from typing import Any
+
+from slugify import slugify
+
+from atlashabita.domain.territories import Territory, TerritoryKind
+from atlashabita.infrastructure.ingestion import SeedDataset
+
+_INE_LENGTHS: Mapping[TerritoryKind, int] = {
+    TerritoryKind.MUNICIPALITY: 5,
+    TerritoryKind.PROVINCE: 2,
+    TerritoryKind.AUTONOMOUS_COMMUNITY: 2,
+}
+
+
+class TerritoryNormalizer:
+    """Normalizador que opera sobre un :class:`SeedDataset` inmutable.
+
+    Construye índices auxiliares al instanciarse para responder en O(1) a las
+    búsquedas por código. Se asume que el dataset es de sólo lectura durante
+    la vida del normalizador: si cambia hay que recrear la instancia.
+    """
+
+    def __init__(self, dataset: SeedDataset) -> None:
+        self._dataset = dataset
+        self._by_kind_and_code: dict[tuple[TerritoryKind, str], Territory] = {
+            (territory.kind, territory.code): territory for territory in dataset.territories
+        }
+
+    # ------------------------------------------------------------------
+    # Códigos
+    # ------------------------------------------------------------------
+
+    def normalize_ine_code(
+        self,
+        code: str,
+        kind: TerritoryKind = TerritoryKind.MUNICIPALITY,
+    ) -> str:
+        """Devuelve el código INE rellenado con ceros a la longitud esperada.
+
+        Si ``code`` contiene caracteres no dígitos se devuelve tal cual tras
+        eliminar espacios: la validación estricta se delega en
+        :func:`quality_gates.validate_territories`.
+        """
+        if not code:
+            raise ValueError("El código INE no puede estar vacío.")
+        stripped = code.strip()
+        if not stripped.isdigit():
+            return stripped
+        expected_length = _INE_LENGTHS[kind]
+        return stripped.zfill(expected_length)
+
+    # ------------------------------------------------------------------
+    # Jerarquía
+    # ------------------------------------------------------------------
+
+    def hierarchy_of(self, territory_id: str) -> dict[str, Any]:
+        """Devuelve la jerarquía (municipio → provincia → CCAA) de un territorio.
+
+        Acepta tanto identificadores completos (``municipality:41091``) como
+        códigos sueltos (``41091``). Eleva :class:`KeyError` si el territorio
+        no existe en el dataset.
+        """
+        territory = self._resolve_territory(territory_id)
+        province = self._lookup(TerritoryKind.PROVINCE, territory.province_code)
+        community = self._lookup(
+            TerritoryKind.AUTONOMOUS_COMMUNITY, territory.autonomous_community_code
+        )
+        return {
+            "territory": {
+                "id": territory.identifier,
+                "code": territory.code,
+                "name": territory.name,
+                "kind": territory.kind.value,
+            },
+            "province": _label_pair(province),
+            "autonomous_community": _label_pair(community),
+        }
+
+    # ------------------------------------------------------------------
+    # Slug y búsqueda
+    # ------------------------------------------------------------------
+
+    def slugify_name(self, name: str) -> str:
+        """Slug reproducible para un nombre territorial.
+
+        Usa ``python-slugify`` con separador ``-`` y sin cortar longitud.
+        """
+        if not name.strip():
+            raise ValueError("El nombre a slugificar no puede estar vacío.")
+        return slugify(name, separator="-", lowercase=True)
+
+    def search_index(self) -> list[dict[str, Any]]:
+        """Índice ordenado por nombre para buscadores tolerantes a tildes."""
+        entries: list[dict[str, Any]] = []
+        for territory in self._dataset.territories:
+            province = self._lookup(TerritoryKind.PROVINCE, territory.province_code)
+            community = self._lookup(
+                TerritoryKind.AUTONOMOUS_COMMUNITY, territory.autonomous_community_code
+            )
+            entries.append(
+                {
+                    "id": territory.identifier,
+                    "code": territory.code,
+                    "name": territory.name,
+                    "slug": self.slugify_name(territory.name),
+                    "ascii_name": _strip_accents(territory.name).lower(),
+                    "kind": territory.kind.value,
+                    "province": _label_pair(province),
+                    "autonomous_community": _label_pair(community),
+                }
+            )
+        entries.sort(key=lambda entry: entry["ascii_name"])
+        return entries
+
+    # ------------------------------------------------------------------
+    # Internos
+    # ------------------------------------------------------------------
+
+    def _resolve_territory(self, territory_id: str) -> Territory:
+        """Busca un territorio por identificador completo o código municipal."""
+        if ":" in territory_id:
+            kind_part, code_part = territory_id.split(":", maxsplit=1)
+            kind = TerritoryKind(kind_part)
+            code = self.normalize_ine_code(code_part, kind)
+            territory = self._by_kind_and_code.get((kind, code))
+            if territory is None:
+                raise KeyError(territory_id)
+            return territory
+        code = self.normalize_ine_code(territory_id, TerritoryKind.MUNICIPALITY)
+        for kind in (
+            TerritoryKind.MUNICIPALITY,
+            TerritoryKind.PROVINCE,
+            TerritoryKind.AUTONOMOUS_COMMUNITY,
+        ):
+            territory = self._by_kind_and_code.get((kind, code))
+            if territory is not None:
+                return territory
+        raise KeyError(territory_id)
+
+    def _lookup(self, kind: TerritoryKind, code: str | None) -> Territory | None:
+        """Busca un territorio ``(kind, code)`` sin lanzar si no existe."""
+        if not code:
+            return None
+        return self._by_kind_and_code.get((kind, code))
+
+
+def _label_pair(territory: Territory | None) -> dict[str, str] | None:
+    """Serializa un territorio opcional como par (code, name)."""
+    if territory is None:
+        return None
+    return {"code": territory.code, "name": territory.name}
+
+
+def _strip_accents(value: str) -> str:
+    """Elimina marcas diacríticas (tildes, diéresis) de forma determinista."""
+    normalized = unicodedata.normalize("NFKD", value)
+    return "".join(char for char in normalized if not unicodedata.combining(char))

--- a/apps/api/src/atlashabita/infrastructure/data/quality_gates.py
+++ b/apps/api/src/atlashabita/infrastructure/data/quality_gates.py
@@ -1,0 +1,543 @@
+"""Validaciones tabulares y orquestadores por tipo de dataset.
+
+Las funciones puras (``check_*``) son bloques reutilizables: dado un iterable de
+filas (``Mapping`` de columna a valor) comprueban una única invariante y
+producen una tupla de :class:`ValidationIssue`. Los orquestadores
+(``validate_*``) combinan esos bloques para construir un
+:class:`QualityReport` global por dataset.
+
+Cada issue lleva su ``severity`` (``critical`` detiene el pipeline,
+``warning`` lo degrada, ``info`` aporta contexto) y un diccionario de detalles
+con evidencia (fila afectada, valor, umbral).
+
+Las invariantes cubren la sección 6 de ``docs/12_INGESTA_ETL_ELT_Y_CALIDAD``:
+columnas obligatorias, no nulos en claves, rangos, unicidad y cobertura
+mínima. El módulo no depende de ``pandas``: el dataset seed es pequeño y
+queremos cero coste de arranque.
+"""
+
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
+from typing import Any, Literal
+
+from atlashabita.infrastructure.ingestion import SeedDataset
+
+Severity = Literal["critical", "warning", "info"]
+Status = Literal["ok", "warning", "error"]
+Row = Mapping[str, Any]
+
+_INE_MUNICIPALITY_LENGTH = 5
+_INE_PROVINCE_LENGTH = 2
+_MIN_INDICATORS_PER_MUNICIPALITY = 4
+_DEFAULT_COVERAGE_THRESHOLD = 0.95
+
+
+@dataclass(frozen=True, slots=True)
+class ValidationIssue:
+    """Hallazgo individual detectado por una regla de calidad."""
+
+    severity: Severity
+    rule: str
+    message: str
+    details: Mapping[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Representación serializable (JSON friendly) del hallazgo."""
+        payload = asdict(self)
+        payload["details"] = dict(self.details)
+        return payload
+
+
+@dataclass(frozen=True, slots=True)
+class QualityReport:
+    """Informe agregado para un dataset concreto."""
+
+    source: str
+    generated_at_iso: str
+    status: Status
+    issues: tuple[ValidationIssue, ...]
+    counters: Mapping[str, int]
+
+    def to_dict(self) -> dict[str, Any]:
+        """Representación serializable usada por :mod:`reporting`."""
+        return {
+            "source": self.source,
+            "generated_at_iso": self.generated_at_iso,
+            "status": self.status,
+            "issues": [issue.to_dict() for issue in self.issues],
+            "counters": dict(self.counters),
+        }
+
+    @property
+    def critical_count(self) -> int:
+        """Número de hallazgos críticos."""
+        return sum(1 for issue in self.issues if issue.severity == "critical")
+
+    @property
+    def warning_count(self) -> int:
+        """Número de advertencias."""
+        return sum(1 for issue in self.issues if issue.severity == "warning")
+
+
+# ---------------------------------------------------------------------------
+# Reglas puras
+# ---------------------------------------------------------------------------
+
+
+def check_required_columns(
+    rows: Sequence[Row], required: Iterable[str]
+) -> tuple[ValidationIssue, ...]:
+    """Verifica que todas las columnas obligatorias aparezcan en la primera fila.
+
+    El contrato es estricto: si el dataset está vacío no hay columnas que
+    comprobar y devolvemos un issue ``warning`` para advertir al operador.
+    """
+    required_tuple = tuple(required)
+    if not rows:
+        return (
+            ValidationIssue(
+                severity="warning",
+                rule="required_columns",
+                message="El dataset está vacío; no hay columnas que validar.",
+                details={"required": list(required_tuple)},
+            ),
+        )
+    first = rows[0]
+    missing = [column for column in required_tuple if column not in first]
+    if not missing:
+        return ()
+    return (
+        ValidationIssue(
+            severity="critical",
+            rule="required_columns",
+            message=f"Faltan columnas obligatorias: {missing}",
+            details={"missing": missing, "required": list(required_tuple)},
+        ),
+    )
+
+
+def check_no_nulls_in_keys(rows: Sequence[Row], keys: Iterable[str]) -> tuple[ValidationIssue, ...]:
+    """Detecta valores nulos o cadenas vacías en columnas clave."""
+    keys_tuple = tuple(keys)
+    issues: list[ValidationIssue] = []
+    for index, row in enumerate(rows, start=1):
+        for key in keys_tuple:
+            value = row.get(key)
+            if value is None or (isinstance(value, str) and not value.strip()):
+                issues.append(
+                    ValidationIssue(
+                        severity="critical",
+                        rule="no_nulls_in_keys",
+                        message=f"Valor nulo en columna clave {key!r} (fila {index}).",
+                        details={"row": index, "column": key},
+                    )
+                )
+    return tuple(issues)
+
+
+def check_values_in_range(
+    rows: Sequence[Row],
+    column: str,
+    min_v: float | None,
+    max_v: float | None,
+) -> tuple[ValidationIssue, ...]:
+    """Comprueba que ``column`` se mantenga dentro de ``[min_v, max_v]``.
+
+    Los extremos son opcionales: ``None`` desactiva la cota correspondiente.
+    Valores no numéricos se reportan como críticos.
+    """
+    issues: list[ValidationIssue] = []
+    for index, row in enumerate(rows, start=1):
+        raw = row.get(column)
+        if raw is None:
+            continue
+        try:
+            value = float(raw)
+        except (TypeError, ValueError):
+            issues.append(
+                ValidationIssue(
+                    severity="critical",
+                    rule="values_in_range",
+                    message=(f"Valor no numérico en {column!r} fila {index}: {raw!r}"),
+                    details={"row": index, "column": column, "value": raw},
+                )
+            )
+            continue
+        if min_v is not None and value < min_v:
+            issues.append(
+                ValidationIssue(
+                    severity="warning",
+                    rule="values_in_range",
+                    message=(
+                        f"Valor {value} por debajo del mínimo {min_v} en {column!r} fila {index}."
+                    ),
+                    details={
+                        "row": index,
+                        "column": column,
+                        "value": value,
+                        "min": min_v,
+                    },
+                )
+            )
+        if max_v is not None and value > max_v:
+            issues.append(
+                ValidationIssue(
+                    severity="warning",
+                    rule="values_in_range",
+                    message=(
+                        f"Valor {value} por encima del máximo {max_v} en {column!r} fila {index}."
+                    ),
+                    details={
+                        "row": index,
+                        "column": column,
+                        "value": value,
+                        "max": max_v,
+                    },
+                )
+            )
+    return tuple(issues)
+
+
+def check_unique_key(rows: Sequence[Row], keys: Iterable[str]) -> tuple[ValidationIssue, ...]:
+    """Garantiza que la tupla ``keys`` sea única en el conjunto de filas."""
+    keys_tuple = tuple(keys)
+    counter: Counter[tuple[Any, ...]] = Counter(
+        tuple(row.get(key) for key in keys_tuple) for row in rows
+    )
+    duplicates = [key for key, count in counter.items() if count > 1]
+    if not duplicates:
+        return ()
+    return tuple(
+        ValidationIssue(
+            severity="critical",
+            rule="unique_key",
+            message=(f"Clave duplicada {dict(zip(keys_tuple, duplicate, strict=True))}"),
+            details={
+                "keys": list(keys_tuple),
+                "values": list(duplicate),
+                "count": counter[duplicate],
+            },
+        )
+        for duplicate in duplicates
+    )
+
+
+def check_coverage(
+    actual: Iterable[str],
+    expected: Iterable[str],
+    threshold: float = _DEFAULT_COVERAGE_THRESHOLD,
+) -> tuple[ValidationIssue, ...]:
+    """Evalúa la ratio ``|actual ∩ expected| / |expected|``.
+
+    - Si ``expected`` está vacío la cobertura se considera ``1.0``.
+    - Si la ratio cae por debajo de ``threshold`` emite ``critical``.
+    """
+    expected_set = {value for value in expected if value}
+    actual_set = {value for value in actual if value}
+    if not expected_set:
+        return ()
+    ratio = len(expected_set & actual_set) / len(expected_set)
+    if ratio >= threshold:
+        return ()
+    missing = sorted(expected_set - actual_set)
+    return (
+        ValidationIssue(
+            severity="critical",
+            rule="coverage",
+            message=(f"Cobertura {ratio:.2%} por debajo del umbral {threshold:.2%}."),
+            details={
+                "ratio": ratio,
+                "threshold": threshold,
+                "missing": missing,
+                "expected_total": len(expected_set),
+                "actual_total": len(actual_set),
+            },
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Orquestadores por dataset
+# ---------------------------------------------------------------------------
+
+
+def _timestamp_iso() -> str:
+    """ISO 8601 en UTC con precisión de segundos."""
+    return datetime.now(tz=UTC).replace(microsecond=0).isoformat()
+
+
+def _status_from_issues(issues: Iterable[ValidationIssue]) -> Status:
+    """Derivación del estado global a partir de las severidades."""
+    severities = {issue.severity for issue in issues}
+    if "critical" in severities:
+        return "error"
+    if "warning" in severities:
+        return "warning"
+    return "ok"
+
+
+def _observations_as_rows(dataset: SeedDataset) -> list[dict[str, Any]]:
+    """Proyecta las observaciones del dataset como filas homogéneas."""
+    return [
+        {
+            "indicator_code": obs.indicator_code,
+            "territory_id": obs.territory_id,
+            "period": obs.period,
+            "value": obs.value,
+            "source_id": obs.source_id,
+            "quality": obs.quality,
+        }
+        for obs in dataset.observations
+    ]
+
+
+def _territories_as_rows(dataset: SeedDataset) -> list[dict[str, Any]]:
+    """Proyecta los territorios del dataset como filas homogéneas."""
+    return [
+        {
+            "kind": territory.kind.value,
+            "code": territory.code,
+            "name": territory.name,
+            "parent_code": territory.parent_code,
+            "province_code": territory.province_code,
+            "autonomous_community_code": territory.autonomous_community_code,
+        }
+        for territory in dataset.territories
+    ]
+
+
+def _sources_as_rows(dataset: SeedDataset) -> list[dict[str, Any]]:
+    """Proyecta las fuentes del dataset como filas homogéneas."""
+    return [
+        {
+            "id": source.id,
+            "title": source.title,
+            "publisher": source.publisher,
+            "url": source.url,
+            "license": source.license,
+            "periodicity": source.periodicity,
+            "description": source.description,
+        }
+        for source in dataset.sources
+    ]
+
+
+def validate_observations(dataset: SeedDataset) -> QualityReport:
+    """Ejecuta el paquete completo de reglas sobre las observaciones.
+
+    Reglas aplicadas:
+
+    - columnas obligatorias
+    - nulos en claves (``indicator_code``, ``territory_id``, ``period``,
+      ``source_id``)
+    - rangos por indicador usando ``min_value``/``max_value``
+    - unicidad ``(indicator_code, territory_id, period)``
+    - cobertura mínima: cada municipio debe aparecer en al menos 4 indicadores.
+    """
+    rows = _observations_as_rows(dataset)
+    issues: list[ValidationIssue] = []
+    issues.extend(
+        check_required_columns(
+            rows,
+            ("indicator_code", "territory_id", "period", "value", "source_id"),
+        )
+    )
+    issues.extend(
+        check_no_nulls_in_keys(rows, ("indicator_code", "territory_id", "period", "source_id"))
+    )
+    issues.extend(check_unique_key(rows, ("indicator_code", "territory_id", "period")))
+
+    indicator_index = {indicator.code: indicator for indicator in dataset.indicators}
+    for indicator_code, indicator in indicator_index.items():
+        indicator_rows = [row for row in rows if row["indicator_code"] == indicator_code]
+        issues.extend(
+            check_values_in_range(indicator_rows, "value", indicator.min_value, indicator.max_value)
+        )
+
+    indicators_by_territory: dict[str, set[str]] = defaultdict(set)
+    for row in rows:
+        indicators_by_territory[row["territory_id"]].add(row["indicator_code"])
+
+    for municipality in dataset.municipalities:
+        indicator_count = len(indicators_by_territory.get(municipality.identifier, set()))
+        if indicator_count < _MIN_INDICATORS_PER_MUNICIPALITY:
+            issues.append(
+                ValidationIssue(
+                    severity="critical",
+                    rule="minimum_indicator_coverage",
+                    message=(
+                        f"{municipality.identifier} tiene observaciones sólo de "
+                        f"{indicator_count} indicadores (mínimo "
+                        f"{_MIN_INDICATORS_PER_MUNICIPALITY})."
+                    ),
+                    details={
+                        "territory_id": municipality.identifier,
+                        "indicators": indicator_count,
+                        "minimum": _MIN_INDICATORS_PER_MUNICIPALITY,
+                    },
+                )
+            )
+
+    counters = {
+        "rows": len(rows),
+        "indicators": len(indicator_index),
+        "municipalities": len(dataset.municipalities),
+        "issues": len(issues),
+    }
+    return QualityReport(
+        source="observations",
+        generated_at_iso=_timestamp_iso(),
+        status=_status_from_issues(issues),
+        issues=tuple(issues),
+        counters=counters,
+    )
+
+
+def validate_territories(dataset: SeedDataset) -> QualityReport:
+    """Comprueba integridad territorial: jerarquías y códigos INE."""
+    rows = _territories_as_rows(dataset)
+    issues: list[ValidationIssue] = []
+    issues.extend(
+        check_required_columns(
+            rows,
+            (
+                "kind",
+                "code",
+                "name",
+                "province_code",
+                "autonomous_community_code",
+            ),
+        )
+    )
+    issues.extend(check_no_nulls_in_keys(rows, ("kind", "code", "name")))
+    issues.extend(check_unique_key(rows, ("kind", "code")))
+
+    for territory in dataset.municipalities:
+        if not territory.province_code:
+            issues.append(
+                ValidationIssue(
+                    severity="critical",
+                    rule="territory_hierarchy",
+                    message=(f"Municipio {territory.identifier} sin province_code."),
+                    details={"territory_id": territory.identifier},
+                )
+            )
+        if not territory.autonomous_community_code:
+            issues.append(
+                ValidationIssue(
+                    severity="critical",
+                    rule="territory_hierarchy",
+                    message=(f"Municipio {territory.identifier} sin autonomous_community_code."),
+                    details={"territory_id": territory.identifier},
+                )
+            )
+        if not _is_valid_ine_code(territory.code, _INE_MUNICIPALITY_LENGTH):
+            issues.append(
+                ValidationIssue(
+                    severity="critical",
+                    rule="ine_code_format",
+                    message=(
+                        f"Código INE de municipio inválido: {territory.code!r} "
+                        f"(se esperan {_INE_MUNICIPALITY_LENGTH} dígitos)."
+                    ),
+                    details={
+                        "territory_id": territory.identifier,
+                        "code": territory.code,
+                        "expected_length": _INE_MUNICIPALITY_LENGTH,
+                    },
+                )
+            )
+
+    for province in dataset.provinces:
+        if not _is_valid_ine_code(province.code, _INE_PROVINCE_LENGTH):
+            issues.append(
+                ValidationIssue(
+                    severity="critical",
+                    rule="ine_code_format",
+                    message=(f"Código INE de provincia inválido: {province.code!r}."),
+                    details={
+                        "territory_id": province.identifier,
+                        "code": province.code,
+                        "expected_length": _INE_PROVINCE_LENGTH,
+                    },
+                )
+            )
+
+    counters = {
+        "territories": len(rows),
+        "municipalities": len(dataset.municipalities),
+        "provinces": len(dataset.provinces),
+        "autonomous_communities": len(dataset.autonomous_communities),
+        "issues": len(issues),
+    }
+    return QualityReport(
+        source="territories",
+        generated_at_iso=_timestamp_iso(),
+        status=_status_from_issues(issues),
+        issues=tuple(issues),
+        counters=counters,
+    )
+
+
+def validate_sources(dataset: SeedDataset) -> QualityReport:
+    """Valida metadatos mínimos exigidos a cada fuente oficial."""
+    rows = _sources_as_rows(dataset)
+    issues: list[ValidationIssue] = []
+    issues.extend(
+        check_required_columns(
+            rows,
+            ("id", "title", "publisher", "url", "license", "periodicity"),
+        )
+    )
+    issues.extend(
+        check_no_nulls_in_keys(rows, ("id", "title", "publisher", "url", "license", "periodicity"))
+    )
+    issues.extend(check_unique_key(rows, ("id",)))
+
+    for source in dataset.sources:
+        if not source.url.startswith(("http://", "https://")):
+            issues.append(
+                ValidationIssue(
+                    severity="critical",
+                    rule="source_url_scheme",
+                    message=(f"URL de fuente {source.id!r} sin esquema http/https: {source.url!r}"),
+                    details={"source_id": source.id, "url": source.url},
+                )
+            )
+        if not source.indicators:
+            issues.append(
+                ValidationIssue(
+                    severity="warning",
+                    rule="source_indicators",
+                    message=f"Fuente {source.id!r} no declara indicadores.",
+                    details={"source_id": source.id},
+                )
+            )
+
+    counters = {
+        "sources": len(rows),
+        "issues": len(issues),
+    }
+    return QualityReport(
+        source="sources",
+        generated_at_iso=_timestamp_iso(),
+        status=_status_from_issues(issues),
+        issues=tuple(issues),
+        counters=counters,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Utilidades privadas
+# ---------------------------------------------------------------------------
+
+
+def _is_valid_ine_code(code: str | None, expected_length: int) -> bool:
+    """Un código INE válido tiene dígitos puros y la longitud esperada."""
+    if not code:
+        return False
+    return len(code) == expected_length and code.isdigit()

--- a/apps/api/src/atlashabita/infrastructure/data/reporting.py
+++ b/apps/api/src/atlashabita/infrastructure/data/reporting.py
@@ -1,0 +1,40 @@
+"""Serialización de :class:`QualityReport` a disco en la zona ``reports``."""
+
+from __future__ import annotations
+
+import json
+import re
+from datetime import UTC, datetime
+from pathlib import Path
+
+from atlashabita.config import Settings
+from atlashabita.infrastructure.data.quality_gates import QualityReport
+
+_SAFE_NAME = re.compile(r"[^a-z0-9_-]+")
+
+
+def write_quality_report(report: QualityReport, settings: Settings, name: str) -> Path:
+    """Escribe el informe como JSON UTF-8 y devuelve la ruta creada.
+
+    El nombre se sanea para evitar rutas relativas inesperadas; el timestamp
+    se añade en formato compacto ``YYYYMMDDTHHMMSSZ`` para que los ficheros
+    ordenen cronológicamente y no se sobrescriban entre ejecuciones.
+    """
+    safe_name = _sanitize_name(name)
+    reports_dir = settings.data_zone("reports")
+    reports_dir.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.now(tz=UTC).strftime("%Y%m%dT%H%M%SZ")
+    destination = reports_dir / f"{safe_name}_{timestamp}.json"
+    payload = json.dumps(report.to_dict(), ensure_ascii=False, indent=2, sort_keys=True)
+    destination.write_text(payload, encoding="utf-8")
+    return destination
+
+
+def _sanitize_name(name: str) -> str:
+    """Devuelve un nombre de fichero seguro: minúsculas, ``[a-z0-9_-]``."""
+    if not name.strip():
+        raise ValueError("El nombre del informe no puede estar vacío.")
+    candidate = _SAFE_NAME.sub("-", name.strip().lower()).strip("-")
+    if not candidate:
+        raise ValueError(f"Nombre de informe no serializable: {name!r}")
+    return candidate

--- a/apps/api/tests/test_data_normalizer.py
+++ b/apps/api/tests/test_data_normalizer.py
@@ -1,0 +1,115 @@
+"""Tests del normalizador territorial y la búsqueda tolerante a tildes."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from atlashabita.domain.territories import TerritoryKind
+from atlashabita.infrastructure.data import TerritoryNormalizer
+from atlashabita.infrastructure.ingestion import SeedDataset, SeedLoader
+
+SEED_DIR = Path(__file__).resolve().parents[3] / "data" / "seed"
+
+
+@pytest.fixture(scope="module")
+def dataset() -> SeedDataset:
+    return SeedLoader(SEED_DIR).load()
+
+
+@pytest.fixture(scope="module")
+def normalizer(dataset: SeedDataset) -> TerritoryNormalizer:
+    return TerritoryNormalizer(dataset)
+
+
+def test_normalize_ine_code_completa_con_ceros_municipio(
+    normalizer: TerritoryNormalizer,
+) -> None:
+    assert normalizer.normalize_ine_code("1091") == "01091"
+    assert normalizer.normalize_ine_code("41091") == "41091"
+
+
+def test_normalize_ine_code_provincia_dos_digitos(
+    normalizer: TerritoryNormalizer,
+) -> None:
+    assert normalizer.normalize_ine_code("1", TerritoryKind.PROVINCE) == "01"
+    assert normalizer.normalize_ine_code("41", TerritoryKind.PROVINCE) == "41"
+
+
+def test_normalize_ine_code_respeta_valores_no_digitos(
+    normalizer: TerritoryNormalizer,
+) -> None:
+    assert normalizer.normalize_ine_code("ES41") == "ES41"
+
+
+def test_normalize_ine_code_falla_con_cadena_vacia(
+    normalizer: TerritoryNormalizer,
+) -> None:
+    with pytest.raises(ValueError):
+        normalizer.normalize_ine_code("")
+
+
+def test_hierarchy_of_devuelve_provincia_y_ccaa(
+    normalizer: TerritoryNormalizer,
+) -> None:
+    hierarchy = normalizer.hierarchy_of("municipality:41091")
+    assert hierarchy["province"] == {"code": "41", "name": "Sevilla"}
+    assert hierarchy["autonomous_community"] == {"code": "01", "name": "Andalucía"}
+    assert hierarchy["territory"]["name"] == "Sevilla"
+
+
+def test_hierarchy_of_acepta_codigo_municipal_puro(
+    normalizer: TerritoryNormalizer,
+) -> None:
+    hierarchy = normalizer.hierarchy_of("20069")
+    assert hierarchy["autonomous_community"] == {"code": "16", "name": "País Vasco"}
+
+
+def test_hierarchy_of_falla_si_territorio_no_existe(
+    normalizer: TerritoryNormalizer,
+) -> None:
+    with pytest.raises(KeyError):
+        normalizer.hierarchy_of("municipality:99999")
+
+
+def test_slugify_name_elimina_tildes_y_mayusculas(
+    normalizer: TerritoryNormalizer,
+) -> None:
+    assert normalizer.slugify_name("Alcalá de Guadaíra") == "alcala-de-guadaira"
+    assert normalizer.slugify_name("Donostia/San Sebastián") == "donostia-san-sebastian"
+
+
+def test_slugify_name_falla_cuando_el_nombre_es_vacio(
+    normalizer: TerritoryNormalizer,
+) -> None:
+    with pytest.raises(ValueError):
+        normalizer.slugify_name("   ")
+
+
+def test_search_index_incluye_todos_los_territorios(
+    normalizer: TerritoryNormalizer, dataset: SeedDataset
+) -> None:
+    index = normalizer.search_index()
+    assert len(index) == len(dataset.territories)
+    # El índice debe ordenarse alfabéticamente por nombre sin tildes.
+    ascii_names = [entry["ascii_name"] for entry in index]
+    assert ascii_names == sorted(ascii_names)
+
+
+def test_search_index_permite_buscar_sin_tildes(
+    normalizer: TerritoryNormalizer,
+) -> None:
+    index = normalizer.search_index()
+    query = "alcala"
+    matches = [entry for entry in index if query in entry["ascii_name"]]
+    assert any(match["id"] == "municipality:41004" for match in matches)
+
+
+def test_search_index_slug_coincide_con_nombre_normalizado(
+    normalizer: TerritoryNormalizer,
+) -> None:
+    index = normalizer.search_index()
+    pais_vasco = next(entry for entry in index if entry["id"] == "autonomous_community:16")
+    assert pais_vasco["slug"] == "pais-vasco"
+    assert pais_vasco["ascii_name"] == "pais vasco"

--- a/apps/api/tests/test_data_quality.py
+++ b/apps/api/tests/test_data_quality.py
@@ -1,0 +1,282 @@
+"""Tests de calidad tabular sobre el dataset seed y reglas unitarias."""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from atlashabita.config import Settings
+from atlashabita.domain.indicators import Indicator, IndicatorDirection, IndicatorObservation
+from atlashabita.domain.sources import DataSource
+from atlashabita.domain.territories import Territory, TerritoryKind
+from atlashabita.infrastructure.data import (
+    QualityReport,
+    ValidationIssue,
+    check_coverage,
+    check_no_nulls_in_keys,
+    check_required_columns,
+    check_unique_key,
+    check_values_in_range,
+    validate_observations,
+    validate_sources,
+    validate_territories,
+    write_quality_report,
+)
+from atlashabita.infrastructure.ingestion import SeedDataset, SeedLoader
+
+SEED_DIR = Path(__file__).resolve().parents[3] / "data" / "seed"
+
+
+@pytest.fixture(scope="module")
+def dataset() -> SeedDataset:
+    """Dataset real, compartido entre pruebas del módulo."""
+    return SeedLoader(SEED_DIR).load()
+
+
+# ---------------------------------------------------------------------------
+# Reglas puras
+# ---------------------------------------------------------------------------
+
+
+def test_check_required_columns_detecta_faltantes() -> None:
+    rows = [{"a": 1}]
+    issues = check_required_columns(rows, ("a", "b"))
+    assert len(issues) == 1
+    assert issues[0].severity == "critical"
+    assert "b" in issues[0].details["missing"]
+
+
+def test_check_required_columns_acepta_cuando_todas_estan() -> None:
+    rows = [{"a": 1, "b": 2}]
+    assert check_required_columns(rows, ("a", "b")) == ()
+
+
+def test_check_required_columns_sobre_dataset_vacio_advierte() -> None:
+    issues = check_required_columns([], ("a",))
+    assert len(issues) == 1
+    assert issues[0].severity == "warning"
+
+
+def test_check_no_nulls_in_keys_detecta_valor_vacio() -> None:
+    rows = [{"k": "41091"}, {"k": "   "}, {"k": None}]
+    issues = check_no_nulls_in_keys(rows, ("k",))
+    assert len(issues) == 2
+    assert {issue.details["row"] for issue in issues} == {2, 3}
+
+
+def test_check_no_nulls_in_keys_acepta_valores_validos() -> None:
+    rows = [{"k": "A"}, {"k": "B"}]
+    assert check_no_nulls_in_keys(rows, ("k",)) == ()
+
+
+def test_check_values_in_range_detecta_fuera_de_rango_y_no_numericos() -> None:
+    rows = [
+        {"v": 1.0},
+        {"v": 10.0},
+        {"v": 200.0},
+        {"v": "no-numero"},
+    ]
+    issues = check_values_in_range(rows, "v", min_v=0.0, max_v=100.0)
+    severities = [issue.severity for issue in issues]
+    assert "warning" in severities  # 200 > 100
+    assert "critical" in severities  # no-numero
+    assert len(issues) == 2
+
+
+def test_check_values_in_range_acepta_valores_correctos() -> None:
+    rows = [{"v": 5.0}, {"v": 50.0}]
+    assert check_values_in_range(rows, "v", min_v=0.0, max_v=100.0) == ()
+
+
+def test_check_unique_key_detecta_duplicados() -> None:
+    rows = [{"a": 1, "b": 2}, {"a": 1, "b": 2}, {"a": 1, "b": 3}]
+    issues = check_unique_key(rows, ("a", "b"))
+    assert len(issues) == 1
+    assert issues[0].severity == "critical"
+    assert issues[0].details["count"] == 2
+
+
+def test_check_unique_key_acepta_llaves_unicas() -> None:
+    rows = [{"a": 1}, {"a": 2}, {"a": 3}]
+    assert check_unique_key(rows, ("a",)) == ()
+
+
+def test_check_coverage_detecta_cobertura_insuficiente() -> None:
+    expected = ["a", "b", "c", "d"]
+    actual = ["a"]
+    issues = check_coverage(actual, expected, threshold=0.9)
+    assert len(issues) == 1
+    assert issues[0].details["ratio"] == pytest.approx(0.25)
+
+
+def test_check_coverage_acepta_cobertura_superior_al_umbral() -> None:
+    expected = ["a", "b", "c", "d"]
+    actual = ["a", "b", "c", "d"]
+    assert check_coverage(actual, expected, threshold=0.9) == ()
+
+
+# ---------------------------------------------------------------------------
+# Orquestadores sobre el seed real
+# ---------------------------------------------------------------------------
+
+
+def test_validate_observations_pasa_sobre_el_seed_real(dataset: SeedDataset) -> None:
+    report = validate_observations(dataset)
+    assert isinstance(report, QualityReport)
+    assert report.status == "ok", report.issues
+    assert report.critical_count == 0
+    assert report.counters["rows"] == 50
+
+
+def test_validate_territories_pasa_sobre_el_seed_real(dataset: SeedDataset) -> None:
+    report = validate_territories(dataset)
+    assert report.status == "ok", report.issues
+    assert report.critical_count == 0
+    assert report.counters["municipalities"] == 10
+
+
+def test_validate_sources_pasa_sobre_el_seed_real(dataset: SeedDataset) -> None:
+    report = validate_sources(dataset)
+    assert report.status == "ok", report.issues
+    assert report.counters["sources"] == 5
+
+
+# ---------------------------------------------------------------------------
+# Detección de regresiones intencionales
+# ---------------------------------------------------------------------------
+
+
+def _indicators(dataset: SeedDataset) -> tuple[Indicator, ...]:
+    return dataset.indicators
+
+
+def _replace_observations(
+    dataset: SeedDataset, observations: Iterable[IndicatorObservation]
+) -> SeedDataset:
+    return dataclasses.replace(dataset, observations=tuple(observations))
+
+
+def _replace_territories(dataset: SeedDataset, territories: Iterable[Territory]) -> SeedDataset:
+    return dataclasses.replace(dataset, territories=tuple(territories))
+
+
+def _replace_sources(dataset: SeedDataset, sources: Iterable[DataSource]) -> SeedDataset:
+    return dataclasses.replace(dataset, sources=tuple(sources))
+
+
+def test_validate_observations_detecta_duplicados(dataset: SeedDataset) -> None:
+    duplicate = dataset.observations[0]
+    broken = _replace_observations(dataset, (*dataset.observations, duplicate))
+    report = validate_observations(broken)
+    assert report.status == "error"
+    assert any(issue.rule == "unique_key" for issue in report.issues)
+
+
+def test_validate_observations_detecta_valor_fuera_de_rango(
+    dataset: SeedDataset,
+) -> None:
+    first = dataset.observations[0]
+    outlier = IndicatorObservation(
+        indicator_code=first.indicator_code,
+        territory_id=first.territory_id,
+        period="2099",
+        value=999.0,
+        source_id=first.source_id,
+    )
+    broken = _replace_observations(dataset, (*dataset.observations, outlier))
+    report = validate_observations(broken)
+    assert any(issue.rule == "values_in_range" for issue in report.issues)
+
+
+def test_validate_observations_detecta_cobertura_incompleta(
+    dataset: SeedDataset,
+) -> None:
+    target = dataset.municipalities[0].identifier
+    reduced = tuple(obs for obs in dataset.observations if obs.territory_id != target)
+    # Dejamos sólo una observación para que caiga por debajo del mínimo.
+    reduced = (*reduced, dataset.observations[0])
+    broken = _replace_observations(dataset, reduced)
+    report = validate_observations(broken)
+    assert any(issue.rule == "minimum_indicator_coverage" for issue in report.issues)
+
+
+def test_validate_territories_detecta_codigo_ine_invalido(
+    dataset: SeedDataset,
+) -> None:
+    target = dataset.municipalities[0]
+    mutated = Territory(
+        code="999",  # sólo tres dígitos
+        name=target.name,
+        kind=TerritoryKind.MUNICIPALITY,
+        parent_code=target.parent_code,
+        province_code=target.province_code,
+        autonomous_community_code=target.autonomous_community_code,
+        centroid=target.centroid,
+        population=target.population,
+        area_km2=target.area_km2,
+    )
+    others = tuple(t for t in dataset.territories if t is not target)
+    broken = _replace_territories(dataset, (*others, mutated))
+    report = validate_territories(broken)
+    assert any(issue.rule == "ine_code_format" for issue in report.issues)
+
+
+def test_validate_sources_detecta_url_no_http(dataset: SeedDataset) -> None:
+    target = dataset.sources[0]
+    mutated = DataSource(
+        id=target.id,
+        title=target.title,
+        publisher=target.publisher,
+        url="ftp://legacy.example.com/data.zip",
+        license=target.license,
+        periodicity=target.periodicity,
+        description=target.description,
+        indicators=target.indicators,
+    )
+    others = tuple(source for source in dataset.sources if source.id != target.id)
+    broken = _replace_sources(dataset, (*others, mutated))
+    report = validate_sources(broken)
+    assert any(issue.rule == "source_url_scheme" for issue in report.issues)
+
+
+# ---------------------------------------------------------------------------
+# Reporting
+# ---------------------------------------------------------------------------
+
+
+def test_write_quality_report_crea_json_en_zona_reports(
+    dataset: SeedDataset, tmp_path: Path
+) -> None:
+    settings = Settings(data_root=tmp_path)
+    report = validate_observations(dataset)
+    destination = write_quality_report(report, settings, "observations")
+    assert destination.exists()
+    assert destination.parent == settings.data_zone("reports")
+    payload: dict[str, Any] = json.loads(destination.read_text(encoding="utf-8"))
+    assert payload["source"] == "observations"
+    assert payload["status"] == report.status
+
+
+def test_validation_issue_serializable() -> None:
+    issue = ValidationIssue(severity="info", rule="demo", message="hola", details={"x": 1})
+    assert issue.to_dict() == {
+        "severity": "info",
+        "rule": "demo",
+        "message": "hola",
+        "details": {"x": 1},
+    }
+
+
+def test_indicadores_seed_tienen_min_max_definidos(dataset: SeedDataset) -> None:
+    for indicator in _indicators(dataset):
+        assert indicator.direction in {
+            IndicatorDirection.HIGHER_IS_BETTER,
+            IndicatorDirection.LOWER_IS_BETTER,
+        }
+        assert indicator.min_value is not None
+        assert indicator.max_value is not None


### PR DESCRIPTION
## Resumen

Paquete `atlashabita.infrastructure.data` con las reglas de validación tabular (columnas, nulos en claves, rangos por indicador, unicidad, cobertura), la normalización territorial (códigos INE, jerarquía, slugify, índice de búsqueda sin tildes) y la escritura de reportes de calidad.

## Issues

Closes #9
Closes #10

## Verificación

- ruff y ruff format en verde (35 archivos).
- mypy strict (25 source files).
- 61 tests en verde (25 nuevos) · 95 % cobertura.
- Validaciones pasan sobre el seed real y fallan cuando se rompen los invariantes.

## Checklist

- [x] Rama de `develop`.
- [x] Conventional Commits.
- [x] Sin duplicación con el lector `SeedLoader` ni con la infraestructura RDF.