### PR TITLE
feat(application): scoring explicable, casos de uso y middleware request-id

### DIFF
--- a/apps/api/src/atlashabita/application/__init__.py
+++ b/apps/api/src/atlashabita/application/__init__.py
@@ -1,1 +1,33 @@
-"""Capa de aplicación: casos de uso orquestando el dominio y la infraestructura."""
+"""Capa de aplicación: casos de uso orquestando el dominio y la infraestructura.
+
+Expone el :class:`Container` (composition root), el :class:`ScoringService`
+explicable y los casos de uso que utilizan los routers HTTP. Los módulos de
+interfaz solo deberían depender de estos símbolos, nunca de la infraestructura
+directamente.
+"""
+
+from atlashabita.application.container import Container
+from atlashabita.application.scoring import ScoringService
+from atlashabita.application.use_cases import (
+    ComputeRankingsUseCase,
+    GetMapLayerUseCase,
+    GetQualityReportUseCase,
+    GetTerritoryDetailUseCase,
+    ListMapLayersUseCase,
+    ListProfilesUseCase,
+    ListSourcesUseCase,
+    SearchTerritoriesUseCase,
+)
+
+__all__ = [
+    "ComputeRankingsUseCase",
+    "Container",
+    "GetMapLayerUseCase",
+    "GetQualityReportUseCase",
+    "GetTerritoryDetailUseCase",
+    "ListMapLayersUseCase",
+    "ListProfilesUseCase",
+    "ListSourcesUseCase",
+    "ScoringService",
+    "SearchTerritoriesUseCase",
+]

--- a/apps/api/src/atlashabita/application/container.py
+++ b/apps/api/src/atlashabita/application/container.py
@@ -1,0 +1,130 @@
+"""Composition root de la capa de aplicación.
+
+El contenedor agrupa las dependencias compartidas (dataset, scoring) y
+construye los casos de uso bajo demanda mediante ``cached_property``. Es el
+único punto donde se cablean objetos; los consumidores (routers FastAPI,
+tests) piden casos de uso al contenedor en lugar de instanciar servicios.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from functools import cached_property
+from typing import Final
+
+from atlashabita.application.scoring import ScoringService
+from atlashabita.application.use_cases import (
+    ComputeRankingsUseCase,
+    GetMapLayerUseCase,
+    GetQualityReportUseCase,
+    GetTerritoryDetailUseCase,
+    ListMapLayersUseCase,
+    ListProfilesUseCase,
+    ListSourcesUseCase,
+    SearchTerritoriesUseCase,
+)
+from atlashabita.config import Settings
+from atlashabita.domain.territories import Territory
+from atlashabita.infrastructure.ingestion import SeedDataset, SeedLoader
+
+_DATA_VERSION_PREFIX: Final[str] = "seed:"
+
+
+class Container:
+    """Contenedor de dependencias inyectable.
+
+    La instancia puede compartirse entre peticiones: los casos de uso son
+    puros sobre el dataset cacheado en memoria. Para invalidar el dataset
+    basta con instanciar un nuevo contenedor.
+    """
+
+    def __init__(self, settings: Settings) -> None:
+        self._settings = settings
+
+    @property
+    def settings(self) -> Settings:
+        """Configuración inyectada al crear el contenedor."""
+        return self._settings
+
+    @cached_property
+    def dataset(self) -> SeedDataset:
+        """Dataset seed cargado de forma perezosa la primera vez que se pide."""
+        loader = SeedLoader(self._settings.data_zone("seed"))
+        return loader.load()
+
+    @cached_property
+    def scoring_service(self) -> ScoringService:
+        """Servicio de scoring explicable vinculado al dataset actual."""
+        return ScoringService(self.dataset, self._settings)
+
+    @cached_property
+    def territory_index(self) -> dict[str, Territory]:
+        """Índice ``identifier -> Territory`` para búsquedas O(1)."""
+        return {territory.identifier: territory for territory in self.dataset.territories}
+
+    @cached_property
+    def data_version(self) -> str:
+        """Identificador estable del dataset en memoria."""
+        digest = hashlib.sha256()
+        for territory in self.dataset.territories:
+            digest.update(territory.identifier.encode("utf-8"))
+        for observation in self.dataset.observations:
+            digest.update(
+                f"{observation.indicator_code}:{observation.territory_id}:"
+                f"{observation.period}:{observation.value}".encode()
+            )
+        return f"{_DATA_VERSION_PREFIX}{digest.hexdigest()[:12]}"
+
+    @cached_property
+    def search_territories(self) -> SearchTerritoriesUseCase:
+        """Caso de uso de búsqueda textual de territorios."""
+        return SearchTerritoriesUseCase(dataset=self.dataset)
+
+    @cached_property
+    def get_territory_detail(self) -> GetTerritoryDetailUseCase:
+        """Ficha territorial con scores por perfil."""
+        return GetTerritoryDetailUseCase(
+            dataset=self.dataset,
+            scoring_service=self.scoring_service,
+        )
+
+    @cached_property
+    def compute_rankings(self) -> ComputeRankingsUseCase:
+        """Ranking parametrizado por perfil, ámbito y pesos."""
+        return ComputeRankingsUseCase(
+            dataset=self.dataset,
+            scoring_service=self.scoring_service,
+            settings=self._settings,
+            data_version=self.data_version,
+        )
+
+    @cached_property
+    def list_profiles(self) -> ListProfilesUseCase:
+        """Listado de perfiles de decisión."""
+        return ListProfilesUseCase(dataset=self.dataset)
+
+    @cached_property
+    def list_sources(self) -> ListSourcesUseCase:
+        """Listado de fuentes de datos."""
+        return ListSourcesUseCase(dataset=self.dataset)
+
+    @cached_property
+    def list_map_layers(self) -> ListMapLayersUseCase:
+        """Catálogo de capas cartográficas."""
+        return ListMapLayersUseCase(dataset=self.dataset)
+
+    @cached_property
+    def get_map_layer(self) -> GetMapLayerUseCase:
+        """Generación de GeoJSON para una capa concreta."""
+        return GetMapLayerUseCase(
+            dataset=self.dataset,
+            scoring_service=self.scoring_service,
+        )
+
+    @cached_property
+    def get_quality_report(self) -> GetQualityReportUseCase:
+        """Informe de calidad resumido del dataset."""
+        return GetQualityReportUseCase(
+            dataset=self.dataset,
+            data_version=self.data_version,
+        )

--- a/apps/api/src/atlashabita/application/scoring.py
+++ b/apps/api/src/atlashabita/application/scoring.py
@@ -1,0 +1,242 @@
+"""Servicio de scoring explicable por perfil de decisión.
+
+El cálculo se apoya en la normalización min-max de cada indicador a ``[0, 1]``
+con inversión si ``lower_is_better``. Los pesos se reescalan cuando un
+municipio carece de datos para algún indicador del perfil. Cada score se
+acompaña de contribuciones ordenadas por impacto, highlights y warnings
+para garantizar explicabilidad (RF-012).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import replace
+from typing import Final
+
+from atlashabita.config import Settings
+from atlashabita.domain.indicators import (
+    Indicator,
+    IndicatorDirection,
+    IndicatorObservation,
+)
+from atlashabita.domain.profiles import DecisionProfile
+from atlashabita.domain.scoring import ScoreContribution, TerritoryScore
+from atlashabita.domain.territories import Territory, TerritoryKind
+from atlashabita.infrastructure.ingestion import SeedDataset
+from atlashabita.observability.errors import InvalidProfileError
+
+_HIGHLIGHT_THRESHOLD: Final[float] = 0.7
+_WARNING_THRESHOLD: Final[float] = 0.3
+_HIGHLIGHT_TOP_K: Final[int] = 2
+
+
+class ScoringService:
+    """Calcula rankings explicables a partir del dataset y los perfiles."""
+
+    def __init__(self, dataset: SeedDataset, settings: Settings) -> None:
+        self._dataset = dataset
+        self._settings = settings
+        self._indicators_by_code: dict[str, Indicator] = {
+            indicator.code: indicator for indicator in dataset.indicators
+        }
+        self._profiles_by_id: dict[str, DecisionProfile] = {
+            profile.id: profile for profile in dataset.profiles
+        }
+        self._municipalities: tuple[Territory, ...] = tuple(
+            t for t in dataset.territories if t.kind is TerritoryKind.MUNICIPALITY
+        )
+        self._observations_index: dict[tuple[str, str], IndicatorObservation] = {
+            (obs.indicator_code, obs.territory_id): obs for obs in dataset.observations
+        }
+
+    @property
+    def dataset(self) -> SeedDataset:
+        """Acceso de lectura al dataset asociado."""
+        return self._dataset
+
+    def compute(
+        self,
+        profile_id: str,
+        scope: Sequence[Territory] | None = None,
+        weights: Mapping[str, float] | None = None,
+    ) -> list[TerritoryScore]:
+        """Calcula los scores de un conjunto de territorios para un perfil.
+
+        Args:
+            profile_id: identificador del perfil de decisión.
+            scope: lista opcional de territorios sobre los que calcular. Si es
+                ``None`` se usan todos los municipios del dataset.
+            weights: pesos personalizados que reemplazan a los del perfil.
+
+        Returns:
+            Lista de :class:`TerritoryScore` ordenada por score descendente.
+        """
+        profile = self._profiles_by_id.get(profile_id)
+        if profile is None:
+            raise InvalidProfileError(profile_id)
+
+        territories = tuple(scope) if scope is not None else self._municipalities
+        effective_weights = self._effective_weights(profile, weights)
+
+        ranges = {
+            code: self._resolve_range(code, territories)
+            for code in effective_weights
+            if code in self._indicators_by_code
+        }
+
+        scores: list[TerritoryScore] = []
+        for territory in territories:
+            score = self._score_territory(
+                territory=territory,
+                profile_id=profile.id,
+                weights=effective_weights,
+                ranges=ranges,
+            )
+            if score is not None:
+                scores.append(score)
+
+        scores.sort(key=lambda item: item.score, reverse=True)
+        return scores
+
+    def _effective_weights(
+        self,
+        profile: DecisionProfile,
+        override: Mapping[str, float] | None,
+    ) -> dict[str, float]:
+        base = override if override is not None else profile.weights
+        sanitized = {code: float(weight) for code, weight in base.items() if weight > 0}
+        if not sanitized:
+            raise InvalidProfileError(profile.id)
+        return sanitized
+
+    def _resolve_range(
+        self,
+        indicator_code: str,
+        territories: Sequence[Territory],
+    ) -> tuple[float, float]:
+        indicator = self._indicators_by_code[indicator_code]
+        if indicator.min_value is not None and indicator.max_value is not None:
+            return (indicator.min_value, indicator.max_value)
+        values = [
+            obs.value
+            for t in territories
+            if (obs := self._observations_index.get((indicator_code, t.identifier))) is not None
+        ]
+        if not values:
+            return (0.0, 1.0)
+        return (min(values), max(values))
+
+    def _score_territory(
+        self,
+        territory: Territory,
+        profile_id: str,
+        weights: Mapping[str, float],
+        ranges: Mapping[str, tuple[float, float]],
+    ) -> TerritoryScore | None:
+        available: dict[str, tuple[IndicatorObservation, Indicator]] = {}
+        for code in weights:
+            indicator = self._indicators_by_code.get(code)
+            if indicator is None:
+                continue
+            observation = self._observations_index.get((code, territory.identifier))
+            if observation is None:
+                continue
+            available[code] = (observation, indicator)
+
+        if not available:
+            return None
+
+        rescaled = _rescale_weights({code: weights[code] for code in available})
+
+        contributions: list[ScoreContribution] = []
+        weighted_sum = 0.0
+        for code, (observation, indicator) in available.items():
+            min_value, max_value = ranges[code]
+            normalized = _minmax_normalize(
+                observation.value, min_value, max_value, indicator.direction
+            )
+            weight = rescaled[code]
+            impact = weight * normalized * 100.0
+            contributions.append(
+                _build_contribution(
+                    indicator=indicator,
+                    weight=weight,
+                    normalized=normalized,
+                    raw_value=observation.value,
+                    impact=impact,
+                )
+            )
+            weighted_sum += weight * normalized
+
+        contributions.sort(key=lambda contribution: contribution.impact, reverse=True)
+        highlights = tuple(
+            contribution.label
+            for contribution in contributions
+            if contribution.normalized_value >= _HIGHLIGHT_THRESHOLD
+        )[:_HIGHLIGHT_TOP_K]
+        warnings = tuple(
+            contribution.label
+            for contribution in contributions
+            if contribution.normalized_value <= _WARNING_THRESHOLD
+        )
+
+        confidence = round(len(available) / len(weights), 4)
+        score_value = round(weighted_sum * 100.0, 1)
+
+        return TerritoryScore(
+            territory_id=territory.identifier,
+            territory_name=territory.name,
+            profile_id=profile_id,
+            score=score_value,
+            confidence=confidence,
+            contributions=tuple(contributions),
+            highlights=highlights,
+            warnings=warnings,
+            version=self._settings.scoring_version,
+        )
+
+
+def _minmax_normalize(
+    value: float,
+    min_value: float,
+    max_value: float,
+    direction: IndicatorDirection,
+) -> float:
+    """Normaliza un valor al rango ``[0, 1]`` aplicando inversión si procede."""
+    if max_value <= min_value:
+        return 0.5
+    clipped = max(min(value, max_value), min_value)
+    normalized = (clipped - min_value) / (max_value - min_value)
+    if direction is IndicatorDirection.LOWER_IS_BETTER:
+        normalized = 1.0 - normalized
+    return round(normalized, 6)
+
+
+def _rescale_weights(weights: Mapping[str, float]) -> dict[str, float]:
+    """Reescala un conjunto de pesos para que sumen ``1.0`` exactamente."""
+    total = sum(weights.values())
+    if total <= 0:
+        raise ValueError("La suma de pesos debe ser positiva para reescalar.")
+    return {code: weight / total for code, weight in weights.items()}
+
+
+def _build_contribution(
+    indicator: Indicator,
+    weight: float,
+    normalized: float,
+    raw_value: float,
+    impact: float,
+) -> ScoreContribution:
+    """Construye una :class:`ScoreContribution` con la metadata del indicador."""
+    return replace(
+        ScoreContribution(
+            indicator_code=indicator.code,
+            label=indicator.label,
+            weight=round(weight, 6),
+            normalized_value=normalized,
+            raw_value=raw_value,
+            unit=indicator.unit,
+            impact=round(impact, 4),
+            direction=indicator.direction.value,
+        )
+    )

--- a/apps/api/src/atlashabita/application/use_cases/__init__.py
+++ b/apps/api/src/atlashabita/application/use_cases/__init__.py
@@ -1,0 +1,27 @@
+"""Casos de uso de la capa de aplicación.
+
+Cada caso de uso encapsula una intención del usuario y orquesta el dominio,
+el lector de seed y el servicio de scoring. Son deliberadamente finos:
+validación de parámetros, traducción a objetos de dominio y formateo
+JSON-serializable. No conocen FastAPI ni rdflib.
+"""
+
+from atlashabita.application.use_cases.compute_rankings import ComputeRankingsUseCase
+from atlashabita.application.use_cases.get_map_layer import GetMapLayerUseCase
+from atlashabita.application.use_cases.get_quality_report import GetQualityReportUseCase
+from atlashabita.application.use_cases.get_territory_detail import GetTerritoryDetailUseCase
+from atlashabita.application.use_cases.list_map_layers import ListMapLayersUseCase
+from atlashabita.application.use_cases.list_profiles import ListProfilesUseCase
+from atlashabita.application.use_cases.list_sources import ListSourcesUseCase
+from atlashabita.application.use_cases.search_territories import SearchTerritoriesUseCase
+
+__all__ = [
+    "ComputeRankingsUseCase",
+    "GetMapLayerUseCase",
+    "GetQualityReportUseCase",
+    "GetTerritoryDetailUseCase",
+    "ListMapLayersUseCase",
+    "ListProfilesUseCase",
+    "ListSourcesUseCase",
+    "SearchTerritoriesUseCase",
+]

--- a/apps/api/src/atlashabita/application/use_cases/compute_rankings.py
+++ b/apps/api/src/atlashabita/application/use_cases/compute_rankings.py
@@ -1,0 +1,159 @@
+"""Rankings parametrizados por perfil, ámbito y pesos (RF-003, RF-005, RF-030)."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from atlashabita.application.scoring import ScoringService
+from atlashabita.config import Settings
+from atlashabita.domain.scoring import TerritoryScore
+from atlashabita.domain.territories import Territory, TerritoryKind
+from atlashabita.infrastructure.ingestion import SeedDataset
+from atlashabita.observability.errors import InvalidProfileError, InvalidScopeError
+
+_DEFAULT_LIMIT = 20
+_SCOPE_SEPARATOR = ":"
+_SCOPE_ALL = "es"
+_ALLOWED_SCOPE_PREFIXES = {"autonomous_community", "province"}
+
+
+class ComputeRankingsUseCase:
+    """Calcula y cachea rankings para un perfil dado."""
+
+    def __init__(
+        self,
+        dataset: SeedDataset,
+        scoring_service: ScoringService,
+        settings: Settings,
+        data_version: str,
+    ) -> None:
+        self._dataset = dataset
+        self._scoring_service = scoring_service
+        self._settings = settings
+        self._data_version = data_version
+        self._cache: dict[
+            tuple[str, str, tuple[tuple[str, float], ...], str], tuple[TerritoryScore, ...]
+        ] = {}
+
+    def execute(
+        self,
+        profile_id: str,
+        scope: str | None = None,
+        weights: Mapping[str, float] | None = None,
+        limit: int = _DEFAULT_LIMIT,
+    ) -> dict[str, Any]:
+        """Produce un ranking ordenado con metadatos reproducibles.
+
+        Args:
+            profile_id: identificador del perfil.
+            scope: ``"es"``, ``"autonomous_community:XX"``, ``"province:YY"``
+                o ``None`` (equivalente a ``"es"``).
+            weights: pesos opcionales que sustituyen a los del perfil.
+            limit: número máximo de resultados a devolver.
+
+        Returns:
+            Diccionario JSON-serializable con resultados y metadatos.
+        """
+        if profile_id not in {profile.id for profile in self._dataset.profiles}:
+            raise InvalidProfileError(profile_id)
+
+        resolved_scope = (scope or _SCOPE_ALL).strip().lower() or _SCOPE_ALL
+        territories = self._resolve_scope(resolved_scope)
+        bounded_limit = max(1, int(limit))
+        cache_key = self._build_cache_key(profile_id, resolved_scope, weights)
+        if cache_key not in self._cache:
+            scores = self._scoring_service.compute(profile_id, scope=territories, weights=weights)
+            self._cache[cache_key] = tuple(scores)
+        scores = list(self._cache[cache_key])
+        limited = scores[:bounded_limit]
+
+        return {
+            "profile": profile_id,
+            "scope": resolved_scope,
+            "scoring_version": self._settings.scoring_version,
+            "data_version": self._data_version,
+            "results": [
+                self._serialize_result(rank=index + 1, score=score)
+                for index, score in enumerate(limited)
+            ],
+        }
+
+    def _resolve_scope(self, scope: str) -> tuple[Territory, ...]:
+        if scope == _SCOPE_ALL:
+            return tuple(
+                t for t in self._dataset.territories if t.kind is TerritoryKind.MUNICIPALITY
+            )
+        if _SCOPE_SEPARATOR not in scope:
+            raise InvalidScopeError(scope)
+        prefix, _, code = scope.partition(_SCOPE_SEPARATOR)
+        if prefix not in _ALLOWED_SCOPE_PREFIXES or not code:
+            raise InvalidScopeError(scope)
+        if prefix == "autonomous_community":
+            municipalities = tuple(
+                t
+                for t in self._dataset.territories
+                if t.kind is TerritoryKind.MUNICIPALITY and t.autonomous_community_code == code
+            )
+        else:
+            municipalities = tuple(
+                t
+                for t in self._dataset.territories
+                if t.kind is TerritoryKind.MUNICIPALITY and t.province_code == code
+            )
+        if not municipalities:
+            raise InvalidScopeError(scope)
+        return municipalities
+
+    def _build_cache_key(
+        self,
+        profile_id: str,
+        scope: str,
+        weights: Mapping[str, float] | None,
+    ) -> tuple[str, str, tuple[tuple[str, float], ...], str]:
+        frozen_weights = (
+            tuple(sorted((str(k), float(v)) for k, v in weights.items()))
+            if weights is not None
+            else ()
+        )
+        return (profile_id, scope, frozen_weights, self._data_version)
+
+    def _serialize_result(self, rank: int, score: TerritoryScore) -> dict[str, Any]:
+        territory = self._dataset.get_territory(score.territory_id)
+        province = None
+        community = None
+        if territory is not None:
+            province = self._lookup_name(territory.province_code, TerritoryKind.PROVINCE)
+            community = self._lookup_name(
+                territory.autonomous_community_code, TerritoryKind.AUTONOMOUS_COMMUNITY
+            )
+        top_contributions = [
+            {
+                "factor": contribution.indicator_code,
+                "label": contribution.label,
+                "weight": contribution.weight,
+                "normalized": contribution.normalized_value,
+                "impact": contribution.impact,
+            }
+            for contribution in score.contributions[:3]
+        ]
+        return {
+            "rank": rank,
+            "territory_id": score.territory_id,
+            "name": score.territory_name,
+            "province": province,
+            "autonomous_community": community,
+            "score": score.score,
+            "confidence": score.confidence,
+            "highlights": list(score.highlights),
+            "warnings": list(score.warnings),
+            "top_contributions": top_contributions,
+        }
+
+    def _lookup_name(self, code: str | None, kind: TerritoryKind) -> str | None:
+        if code is None:
+            return None
+        for candidate in self._dataset.territories:
+            if candidate.kind is kind and candidate.code == code:
+                return candidate.name
+        return None

--- a/apps/api/src/atlashabita/application/use_cases/get_map_layer.py
+++ b/apps/api/src/atlashabita/application/use_cases/get_map_layer.py
@@ -1,0 +1,145 @@
+"""Generación de GeoJSON FeatureCollection para una capa de mapa (RF-004, RF-026)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from atlashabita.application.scoring import ScoringService
+from atlashabita.domain.territories import Territory, TerritoryKind
+from atlashabita.infrastructure.ingestion import SeedDataset
+from atlashabita.observability.errors import InvalidProfileError, InvalidScopeError
+
+_SCORE_PREFIX = "score_"
+
+
+@dataclass(frozen=True, slots=True)
+class GetMapLayerUseCase:
+    """Construye una colección GeoJSON de puntos para una capa concreta."""
+
+    dataset: SeedDataset
+    scoring_service: ScoringService
+
+    def execute(self, layer_id: str, profile_id: str | None = None) -> dict[str, Any]:
+        """Devuelve un FeatureCollection con un punto por municipio.
+
+        Args:
+            layer_id: identificador de capa devuelto por ``ListMapLayersUseCase``.
+            profile_id: perfil explícito si la capa pertenece a un score y no
+                está embebido en ``layer_id``.
+
+        Returns:
+            Objeto GeoJSON con ``type = FeatureCollection`` y ``features`` con
+            propiedad ``value``, ``label`` y ``territory_id``.
+        """
+        if not layer_id:
+            raise InvalidScopeError(layer_id)
+
+        municipalities = tuple(
+            t for t in self.dataset.territories if t.kind is TerritoryKind.MUNICIPALITY
+        )
+        if layer_id.startswith(_SCORE_PREFIX):
+            resolved_profile = layer_id[len(_SCORE_PREFIX) :]
+            if not resolved_profile:
+                raise InvalidProfileError(layer_id)
+            return self._score_layer(
+                layer_id=layer_id,
+                profile_id=resolved_profile,
+                municipalities=municipalities,
+            )
+
+        if self._is_indicator(layer_id):
+            return self._indicator_layer(layer_id=layer_id, municipalities=municipalities)
+
+        if profile_id is not None:
+            return self._score_layer(
+                layer_id=layer_id,
+                profile_id=profile_id,
+                municipalities=municipalities,
+            )
+        raise InvalidScopeError(layer_id)
+
+    def _is_indicator(self, layer_id: str) -> bool:
+        return any(indicator.code == layer_id for indicator in self.dataset.indicators)
+
+    def _score_layer(
+        self,
+        layer_id: str,
+        profile_id: str,
+        municipalities: tuple[Territory, ...],
+    ) -> dict[str, Any]:
+        scores = self.scoring_service.compute(profile_id, scope=municipalities)
+        score_by_territory = {score.territory_id: score for score in scores}
+        features: list[dict[str, Any]] = []
+        for territory in municipalities:
+            score = score_by_territory.get(territory.identifier)
+            if score is None or territory.centroid is None:
+                continue
+            features.append(
+                _build_feature(
+                    territory=territory,
+                    value=score.score,
+                    label=f"{territory.name}: {score.score}",
+                )
+            )
+        return _feature_collection(layer_id=layer_id, features=features, kind="score")
+
+    def _indicator_layer(
+        self,
+        layer_id: str,
+        municipalities: tuple[Territory, ...],
+    ) -> dict[str, Any]:
+        values = {
+            obs.territory_id: obs
+            for obs in self.dataset.observations
+            if obs.indicator_code == layer_id
+        }
+        features: list[dict[str, Any]] = []
+        for territory in municipalities:
+            if territory.centroid is None:
+                continue
+            observation = values.get(territory.identifier)
+            if observation is None:
+                continue
+            features.append(
+                _build_feature(
+                    territory=territory,
+                    value=observation.value,
+                    label=f"{territory.name}: {observation.value}",
+                )
+            )
+        return _feature_collection(layer_id=layer_id, features=features, kind="indicator")
+
+
+def _feature_collection(
+    layer_id: str,
+    features: list[dict[str, Any]],
+    kind: str,
+) -> dict[str, Any]:
+    return {
+        "type": "FeatureCollection",
+        "layer_id": layer_id,
+        "kind": kind,
+        "features": features,
+    }
+
+
+def _build_feature(
+    territory: Territory,
+    value: float,
+    label: str,
+) -> dict[str, Any]:
+    assert territory.centroid is not None  # invariante: filtrado previo
+    return {
+        "type": "Feature",
+        "geometry": {
+            "type": "Point",
+            "coordinates": [territory.centroid.lon, territory.centroid.lat],
+        },
+        "properties": {
+            "territory_id": territory.identifier,
+            "name": territory.name,
+            "value": value,
+            "label": label,
+        },
+    }

--- a/apps/api/src/atlashabita/application/use_cases/get_quality_report.py
+++ b/apps/api/src/atlashabita/application/use_cases/get_quality_report.py
@@ -1,0 +1,81 @@
+"""Resumen simple de calidad del dataset (RF-022, RF-029).
+
+Este caso de uso sintetiza métricas volumétricas y de cobertura sin depender
+de otros gates específicos. Está pensado como placeholder observable que
+puede ser extendido una vez los quality gates tabulares estén disponibles.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass
+from typing import Any
+
+from atlashabita.domain.territories import TerritoryKind
+from atlashabita.infrastructure.ingestion import SeedDataset
+
+
+@dataclass(frozen=True, slots=True)
+class GetQualityReportUseCase:
+    """Genera un informe de calidad con métricas básicas de cobertura."""
+
+    dataset: SeedDataset
+    data_version: str
+
+    def execute(self) -> dict[str, Any]:
+        """Construye un informe JSON-serializable con conteos por tabla."""
+        observations_by_quality: Counter[str] = Counter(
+            obs.quality for obs in self.dataset.observations
+        )
+        observations_by_indicator: Counter[str] = Counter(
+            obs.indicator_code for obs in self.dataset.observations
+        )
+        municipalities = [
+            t for t in self.dataset.territories if t.kind is TerritoryKind.MUNICIPALITY
+        ]
+        indicators_count = len(self.dataset.indicators)
+        expected = indicators_count * len(municipalities)
+        actual = len(self.dataset.observations)
+        coverage_ratio = round(actual / expected, 4) if expected else 0.0
+
+        return {
+            "data_version": self.data_version,
+            "tables": {
+                "territories": len(self.dataset.territories),
+                "autonomous_communities": self._count(TerritoryKind.AUTONOMOUS_COMMUNITY),
+                "provinces": self._count(TerritoryKind.PROVINCE),
+                "municipalities": len(municipalities),
+                "sources": len(self.dataset.sources),
+                "indicators": indicators_count,
+                "observations": actual,
+                "profiles": len(self.dataset.profiles),
+            },
+            "observations_by_quality": dict(observations_by_quality),
+            "observations_by_indicator": dict(observations_by_indicator),
+            "coverage": {
+                "expected_observations": expected,
+                "actual_observations": actual,
+                "ratio": coverage_ratio,
+            },
+            "warnings": self._build_warnings(
+                observations_by_indicator,
+                municipalities_count=len(municipalities),
+            ),
+        }
+
+    def _count(self, kind: TerritoryKind) -> int:
+        return sum(1 for t in self.dataset.territories if t.kind is kind)
+
+    def _build_warnings(
+        self,
+        observations_by_indicator: Counter[str],
+        municipalities_count: int,
+    ) -> list[str]:
+        warnings: list[str] = []
+        for indicator in self.dataset.indicators:
+            count = observations_by_indicator.get(indicator.code, 0)
+            if municipalities_count and count < municipalities_count:
+                warnings.append(
+                    f"Indicador {indicator.code} cubre {count}/{municipalities_count} municipios."
+                )
+        return warnings

--- a/apps/api/src/atlashabita/application/use_cases/get_territory_detail.py
+++ b/apps/api/src/atlashabita/application/use_cases/get_territory_detail.py
@@ -1,0 +1,119 @@
+"""Ficha territorial con indicadores, jerarquía y scores por perfil (RF-006, RF-031)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from atlashabita.application.scoring import ScoringService
+from atlashabita.domain.territories import Territory
+from atlashabita.infrastructure.ingestion import SeedDataset
+from atlashabita.observability.errors import TerritoryNotFoundError
+
+
+@dataclass(frozen=True, slots=True)
+class GetTerritoryDetailUseCase:
+    """Construye la vista detallada de un territorio."""
+
+    dataset: SeedDataset
+    scoring_service: ScoringService
+
+    def execute(self, territory_id: str) -> dict[str, Any]:
+        """Devuelve la ficha territorial serializable.
+
+        Args:
+            territory_id: identificador público (``kind:code``).
+
+        Returns:
+            Diccionario con datos territoriales, jerarquía, indicadores y
+            scores por perfil.
+
+        Raises:
+            TerritoryNotFoundError: si el territorio no existe.
+        """
+        territory = self.dataset.get_territory(territory_id)
+        if territory is None:
+            raise TerritoryNotFoundError(territory_id)
+
+        indicators = self._collect_indicators(territory_id)
+        scores = self._collect_scores(territory)
+        return {
+            "id": territory.identifier,
+            "code": territory.code,
+            "name": territory.name,
+            "type": territory.kind.value,
+            "hierarchy": self._hierarchy(territory),
+            "centroid": self._centroid(territory),
+            "population": territory.population,
+            "area_km2": territory.area_km2,
+            "indicators": indicators,
+            "scores": scores,
+        }
+
+    def _hierarchy(self, territory: Territory) -> dict[str, str | None]:
+        province = self._find_by_code(territory.province_code, "province")
+        community = self._find_by_code(territory.autonomous_community_code, "autonomous_community")
+        return {
+            "province": province.name if province else None,
+            "province_code": territory.province_code,
+            "autonomous_community": community.name if community else None,
+            "autonomous_community_code": territory.autonomous_community_code,
+        }
+
+    def _centroid(self, territory: Territory) -> dict[str, float] | None:
+        if territory.centroid is None:
+            return None
+        return {"lat": territory.centroid.lat, "lon": territory.centroid.lon}
+
+    def _find_by_code(self, code: str | None, kind: str) -> Territory | None:
+        if code is None:
+            return None
+        for candidate in self.dataset.territories:
+            if candidate.code == code and candidate.kind.value == kind:
+                return candidate
+        return None
+
+    def _collect_indicators(self, territory_id: str) -> list[dict[str, Any]]:
+        indicators_by_code = {indicator.code: indicator for indicator in self.dataset.indicators}
+        observations = [
+            obs for obs in self.dataset.observations if obs.territory_id == territory_id
+        ]
+        observations.sort(key=lambda obs: obs.indicator_code)
+        rows: list[dict[str, Any]] = []
+        for obs in observations:
+            indicator = indicators_by_code.get(obs.indicator_code)
+            if indicator is None:
+                continue
+            rows.append(
+                {
+                    "id": indicator.code,
+                    "label": indicator.label,
+                    "unit": indicator.unit,
+                    "direction": indicator.direction.value,
+                    "value": obs.value,
+                    "period": obs.period,
+                    "source_id": obs.source_id,
+                    "quality": obs.quality,
+                }
+            )
+        return rows
+
+    def _collect_scores(self, territory: Territory) -> list[dict[str, Any]]:
+        rows: list[dict[str, Any]] = []
+        for profile in self.dataset.profiles:
+            results = self.scoring_service.compute(profile.id, scope=(territory,))
+            if not results:
+                continue
+            result = results[0]
+            rows.append(
+                {
+                    "profile": profile.id,
+                    "profile_label": profile.label,
+                    "score": result.score,
+                    "confidence": result.confidence,
+                    "highlights": list(result.highlights),
+                    "warnings": list(result.warnings),
+                    "version": result.version,
+                }
+            )
+        return rows

--- a/apps/api/src/atlashabita/application/use_cases/list_map_layers.py
+++ b/apps/api/src/atlashabita/application/use_cases/list_map_layers.py
@@ -1,0 +1,71 @@
+"""Catálogo de capas cartográficas disponibles (RF-026, RF-027)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from atlashabita.domain.indicators import IndicatorDirection
+from atlashabita.infrastructure.ingestion import SeedDataset
+
+_SCORE_DOMAIN: tuple[float, float] = (0.0, 100.0)
+_SCORE_RANGE: tuple[str, str, str] = ("#f7fbff", "#6baed6", "#08306b")
+_INDICATOR_RANGE_HIGHER: tuple[str, str, str] = ("#fee5d9", "#fcae91", "#de2d26")
+_INDICATOR_RANGE_LOWER: tuple[str, str, str] = ("#edf8e9", "#74c476", "#006d2c")
+
+
+@dataclass(frozen=True, slots=True)
+class ListMapLayersUseCase:
+    """Enumera capas disponibles: un score por perfil y un indicador por capa."""
+
+    dataset: SeedDataset
+
+    def execute(self) -> list[dict[str, Any]]:
+        """Capas de mapa JSON-serializables con leyenda y dominio."""
+        layers: list[dict[str, Any]] = []
+        for profile in sorted(self.dataset.profiles, key=lambda item: item.id):
+            layers.append(
+                {
+                    "id": f"score_{profile.id}",
+                    "label": f"Score {profile.label}",
+                    "type": "choropleth",
+                    "legend": f"Score explicable del perfil {profile.label}",
+                    "domain": list(_SCORE_DOMAIN),
+                    "range": list(_SCORE_RANGE),
+                    "kind": "score",
+                    "profile": profile.id,
+                }
+            )
+        for indicator in sorted(self.dataset.indicators, key=lambda item: item.code):
+            domain = self._indicator_domain(indicator.code)
+            palette = (
+                _INDICATOR_RANGE_HIGHER
+                if indicator.direction is IndicatorDirection.HIGHER_IS_BETTER
+                else _INDICATOR_RANGE_LOWER
+            )
+            layers.append(
+                {
+                    "id": indicator.code,
+                    "label": indicator.label,
+                    "type": "choropleth",
+                    "legend": f"{indicator.label} ({indicator.unit})",
+                    "domain": list(domain),
+                    "range": list(palette),
+                    "kind": "indicator",
+                    "unit": indicator.unit,
+                    "direction": indicator.direction.value,
+                }
+            )
+        return layers
+
+    def _indicator_domain(self, indicator_code: str) -> tuple[float, float]:
+        indicators = {indicator.code: indicator for indicator in self.dataset.indicators}
+        indicator = indicators[indicator_code]
+        if indicator.min_value is not None and indicator.max_value is not None:
+            return (indicator.min_value, indicator.max_value)
+        values = [
+            obs.value for obs in self.dataset.observations if obs.indicator_code == indicator_code
+        ]
+        if not values:
+            return (0.0, 1.0)
+        return (min(values), max(values))

--- a/apps/api/src/atlashabita/application/use_cases/list_profiles.py
+++ b/apps/api/src/atlashabita/application/use_cases/list_profiles.py
@@ -1,0 +1,19 @@
+"""Exposición de los perfiles de decisión disponibles (RF-001)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from atlashabita.domain.profiles import DecisionProfile
+from atlashabita.infrastructure.ingestion import SeedDataset
+
+
+@dataclass(frozen=True, slots=True)
+class ListProfilesUseCase:
+    """Devuelve los perfiles conocidos por el sistema."""
+
+    dataset: SeedDataset
+
+    def execute(self) -> list[DecisionProfile]:
+        """Lista ordenada por identificador para respuestas estables."""
+        return sorted(self.dataset.profiles, key=lambda profile: profile.id)

--- a/apps/api/src/atlashabita/application/use_cases/list_sources.py
+++ b/apps/api/src/atlashabita/application/use_cases/list_sources.py
@@ -1,0 +1,19 @@
+"""Exposición de las fuentes de datos oficiales (RF-013, RF-032)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from atlashabita.domain.sources import DataSource
+from atlashabita.infrastructure.ingestion import SeedDataset
+
+
+@dataclass(frozen=True, slots=True)
+class ListSourcesUseCase:
+    """Devuelve las fuentes registradas."""
+
+    dataset: SeedDataset
+
+    def execute(self) -> list[DataSource]:
+        """Lista ordenada alfabéticamente por título para respuestas estables."""
+        return sorted(self.dataset.sources, key=lambda source: source.title.lower())

--- a/apps/api/src/atlashabita/application/use_cases/search_territories.py
+++ b/apps/api/src/atlashabita/application/use_cases/search_territories.py
@@ -1,0 +1,60 @@
+"""Búsqueda de territorios por nombre tolerante a tildes y mayúsculas (RF-024)."""
+
+from __future__ import annotations
+
+import unicodedata
+from dataclasses import dataclass
+
+from atlashabita.domain.territories import Territory
+from atlashabita.infrastructure.ingestion import SeedDataset
+
+
+@dataclass(frozen=True, slots=True)
+class SearchTerritoriesUseCase:
+    """Caso de uso de búsqueda textual de territorios."""
+
+    dataset: SeedDataset
+
+    def execute(self, query: str, limit: int = 20) -> list[Territory]:
+        """Busca territorios cuyo nombre o alias coincida con la consulta.
+
+        Args:
+            query: texto introducido por el usuario.
+            limit: número máximo de resultados a devolver.
+
+        Returns:
+            Lista de territorios ordenada por prioridad: coincidencia exacta,
+            prefijo y luego subcadena. Si ``query`` está vacía devuelve ``[]``.
+        """
+        normalized_query = _normalize(query)
+        if not normalized_query:
+            return []
+        bounded_limit = max(1, min(int(limit), len(self.dataset.territories)))
+
+        exact: list[Territory] = []
+        prefix: list[Territory] = []
+        contains: list[Territory] = []
+
+        for territory in self.dataset.territories:
+            name_normalized = _normalize(territory.name)
+            aliases_normalized = tuple(_normalize(alias) for alias in territory.aliases)
+            if name_normalized == normalized_query or normalized_query in aliases_normalized:
+                exact.append(territory)
+            elif name_normalized.startswith(normalized_query) or any(
+                alias.startswith(normalized_query) for alias in aliases_normalized
+            ):
+                prefix.append(territory)
+            elif normalized_query in name_normalized or any(
+                normalized_query in alias for alias in aliases_normalized
+            ):
+                contains.append(territory)
+
+        ordered: list[Territory] = [*exact, *prefix, *contains]
+        return ordered[:bounded_limit]
+
+
+def _normalize(text: str) -> str:
+    """Normaliza texto eliminando tildes y uniformando a minúsculas."""
+    decomposed = unicodedata.normalize("NFKD", text)
+    without_marks = "".join(char for char in decomposed if not unicodedata.combining(char))
+    return without_marks.strip().lower()

--- a/apps/api/src/atlashabita/observability/middleware.py
+++ b/apps/api/src/atlashabita/observability/middleware.py
@@ -1,0 +1,71 @@
+"""Middleware ASGI para trazabilidad de peticiones.
+
+Cada petición HTTP recibe un ``request_id`` propio que se inyecta en el
+contexto de ``structlog`` y se devuelve al cliente mediante el header
+``X-Request-ID``. Esto habilita observabilidad end-to-end sin acoplar la
+capa de dominio al framework.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, MutableMapping
+from typing import Any
+from uuid import uuid4
+
+import structlog
+
+_REQUEST_ID_HEADER = b"x-request-id"
+_REQUEST_ID_HEADER_STR = "X-Request-ID"
+
+_Scope = MutableMapping[str, Any]
+_Message = MutableMapping[str, Any]
+_Receive = Callable[[], Awaitable[_Message]]
+_Send = Callable[[_Message], Awaitable[None]]
+_ASGIApp = Callable[[_Scope, _Receive, _Send], Awaitable[None]]
+
+
+class RequestContextMiddleware:
+    """Middleware ASGI que asigna ``request_id`` a cada petición HTTP.
+
+    Si el cliente envía ``X-Request-ID`` se preserva; en caso contrario se
+    genera uno nuevo con ``uuid4().hex``. El identificador se expone en el
+    contexto de structlog y se devuelve al cliente como header.
+    """
+
+    def __init__(self, app: _ASGIApp) -> None:
+        self._app = app
+
+    async def __call__(self, scope: _Scope, receive: _Receive, send: _Send) -> None:
+        if scope.get("type") != "http":
+            await self._app(scope, receive, send)
+            return
+
+        request_id = _extract_or_create_request_id(scope)
+        structlog.contextvars.bind_contextvars(request_id=request_id)
+
+        async def send_with_request_id(message: _Message) -> None:
+            if message.get("type") == "http.response.start":
+                headers = list(message.get("headers", []))
+                headers = [
+                    (name, value) for (name, value) in headers if name.lower() != _REQUEST_ID_HEADER
+                ]
+                headers.append((_REQUEST_ID_HEADER, request_id.encode("latin-1")))
+                message["headers"] = headers
+            await send(message)
+
+        try:
+            await self._app(scope, receive, send_with_request_id)
+        finally:
+            structlog.contextvars.unbind_contextvars("request_id")
+
+
+def _extract_or_create_request_id(scope: _Scope) -> str:
+    for name, value in scope.get("headers", []):
+        if name.lower() == _REQUEST_ID_HEADER:
+            decoded = value.decode("latin-1").strip()
+            if decoded:
+                return decoded
+    return uuid4().hex
+
+
+__all__ = ["_REQUEST_ID_HEADER_STR", "RequestContextMiddleware"]

--- a/apps/api/tests/test_scoring.py
+++ b/apps/api/tests/test_scoring.py
@@ -1,0 +1,141 @@
+"""Pruebas del servicio de scoring explicable."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from atlashabita.application.scoring import (
+    ScoringService,
+    _minmax_normalize,
+    _rescale_weights,
+)
+from atlashabita.config import Settings
+from atlashabita.domain.indicators import IndicatorDirection
+from atlashabita.infrastructure.ingestion import SeedDataset, SeedLoader
+from atlashabita.observability.errors import InvalidProfileError
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SEED_DIR = REPO_ROOT / "data" / "seed"
+
+
+@pytest.fixture(scope="module")
+def dataset() -> SeedDataset:
+    return SeedLoader(SEED_DIR).load()
+
+
+@pytest.fixture(scope="module")
+def settings() -> Settings:
+    return Settings(
+        env="test",
+        data_root=REPO_ROOT / "data",
+        ontology_root=REPO_ROOT / "ontology",
+        scoring_version="2026.04.1-test",
+    )
+
+
+@pytest.fixture(scope="module")
+def scoring(dataset: SeedDataset, settings: Settings) -> ScoringService:
+    return ScoringService(dataset, settings)
+
+
+def test_minmax_normalize_higher_is_better_monotono() -> None:
+    low = _minmax_normalize(10.0, 0.0, 100.0, IndicatorDirection.HIGHER_IS_BETTER)
+    high = _minmax_normalize(90.0, 0.0, 100.0, IndicatorDirection.HIGHER_IS_BETTER)
+    assert low < high
+    assert 0.0 <= low <= 1.0
+    assert 0.0 <= high <= 1.0
+
+
+def test_minmax_normalize_lower_is_better_invierte() -> None:
+    low = _minmax_normalize(5.0, 0.0, 20.0, IndicatorDirection.LOWER_IS_BETTER)
+    high = _minmax_normalize(18.0, 0.0, 20.0, IndicatorDirection.LOWER_IS_BETTER)
+    assert low > high
+    assert low == pytest.approx(0.75)
+    assert high == pytest.approx(0.1)
+
+
+def test_minmax_normalize_clipea_fuera_de_rango() -> None:
+    por_debajo = _minmax_normalize(-5.0, 0.0, 100.0, IndicatorDirection.HIGHER_IS_BETTER)
+    por_encima = _minmax_normalize(120.0, 0.0, 100.0, IndicatorDirection.HIGHER_IS_BETTER)
+    assert por_debajo == pytest.approx(0.0)
+    assert por_encima == pytest.approx(1.0)
+
+
+def test_rescale_weights_suman_uno() -> None:
+    result = _rescale_weights({"a": 0.2, "b": 0.3, "c": 0.5})
+    assert sum(result.values()) == pytest.approx(1.0)
+
+
+def test_rescale_weights_mantiene_proporciones() -> None:
+    result = _rescale_weights({"a": 1.0, "b": 3.0})
+    assert result["b"] == pytest.approx(0.75)
+    assert result["a"] == pytest.approx(0.25)
+
+
+def test_rescale_weights_rechaza_total_cero() -> None:
+    with pytest.raises(ValueError):
+        _rescale_weights({"a": 0.0, "b": 0.0})
+
+
+def test_compute_ordena_por_score_descendente(scoring: ScoringService) -> None:
+    results = scoring.compute("remote_work")
+    scores = [result.score for result in results]
+    assert scores == sorted(scores, reverse=True)
+    assert len(results) == 10
+
+
+def test_compute_highlights_y_warnings_coherentes(scoring: ScoringService) -> None:
+    results = scoring.compute("remote_work")
+    for result in results:
+        for contribution in result.contributions:
+            if contribution.label in result.highlights:
+                assert contribution.normalized_value >= 0.7
+            if contribution.label in result.warnings:
+                assert contribution.normalized_value <= 0.3
+        assert len(result.highlights) <= 2
+
+
+def test_compute_propaga_version_del_settings(scoring: ScoringService, settings: Settings) -> None:
+    results = scoring.compute("remote_work")
+    assert all(result.version == settings.scoring_version for result in results)
+
+
+def test_compute_rescala_pesos_si_faltan_datos(dataset: SeedDataset, settings: Settings) -> None:
+    observations = tuple(
+        obs
+        for obs in dataset.observations
+        if not (
+            obs.indicator_code == "broadband_coverage" and obs.territory_id == "municipality:41091"
+        )
+    )
+    mutated = replace(dataset, observations=observations)
+    scoring = ScoringService(mutated, settings)
+    results = scoring.compute("remote_work")
+    sevilla = next(r for r in results if r.territory_id == "municipality:41091")
+    assert sevilla.confidence == pytest.approx(0.8)
+    total_weights = sum(contribution.weight for contribution in sevilla.contributions)
+    assert total_weights == pytest.approx(1.0)
+
+
+def test_compute_lanza_error_si_perfil_no_existe(scoring: ScoringService) -> None:
+    with pytest.raises(InvalidProfileError):
+        scoring.compute("inexistente")
+
+
+def test_compute_respeta_weights_personalizados(scoring: ScoringService) -> None:
+    custom = {"broadband_coverage": 1.0}
+    results = scoring.compute("remote_work", weights=custom)
+    for result in results:
+        assert len(result.contributions) == 1
+        assert result.contributions[0].indicator_code == "broadband_coverage"
+        assert result.contributions[0].weight == pytest.approx(1.0)
+
+
+def test_contribuciones_ordenadas_por_impact(scoring: ScoringService) -> None:
+    results = scoring.compute("family")
+    for result in results:
+        impacts = [contribution.impact for contribution in result.contributions]
+        assert impacts == sorted(impacts, reverse=True)

--- a/apps/api/tests/test_use_case_compute_rankings.py
+++ b/apps/api/tests/test_use_case_compute_rankings.py
@@ -1,0 +1,106 @@
+"""Pruebas del caso de uso de cálculo de rankings."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from atlashabita.application import Container
+from atlashabita.config import Settings
+from atlashabita.observability.errors import InvalidProfileError, InvalidScopeError
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+@pytest.fixture(scope="module")
+def container() -> Container:
+    settings = Settings(
+        env="test",
+        data_root=REPO_ROOT / "data",
+        ontology_root=REPO_ROOT / "ontology",
+    )
+    return Container(settings)
+
+
+def test_scope_es_devuelve_10_municipios(container: Container) -> None:
+    payload = container.compute_rankings.execute("remote_work", scope="es", limit=50)
+    assert payload["profile"] == "remote_work"
+    assert payload["scope"] == "es"
+    assert len(payload["results"]) == 10
+    assert payload["scoring_version"]
+    assert payload["data_version"].startswith("seed:")
+
+
+def test_scope_por_defecto_es_equivalente_a_es(container: Container) -> None:
+    con_default = container.compute_rankings.execute("remote_work", scope=None, limit=50)
+    con_es = container.compute_rankings.execute("remote_work", scope="es", limit=50)
+    assert [r["territory_id"] for r in con_default["results"]] == [
+        r["territory_id"] for r in con_es["results"]
+    ]
+
+
+def test_scope_province_20_devuelve_4_municipios_guipuzcoanos(
+    container: Container,
+) -> None:
+    payload = container.compute_rankings.execute("remote_work", scope="province:20", limit=20)
+    ids = {result["territory_id"] for result in payload["results"]}
+    assert ids == {
+        "municipality:20069",
+        "municipality:20036",
+        "municipality:20038",
+        "municipality:20071",
+    }
+
+
+def test_scope_autonomous_community_01_solo_andalucia(container: Container) -> None:
+    payload = container.compute_rankings.execute(
+        "remote_work", scope="autonomous_community:01", limit=50
+    )
+    for result in payload["results"]:
+        territory_id = result["territory_id"]
+        # Andalucía agrupa provincias 41 y 29
+        assert territory_id.startswith("municipality:41") or territory_id.startswith(
+            "municipality:29"
+        )
+
+
+def test_perfil_inexistente_lanza_invalid_profile_error(container: Container) -> None:
+    with pytest.raises(InvalidProfileError):
+        container.compute_rankings.execute("inexistente", scope="es")
+
+
+def test_scope_invalido_lanza_invalid_scope_error(container: Container) -> None:
+    with pytest.raises(InvalidScopeError):
+        container.compute_rankings.execute("remote_work", scope="region:001")
+
+
+def test_scope_con_codigo_inexistente_lanza_invalid_scope_error(
+    container: Container,
+) -> None:
+    with pytest.raises(InvalidScopeError):
+        container.compute_rankings.execute("remote_work", scope="province:99")
+
+
+def test_ranking_cachea_resultados(container: Container) -> None:
+    primero = container.compute_rankings.execute("remote_work", scope="es", limit=3)
+    segundo = container.compute_rankings.execute("remote_work", scope="es", limit=3)
+    assert [r["score"] for r in primero["results"]] == [r["score"] for r in segundo["results"]]
+
+
+def test_ranking_incluye_rank_ascendente(container: Container) -> None:
+    payload = container.compute_rankings.execute("student", scope="es", limit=5)
+    ranks = [result["rank"] for result in payload["results"]]
+    assert ranks == [1, 2, 3, 4, 5]
+
+
+def test_ranking_con_pesos_personalizados(container: Container) -> None:
+    payload = container.compute_rankings.execute(
+        "remote_work",
+        scope="es",
+        weights={"broadband_coverage": 1.0},
+        limit=3,
+    )
+    for result in payload["results"]:
+        assert len(result["top_contributions"]) == 1
+        assert result["top_contributions"][0]["factor"] == "broadband_coverage"

--- a/apps/api/tests/test_use_case_get_territory_detail.py
+++ b/apps/api/tests/test_use_case_get_territory_detail.py
@@ -1,0 +1,66 @@
+"""Pruebas del caso de uso de ficha territorial."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from atlashabita.application import Container
+from atlashabita.config import Settings
+from atlashabita.observability.errors import TerritoryNotFoundError
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+@pytest.fixture(scope="module")
+def container() -> Container:
+    settings = Settings(
+        env="test",
+        data_root=REPO_ROOT / "data",
+        ontology_root=REPO_ROOT / "ontology",
+    )
+    return Container(settings)
+
+
+def test_ficha_sevilla_contiene_los_cinco_indicadores(container: Container) -> None:
+    detail = container.get_territory_detail.execute("municipality:41091")
+    assert detail["name"] == "Sevilla"
+    assert detail["type"] == "municipality"
+    assert detail["hierarchy"]["province"] == "Sevilla"
+    assert detail["hierarchy"]["autonomous_community"] == "Andalucía"
+    indicators = {row["id"] for row in detail["indicators"]}
+    assert indicators == {
+        "rent_median",
+        "broadband_coverage",
+        "income_per_capita",
+        "services_score",
+        "climate_comfort",
+    }
+
+
+def test_ficha_sevilla_incluye_scores_por_perfil(container: Container) -> None:
+    detail = container.get_territory_detail.execute("municipality:41091")
+    perfiles = {row["profile"] for row in detail["scores"]}
+    assert perfiles == {"remote_work", "family", "student"}
+    for row in detail["scores"]:
+        assert 0.0 <= row["score"] <= 100.0
+        assert row["version"] == container.settings.scoring_version
+
+
+def test_ficha_incluye_centroide_para_municipios(container: Container) -> None:
+    detail = container.get_territory_detail.execute("municipality:41091")
+    assert detail["centroid"] is not None
+    assert "lat" in detail["centroid"]
+    assert "lon" in detail["centroid"]
+
+
+def test_ficha_id_inexistente_lanza_territory_not_found(container: Container) -> None:
+    with pytest.raises(TerritoryNotFoundError):
+        container.get_territory_detail.execute("municipality:99999")
+
+
+def test_ficha_indicadores_ordenados_alfabeticamente(container: Container) -> None:
+    detail = container.get_territory_detail.execute("municipality:41091")
+    ids = [row["id"] for row in detail["indicators"]]
+    assert ids == sorted(ids)

--- a/apps/api/tests/test_use_case_list_profiles.py
+++ b/apps/api/tests/test_use_case_list_profiles.py
@@ -1,0 +1,38 @@
+"""Pruebas del caso de uso de listado de perfiles."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from atlashabita.application import Container
+from atlashabita.config import Settings
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+@pytest.fixture(scope="module")
+def container() -> Container:
+    settings = Settings(
+        env="test",
+        data_root=REPO_ROOT / "data",
+        ontology_root=REPO_ROOT / "ontology",
+    )
+    return Container(settings)
+
+
+def test_lista_contiene_los_tres_perfiles_seed(container: Container) -> None:
+    profiles = container.list_profiles.execute()
+    assert {profile.id for profile in profiles} == {"remote_work", "family", "student"}
+
+
+def test_lista_devuelve_perfiles_ordenados_por_id(container: Container) -> None:
+    profiles = container.list_profiles.execute()
+    ids = [profile.id for profile in profiles]
+    assert ids == sorted(ids)
+
+
+def test_cada_perfil_tiene_pesos_positivos(container: Container) -> None:
+    for profile in container.list_profiles.execute():
+        assert sum(profile.weights.values()) > 0

--- a/apps/api/tests/test_use_case_list_sources.py
+++ b/apps/api/tests/test_use_case_list_sources.py
@@ -1,0 +1,45 @@
+"""Pruebas del caso de uso de listado de fuentes."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from atlashabita.application import Container
+from atlashabita.config import Settings
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+@pytest.fixture(scope="module")
+def container() -> Container:
+    settings = Settings(
+        env="test",
+        data_root=REPO_ROOT / "data",
+        ontology_root=REPO_ROOT / "ontology",
+    )
+    return Container(settings)
+
+
+def test_lista_fuentes_contiene_las_cinco_del_seed(container: Container) -> None:
+    sources = container.list_sources.execute()
+    assert {source.id for source in sources} == {
+        "mivau_serpavi",
+        "seteleco_broadband_maps",
+        "ine_atlas_renta",
+        "miteco_reto_demografico",
+        "aemet_opendata",
+    }
+
+
+def test_fuentes_ordenadas_alfabeticamente_por_titulo(container: Container) -> None:
+    sources = container.list_sources.execute()
+    titulos = [source.title.lower() for source in sources]
+    assert titulos == sorted(titulos)
+
+
+def test_cada_fuente_tiene_licencia_declarada(container: Container) -> None:
+    for source in container.list_sources.execute():
+        assert source.license
+        assert source.url.startswith("https://")

--- a/apps/api/tests/test_use_case_map_layers.py
+++ b/apps/api/tests/test_use_case_map_layers.py
@@ -1,0 +1,79 @@
+"""Pruebas de los casos de uso de capas cartográficas."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from atlashabita.application import Container
+from atlashabita.config import Settings
+from atlashabita.observability.errors import InvalidScopeError
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+@pytest.fixture(scope="module")
+def container() -> Container:
+    settings = Settings(
+        env="test",
+        data_root=REPO_ROOT / "data",
+        ontology_root=REPO_ROOT / "ontology",
+    )
+    return Container(settings)
+
+
+def test_list_map_layers_incluye_score_por_perfil_y_cinco_indicadores(
+    container: Container,
+) -> None:
+    layers = container.list_map_layers.execute()
+    score_layers = [layer for layer in layers if layer["kind"] == "score"]
+    indicator_layers = [layer for layer in layers if layer["kind"] == "indicator"]
+    assert len(score_layers) == 3
+    assert len(indicator_layers) == 5
+    assert len(layers) == 8
+
+
+def test_list_map_layers_formato_correcto(container: Container) -> None:
+    layers = container.list_map_layers.execute()
+    for layer in layers:
+        assert layer["type"] == "choropleth"
+        assert isinstance(layer["domain"], list)
+        assert isinstance(layer["range"], list)
+        assert layer["legend"]
+
+
+def test_get_map_layer_indicator_broadband_devuelve_10_features(
+    container: Container,
+) -> None:
+    collection = container.get_map_layer.execute("broadband_coverage")
+    assert collection["type"] == "FeatureCollection"
+    assert collection["layer_id"] == "broadband_coverage"
+    assert len(collection["features"]) == 10
+    for feature in collection["features"]:
+        assert feature["geometry"]["type"] == "Point"
+        coords = feature["geometry"]["coordinates"]
+        assert len(coords) == 2
+        assert "value" in feature["properties"]
+        assert "territory_id" in feature["properties"]
+
+
+def test_get_map_layer_score_remote_work_devuelve_10_features(
+    container: Container,
+) -> None:
+    collection = container.get_map_layer.execute("score_remote_work")
+    assert collection["kind"] == "score"
+    assert len(collection["features"]) == 10
+    for feature in collection["features"]:
+        value = feature["properties"]["value"]
+        assert 0.0 <= value <= 100.0
+
+
+def test_get_map_layer_id_invalido_lanza_error(container: Container) -> None:
+    with pytest.raises(InvalidScopeError):
+        container.get_map_layer.execute("capa-inexistente")
+
+
+def test_get_map_layer_vacio_lanza_error(container: Container) -> None:
+    with pytest.raises(InvalidScopeError):
+        container.get_map_layer.execute("")

--- a/apps/api/tests/test_use_case_middleware.py
+++ b/apps/api/tests/test_use_case_middleware.py
@@ -1,0 +1,78 @@
+"""Pruebas del middleware ASGI de contexto de request."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, MutableMapping
+from typing import Any
+
+import pytest
+
+from atlashabita.observability.middleware import RequestContextMiddleware
+
+_Scope = MutableMapping[str, Any]
+_Message = MutableMapping[str, Any]
+
+
+async def _dummy_app(
+    scope: _Scope,
+    receive: Callable[[], Awaitable[_Message]],
+    send: Callable[[_Message], Awaitable[None]],
+) -> None:
+    await send({"type": "http.response.start", "status": 200, "headers": []})
+    await send({"type": "http.response.body", "body": b"ok", "more_body": False})
+
+
+@pytest.mark.asyncio
+async def test_middleware_agrega_header_x_request_id() -> None:
+    mw = RequestContextMiddleware(_dummy_app)
+    messages: list[_Message] = []
+
+    async def send(message: _Message) -> None:
+        messages.append(message)
+
+    async def receive() -> _Message:
+        return {"type": "http.request", "body": b""}
+
+    scope: _Scope = {"type": "http", "headers": []}
+    await mw(scope, receive, send)
+
+    start = next(message for message in messages if message["type"] == "http.response.start")
+    headers = dict(start["headers"])
+    assert b"x-request-id" in headers
+    assert len(headers[b"x-request-id"]) > 0
+
+
+@pytest.mark.asyncio
+async def test_middleware_preserva_request_id_entrante() -> None:
+    mw = RequestContextMiddleware(_dummy_app)
+    messages: list[_Message] = []
+
+    async def send(message: _Message) -> None:
+        messages.append(message)
+
+    async def receive() -> _Message:
+        return {"type": "http.request", "body": b""}
+
+    scope: _Scope = {
+        "type": "http",
+        "headers": [(b"x-request-id", b"deadbeef")],
+    }
+    await mw(scope, receive, send)
+
+    start = next(message for message in messages if message["type"] == "http.response.start")
+    headers = dict(start["headers"])
+    assert headers[b"x-request-id"] == b"deadbeef"
+
+
+@pytest.mark.asyncio
+async def test_middleware_ignora_scope_no_http() -> None:
+    mw = RequestContextMiddleware(_dummy_app)
+
+    async def send(_: _Message) -> None:
+        return None
+
+    async def receive() -> _Message:
+        return {"type": "lifespan.startup"}
+
+    scope: _Scope = {"type": "lifespan"}
+    await mw(scope, receive, send)  # no explota

--- a/apps/api/tests/test_use_case_quality_report.py
+++ b/apps/api/tests/test_use_case_quality_report.py
@@ -1,0 +1,50 @@
+"""Pruebas del caso de uso de informe de calidad."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from atlashabita.application import Container
+from atlashabita.config import Settings
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+@pytest.fixture(scope="module")
+def container() -> Container:
+    settings = Settings(
+        env="test",
+        data_root=REPO_ROOT / "data",
+        ontology_root=REPO_ROOT / "ontology",
+    )
+    return Container(settings)
+
+
+def test_informe_incluye_conteos_esperados(container: Container) -> None:
+    report = container.get_quality_report.execute()
+    assert report["tables"]["municipalities"] == 10
+    assert report["tables"]["provinces"] == 3
+    assert report["tables"]["autonomous_communities"] == 2
+    assert report["tables"]["sources"] == 5
+    assert report["tables"]["indicators"] == 5
+    assert report["tables"]["observations"] == 50
+    assert report["tables"]["profiles"] == 3
+
+
+def test_informe_cobertura_100_para_seed(container: Container) -> None:
+    report = container.get_quality_report.execute()
+    assert report["coverage"]["actual_observations"] == 50
+    assert report["coverage"]["expected_observations"] == 50
+    assert report["coverage"]["ratio"] == pytest.approx(1.0)
+
+
+def test_informe_incluye_data_version(container: Container) -> None:
+    report = container.get_quality_report.execute()
+    assert report["data_version"].startswith("seed:")
+
+
+def test_informe_no_genera_warnings_si_cobertura_completa(container: Container) -> None:
+    report = container.get_quality_report.execute()
+    assert report["warnings"] == []

--- a/apps/api/tests/test_use_case_search_territories.py
+++ b/apps/api/tests/test_use_case_search_territories.py
@@ -1,0 +1,72 @@
+"""Pruebas del caso de uso de búsqueda de territorios."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from atlashabita.application.use_cases import SearchTerritoriesUseCase
+from atlashabita.infrastructure.ingestion import SeedDataset, SeedLoader
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SEED_DIR = REPO_ROOT / "data" / "seed"
+
+
+@pytest.fixture(scope="module")
+def dataset() -> SeedDataset:
+    return SeedLoader(SEED_DIR).load()
+
+
+@pytest.fixture(scope="module")
+def use_case(dataset: SeedDataset) -> SearchTerritoriesUseCase:
+    return SearchTerritoriesUseCase(dataset=dataset)
+
+
+def test_busqueda_case_insensitive_encuentra_sevilla(
+    use_case: SearchTerritoriesUseCase,
+) -> None:
+    results = use_case.execute("sevilla")
+    nombres = [t.name for t in results]
+    assert "Sevilla" in nombres
+
+
+def test_busqueda_sin_tilde_encuentra_malaga(
+    use_case: SearchTerritoriesUseCase,
+) -> None:
+    results = use_case.execute("malaga")
+    nombres = [t.name for t in results]
+    assert "Málaga" in nombres
+
+
+def test_busqueda_tolerante_con_donosti(
+    use_case: SearchTerritoriesUseCase,
+) -> None:
+    results = use_case.execute("Donosti")
+    assert any("Donostia" in territory.name for territory in results)
+
+
+def test_busqueda_vacia_devuelve_lista_vacia(
+    use_case: SearchTerritoriesUseCase,
+) -> None:
+    assert use_case.execute("") == []
+    assert use_case.execute("   ") == []
+
+
+def test_busqueda_respeta_limit(use_case: SearchTerritoriesUseCase) -> None:
+    # "a" aparece en muchos municipios; verificar que el límite se respeta.
+    results = use_case.execute("a", limit=3)
+    assert len(results) <= 3
+
+
+def test_busqueda_prioriza_coincidencia_exacta(
+    use_case: SearchTerritoriesUseCase,
+) -> None:
+    results = use_case.execute("Sevilla")
+    assert results[0].name == "Sevilla"
+
+
+def test_busqueda_no_encuentra_si_no_existe(
+    use_case: SearchTerritoriesUseCase,
+) -> None:
+    assert use_case.execute("ciudad-inventada-xyz") == []


### PR DESCRIPTION
## Resumen

Capa de aplicación completa: `ScoringService` explicable con normalización min-max, reescalado de pesos ante datos faltantes, contribuciones, highlights y warnings; composition root `Container`; ocho casos de uso (buscar territorios, detalle, rankings, listar perfiles/fuentes/capas, exportar capa, reporte de calidad); middleware ASGI con `X-Request-ID`.

## Issues

Closes #16
Closes #17
Closes #20

## Verificación

- ruff, ruff format, mypy strict y pytest en verde.
- 81 tests totales · cobertura 94 %, application/ ≥ 87 % en cada módulo.

## Notas

- Scoring propaga `settings.scoring_version` y `confidence` basado en indicadores disponibles.
- `ComputeRankingsUseCase` cachea con hash SHA-256 del seed como `data_version`.
- `RequestContextMiddleware` respeta `X-Request-ID` entrante y lo propaga por `structlog.contextvars`.