### PR TITLE
feat(web): sistema de diseño y shell del dashboard (sidebar, topbar, layout)

### DIFF
--- a/apps/web/src/components/layout/ActionCards.tsx
+++ b/apps/web/src/components/layout/ActionCards.tsx
@@ -1,0 +1,73 @@
+import type { ReactNode } from 'react';
+import { ArrowRight } from 'lucide-react';
+import { Card } from '../ui/Card';
+import { cn } from '../ui/cn';
+
+export interface ActionCardItem {
+  id: string;
+  title: string;
+  description: string;
+  icon: ReactNode;
+  href?: string;
+  accent?: 'brand' | 'emerald' | 'sky' | 'amber';
+}
+
+export interface ActionCardsProps {
+  items: ActionCardItem[];
+  className?: string;
+}
+
+const ACCENT_BG: Record<NonNullable<ActionCardItem['accent']>, string> = {
+  brand: 'bg-brand-50 text-brand-600',
+  emerald: 'bg-emerald-50 text-emerald-600',
+  sky: 'bg-sky-50 text-sky-600',
+  amber: 'bg-amber-50 text-amber-600',
+};
+
+export function ActionCards({ items, className }: ActionCardsProps) {
+  return (
+    <ul className={cn('grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4', className)}>
+      {items.map((item) => (
+        <li key={item.id}>
+          <Card
+            as="article"
+            tone="base"
+            padding="md"
+            interactive
+            className="group relative flex h-full flex-col gap-4"
+          >
+            <header className="flex items-center justify-between">
+              <span
+                aria-hidden="true"
+                className={cn(
+                  'inline-flex h-10 w-10 items-center justify-center rounded-2xl',
+                  ACCENT_BG[item.accent ?? 'brand']
+                )}
+              >
+                {item.icon}
+              </span>
+              <ArrowRight
+                aria-hidden="true"
+                size={18}
+                className="text-ink-300 group-hover:text-brand-500 transition-colors"
+              />
+            </header>
+            <div className="flex flex-col gap-1">
+              <h3 className="font-display text-ink-900 text-base font-semibold">
+                {item.href ? (
+                  <a href={item.href} className="focus:outline-none">
+                    <span className="absolute inset-0" aria-hidden="true" />
+                    {item.title}
+                  </a>
+                ) : (
+                  item.title
+                )}
+              </h3>
+              <p className="text-ink-500 text-sm leading-relaxed">{item.description}</p>
+            </div>
+          </Card>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/apps/web/src/components/layout/ChipFilters.tsx
+++ b/apps/web/src/components/layout/ChipFilters.tsx
@@ -1,0 +1,62 @@
+import type { ReactNode } from 'react';
+import { cn } from '../ui/cn';
+
+export interface ChipFilterOption {
+  id: string;
+  label: string;
+  icon?: ReactNode;
+}
+
+export interface ChipFiltersProps {
+  options: ChipFilterOption[];
+  /** Ids actualmente activos. */
+  value: string[];
+  onToggle?: (id: string) => void;
+  /** Controla cuánto contrastan las chips respecto al fondo (claro sobre hero). */
+  tone?: 'onLight' | 'onBrand';
+  'aria-label'?: string;
+  className?: string;
+}
+
+export function ChipFilters({
+  options,
+  value,
+  onToggle,
+  tone = 'onLight',
+  'aria-label': ariaLabel = 'Filtros rápidos',
+  className,
+}: ChipFiltersProps) {
+  return (
+    <div role="group" aria-label={ariaLabel} className={cn('flex flex-wrap gap-2', className)}>
+      {options.map((option) => {
+        const isActive = value.includes(option.id);
+        return (
+          <button
+            key={option.id}
+            type="button"
+            aria-pressed={isActive}
+            onClick={() => onToggle?.(option.id)}
+            className={cn(
+              'inline-flex h-9 items-center gap-2 rounded-full px-4 text-sm font-medium transition-colors',
+              'focus-visible:ring-brand-300 focus-visible:ring-2 focus-visible:ring-offset-2',
+              tone === 'onBrand'
+                ? isActive
+                  ? 'text-brand-700 bg-white shadow-[var(--shadow-card)]'
+                  : 'bg-white/20 text-white hover:bg-white/30'
+                : isActive
+                  ? 'bg-brand-500 text-white shadow-[var(--shadow-card)]'
+                  : 'text-ink-700 hover:text-brand-700 hover:border-brand-300 border border-[color:var(--color-line-soft)] bg-white'
+            )}
+          >
+            {option.icon ? (
+              <span aria-hidden="true" className="inline-flex">
+                {option.icon}
+              </span>
+            ) : null}
+            {option.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/src/components/layout/DashboardLayout.tsx
+++ b/apps/web/src/components/layout/DashboardLayout.tsx
@@ -1,0 +1,64 @@
+import type { ReactNode } from 'react';
+import { cn } from '../ui/cn';
+import { Sidebar } from './Sidebar';
+import { Topbar } from './Topbar';
+
+export interface DashboardLayoutProps {
+  /** Slot lateral izquierdo. Por defecto `<Sidebar />`. */
+  sidebar?: ReactNode;
+  /** Cabecera superior. Por defecto `<Topbar />`. */
+  topbar?: ReactNode;
+  /** Bloque principal (hero + mapa). Ocupa la columna central. */
+  hero: ReactNode;
+  /** Panel lateral derecho (tendencias, recomendación, ranking…). */
+  side?: ReactNode;
+  /** Cards de acción que se muestran debajo del hero. */
+  footer?: ReactNode;
+  className?: string;
+}
+
+export function DashboardLayout({
+  sidebar,
+  topbar,
+  hero,
+  side,
+  footer,
+  className,
+}: DashboardLayoutProps) {
+  return (
+    <div className={cn('bg-surface-soft text-ink-900 flex min-h-screen w-full', className)}>
+      {sidebar ?? <Sidebar />}
+
+      <div className="flex min-w-0 flex-1 flex-col">
+        {topbar ?? <Topbar />}
+
+        <main
+          id="contenido-principal"
+          className="flex-1 overflow-x-hidden px-8 pt-6 pb-10"
+          aria-label="Panel principal"
+        >
+          <div
+            className={cn(
+              'grid w-full gap-6',
+              side ? 'lg:grid-cols-[minmax(0,1fr)_360px]' : 'grid-cols-1'
+            )}
+          >
+            <section className="flex min-w-0 flex-col gap-6" aria-label="Contenido principal">
+              {hero}
+              {footer ? (
+                <section aria-label="Acciones destacadas" className="mt-2">
+                  {footer}
+                </section>
+              ) : null}
+            </section>
+            {side ? (
+              <aside aria-label="Panel lateral" className="flex flex-col gap-4">
+                {side}
+              </aside>
+            ) : null}
+          </div>
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/layout/LayersPanel.tsx
+++ b/apps/web/src/components/layout/LayersPanel.tsx
@@ -1,0 +1,70 @@
+import { useId } from 'react';
+import { cn } from '../ui/cn';
+
+export interface LayerOption {
+  id: string;
+  label: string;
+  checked: boolean;
+  disabled?: boolean;
+}
+
+export interface LayersPanelProps {
+  title?: string;
+  layers: LayerOption[];
+  onChange?: (id: string, checked: boolean) => void;
+  className?: string;
+}
+
+export function LayersPanel({
+  title = 'Capas activas',
+  layers,
+  onChange,
+  className,
+}: LayersPanelProps) {
+  const groupId = useId();
+
+  return (
+    <section aria-labelledby={groupId} className={cn('flex flex-col gap-3', className)}>
+      <h2 id={groupId} className="text-ink-500 text-xs font-semibold tracking-[0.14em] uppercase">
+        {title}
+      </h2>
+      <ul className="flex flex-col gap-1.5">
+        {layers.map((layer) => {
+          const inputId = `${groupId}-${layer.id}`;
+          return (
+            <li key={layer.id}>
+              <label
+                htmlFor={inputId}
+                className={cn(
+                  'group flex cursor-pointer items-center gap-3 rounded-xl px-2 py-1.5',
+                  'hover:bg-surface-muted transition-colors',
+                  layer.disabled && 'cursor-not-allowed opacity-60'
+                )}
+              >
+                <input
+                  id={inputId}
+                  type="checkbox"
+                  checked={layer.checked}
+                  disabled={layer.disabled}
+                  onChange={(event) => onChange?.(layer.id, event.target.checked)}
+                  className={cn(
+                    'text-brand-500 focus:ring-brand-300 h-4 w-4 rounded',
+                    'border-[color:var(--color-line-strong)]'
+                  )}
+                />
+                <span
+                  className={cn(
+                    'text-sm',
+                    layer.checked ? 'text-ink-900 font-medium' : 'text-ink-500'
+                  )}
+                >
+                  {layer.label}
+                </span>
+              </label>
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+}

--- a/apps/web/src/components/layout/OpportunityIndex.tsx
+++ b/apps/web/src/components/layout/OpportunityIndex.tsx
@@ -1,0 +1,46 @@
+import { Progress } from '../ui/Progress';
+import { cn } from '../ui/cn';
+
+export interface OpportunityIndexProps {
+  title?: string;
+  value: number;
+  description?: string;
+  className?: string;
+}
+
+export function OpportunityIndex({
+  title = 'Índice de oportunidad',
+  value,
+  description,
+  className,
+}: OpportunityIndexProps) {
+  return (
+    <section
+      aria-labelledby="opportunity-index-title"
+      className={cn(
+        'flex flex-col gap-2 rounded-2xl bg-white p-4',
+        'border border-[color:var(--color-line-soft)]',
+        className
+      )}
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <h3
+            id="opportunity-index-title"
+            className="text-ink-500 text-xs font-semibold tracking-wide uppercase"
+          >
+            {title}
+          </h3>
+          {description ? <p className="text-ink-900 mt-1 text-sm">{description}</p> : null}
+        </div>
+        <span className="font-display text-brand-700 text-2xl font-bold">{value}</span>
+      </div>
+      <Progress label={title} value={value} hideLabel tone="brand" size="md" />
+      <div className="text-ink-500 flex justify-between text-[11px] uppercase">
+        <span>0</span>
+        <span>50</span>
+        <span>100</span>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -1,0 +1,139 @@
+import { useState, type ReactNode } from 'react';
+import {
+  BarChart3,
+  Compass,
+  Home,
+  LayoutGrid,
+  Layers,
+  Map as MapIcon,
+  SlidersHorizontal,
+} from 'lucide-react';
+import { cn } from '../ui/cn';
+import { LayersPanel, type LayerOption } from './LayersPanel';
+import { UserCard } from './UserCard';
+
+export interface SidebarNavItem {
+  id: string;
+  label: string;
+  icon: ReactNode;
+  href?: string;
+}
+
+export interface SidebarProps {
+  navItems?: SidebarNavItem[];
+  layers?: LayerOption[];
+  activeNavId?: string;
+  userName?: string;
+  userSubtitle?: string;
+  userAvatarUrl?: string;
+  className?: string;
+}
+
+const DEFAULT_NAV: SidebarNavItem[] = [
+  { id: 'home', label: 'Inicio', icon: <Home size={18} />, href: '#inicio' },
+  { id: 'map', label: 'Explorar mapa', icon: <MapIcon size={18} />, href: '#mapa' },
+  { id: 'recommender', label: 'Recomendador', icon: <Compass size={18} />, href: '#recomendador' },
+  { id: 'comparator', label: 'Comparador', icon: <LayoutGrid size={18} />, href: '#comparador' },
+  {
+    id: 'scenarios',
+    label: 'Escenarios',
+    icon: <SlidersHorizontal size={18} />,
+    href: '#escenarios',
+  },
+];
+
+const DEFAULT_LAYERS: LayerOption[] = [
+  { id: 'housing', label: 'Vivienda asequible', checked: true },
+  { id: 'jobs', label: 'Empleo', checked: true },
+  { id: 'connectivity', label: 'Conectividad', checked: false },
+  { id: 'transport', label: 'Transporte público', checked: false },
+  { id: 'education', label: 'Educación', checked: false },
+];
+
+export function Sidebar({
+  navItems = DEFAULT_NAV,
+  layers = DEFAULT_LAYERS,
+  activeNavId = 'home',
+  userName = 'Alex Romero',
+  userSubtitle = 'Cuenta personal',
+  userAvatarUrl,
+  className,
+}: SidebarProps) {
+  const [layerState, setLayerState] = useState<LayerOption[]>(layers);
+
+  return (
+    <aside
+      aria-label="Barra lateral"
+      className={cn(
+        'flex h-full w-72 shrink-0 flex-col gap-8 border-r border-[color:var(--color-line-soft)]',
+        'bg-white px-5 py-6',
+        className
+      )}
+    >
+      <a href="#inicio" className="flex items-center gap-2.5" aria-label="AtlasHabita, ir a inicio">
+        <span
+          aria-hidden="true"
+          className="bg-brand-500 inline-flex h-9 w-9 items-center justify-center rounded-xl text-white"
+        >
+          <Layers size={18} />
+        </span>
+        <span className="font-display text-ink-900 text-lg font-bold tracking-tight">
+          AtlasHabita
+        </span>
+      </a>
+
+      <nav aria-label="Navegación principal">
+        <ul className="flex flex-col gap-1">
+          {navItems.map((item) => {
+            const isActive = item.id === activeNavId;
+            return (
+              <li key={item.id}>
+                <a
+                  href={item.href ?? '#'}
+                  aria-current={isActive ? 'page' : undefined}
+                  className={cn(
+                    'flex items-center gap-3 rounded-2xl px-3 py-2 text-sm font-medium transition-colors',
+                    isActive
+                      ? 'bg-brand-50 text-brand-700'
+                      : 'text-ink-500 hover:bg-surface-muted hover:text-ink-900'
+                  )}
+                >
+                  <span
+                    aria-hidden="true"
+                    className={cn(
+                      'inline-flex h-8 w-8 items-center justify-center rounded-xl',
+                      isActive ? 'bg-brand-500 text-white' : 'bg-surface-muted text-ink-500'
+                    )}
+                  >
+                    {item.icon}
+                  </span>
+                  <span>{item.label}</span>
+                </a>
+              </li>
+            );
+          })}
+        </ul>
+      </nav>
+
+      <LayersPanel
+        title="Capas activas"
+        layers={layerState}
+        onChange={(id, checked) =>
+          setLayerState((prev) =>
+            prev.map((layer) => (layer.id === id ? { ...layer, checked } : layer))
+          )
+        }
+      />
+
+      <div className="mt-auto space-y-4">
+        <UserCard
+          name={userName}
+          subtitle={userSubtitle}
+          avatarUrl={userAvatarUrl}
+          indicator={{ label: 'Índice actual', value: 74 }}
+          action={{ label: 'Explorar Premium', icon: <BarChart3 size={14} /> }}
+        />
+      </div>
+    </aside>
+  );
+}

--- a/apps/web/src/components/layout/Topbar.tsx
+++ b/apps/web/src/components/layout/Topbar.tsx
@@ -1,0 +1,94 @@
+import { useId, type ReactNode } from 'react';
+import { Bell, MessageCircle, Plus, Search } from 'lucide-react';
+import { Button } from '../ui/Button';
+import { IconButton } from '../ui/IconButton';
+import { cn } from '../ui/cn';
+
+export interface TopbarProps {
+  placeholder?: string;
+  onSearch?: (value: string) => void;
+  onFeedback?: () => void;
+  onNewAnalysis?: () => void;
+  extra?: ReactNode;
+  className?: string;
+}
+
+export function Topbar({
+  placeholder = 'Busca un municipio, provincia o punto de interés…',
+  onSearch,
+  onFeedback,
+  onNewAnalysis,
+  extra,
+  className,
+}: TopbarProps) {
+  const inputId = useId();
+
+  return (
+    <header
+      className={cn(
+        'flex h-16 items-center gap-4 border-b border-[color:var(--color-line-soft)] bg-white px-6',
+        className
+      )}
+    >
+      <form
+        role="search"
+        onSubmit={(event) => {
+          event.preventDefault();
+          const input = event.currentTarget.elements.namedItem('query') as {
+            value?: string;
+          } | null;
+          onSearch?.(input?.value ?? '');
+        }}
+        className="relative flex-1"
+      >
+        <label htmlFor={inputId} className="sr-only">
+          Buscar en AtlasHabita
+        </label>
+        <Search
+          aria-hidden="true"
+          size={18}
+          className="text-ink-500 pointer-events-none absolute top-1/2 left-4 -translate-y-1/2"
+        />
+        <input
+          id={inputId}
+          name="query"
+          type="search"
+          placeholder={placeholder}
+          className={cn(
+            'bg-surface-soft h-11 w-full rounded-full pr-4 pl-11 text-sm',
+            'placeholder:text-ink-300 text-ink-900',
+            'border border-transparent transition-colors',
+            'hover:border-[color:var(--color-line-soft)]',
+            'focus:border-brand-300 focus:bg-white focus:outline-none'
+          )}
+        />
+      </form>
+
+      <nav aria-label="Acciones" className="flex items-center gap-2">
+        {extra}
+        <Button
+          variant="ghost"
+          size="sm"
+          leadingIcon={<MessageCircle size={16} />}
+          onClick={onFeedback}
+        >
+          Feedback
+        </Button>
+        <IconButton
+          label="Notificaciones"
+          icon={<Bell size={18} />}
+          variant="secondary"
+          size="md"
+        />
+        <Button
+          variant="primary"
+          size="md"
+          leadingIcon={<Plus size={16} />}
+          onClick={onNewAnalysis}
+        >
+          Nuevo análisis
+        </Button>
+      </nav>
+    </header>
+  );
+}

--- a/apps/web/src/components/layout/UserCard.tsx
+++ b/apps/web/src/components/layout/UserCard.tsx
@@ -1,0 +1,64 @@
+import type { ReactNode } from 'react';
+import { Avatar } from '../ui/Avatar';
+import { Button } from '../ui/Button';
+import { cn } from '../ui/cn';
+
+export interface UserCardProps {
+  name: string;
+  subtitle?: string;
+  avatarUrl?: string;
+  indicator?: {
+    label: string;
+    /** Valor 0-100 mostrado como chip. */
+    value: number;
+  };
+  action?: {
+    label: string;
+    icon?: ReactNode;
+    onClick?: () => void;
+  };
+  className?: string;
+}
+
+export function UserCard({
+  name,
+  subtitle,
+  avatarUrl,
+  indicator,
+  action,
+  className,
+}: UserCardProps) {
+  return (
+    <div
+      className={cn(
+        'bg-surface-soft flex flex-col gap-3 rounded-2xl p-3',
+        'border border-[color:var(--color-line-soft)]',
+        className
+      )}
+    >
+      <div className="flex items-center gap-3">
+        <Avatar name={name} src={avatarUrl} size="md" />
+        <div className="min-w-0 flex-1">
+          <p className="text-ink-900 truncate text-sm font-semibold">Hola, {name.split(' ')[0]}</p>
+          {subtitle ? <p className="text-ink-500 truncate text-xs">{subtitle}</p> : null}
+        </div>
+        {indicator ? (
+          <span className="bg-brand-50 text-brand-700 rounded-full px-2 py-0.5 text-xs font-semibold">
+            {indicator.value}
+          </span>
+        ) : null}
+      </div>
+      {action ? (
+        <Button
+          variant="subtle"
+          size="sm"
+          fullWidth
+          leadingIcon={action.icon}
+          onClick={action.onClick}
+        >
+          {action.label}
+        </Button>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/components/layout/__tests__/DashboardLayout.test.tsx
+++ b/apps/web/src/components/layout/__tests__/DashboardLayout.test.tsx
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { DashboardLayout } from '../DashboardLayout';
+
+describe('DashboardLayout', () => {
+  it('compone Sidebar, Topbar y slots principales', () => {
+    render(
+      <DashboardLayout
+        hero={<h1 id="dashboard-title">Hero aquí</h1>}
+        side={<p>Panel lateral</p>}
+        footer={<p>Acciones</p>}
+      />
+    );
+
+    expect(screen.getByRole('navigation', { name: 'Navegación principal' })).toBeInTheDocument();
+    expect(screen.getByRole('searchbox', { name: 'Buscar en AtlasHabita' })).toBeInTheDocument();
+    expect(screen.getByText('Hero aquí')).toBeInTheDocument();
+    expect(screen.getByText('Panel lateral')).toBeInTheDocument();
+    expect(screen.getByText('Acciones')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/layout/__tests__/OpportunityIndex.test.tsx
+++ b/apps/web/src/components/layout/__tests__/OpportunityIndex.test.tsx
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { OpportunityIndex } from '../OpportunityIndex';
+
+describe('OpportunityIndex', () => {
+  it('muestra el porcentaje y expone un progressbar con el mismo valor', () => {
+    render(<OpportunityIndex value={82} />);
+    expect(screen.getByText('82')).toBeInTheDocument();
+
+    const bar = screen.getByRole('progressbar');
+    expect(bar).toHaveAttribute('aria-valuenow', '82');
+    expect(bar).toHaveAttribute('aria-valuemax', '100');
+  });
+});

--- a/apps/web/src/components/layout/__tests__/Sidebar.test.tsx
+++ b/apps/web/src/components/layout/__tests__/Sidebar.test.tsx
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import { Sidebar } from '../Sidebar';
+
+describe('Sidebar', () => {
+  it('expone landmark de navegación con las cinco secciones principales', () => {
+    render(<Sidebar />);
+    const nav = screen.getByRole('navigation', { name: 'Navegación principal' });
+    expect(nav).toBeInTheDocument();
+
+    const labels = ['Inicio', 'Explorar mapa', 'Recomendador', 'Comparador', 'Escenarios'];
+    for (const label of labels) {
+      expect(within(nav).getByRole('link', { name: new RegExp(label) })).toBeInTheDocument();
+    }
+  });
+
+  it('marca la sección activa con aria-current', () => {
+    render(<Sidebar activeNavId="map" />);
+    const nav = screen.getByRole('navigation', { name: 'Navegación principal' });
+    const activeLink = within(nav).getByRole('link', { name: /Explorar mapa/ });
+    expect(activeLink).toHaveAttribute('aria-current', 'page');
+  });
+
+  it('incluye la sección "Capas activas" con checkboxes accesibles', () => {
+    render(<Sidebar />);
+    const region = screen.getByRole('region', { name: /Capas activas/i });
+    expect(region).toBeInTheDocument();
+    const checkboxes = within(region).getAllByRole('checkbox');
+    expect(checkboxes.length).toBeGreaterThanOrEqual(3);
+  });
+});

--- a/apps/web/src/components/layout/__tests__/Topbar.test.tsx
+++ b/apps/web/src/components/layout/__tests__/Topbar.test.tsx
@@ -1,0 +1,23 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Topbar } from '../Topbar';
+
+describe('Topbar', () => {
+  it('renderiza buscador accesible, Feedback y botón primario', () => {
+    render(<Topbar />);
+    expect(screen.getByRole('searchbox', { name: 'Buscar en AtlasHabita' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Feedback/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Nuevo análisis/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Notificaciones/i })).toBeInTheDocument();
+  });
+
+  it('envía la búsqueda cuando el formulario se envía', async () => {
+    const onSearch = vi.fn();
+    const user = userEvent.setup();
+    render(<Topbar onSearch={onSearch} />);
+    const input = screen.getByRole('searchbox', { name: 'Buscar en AtlasHabita' });
+    await user.type(input, 'Madrid{enter}');
+    expect(onSearch).toHaveBeenCalledWith('Madrid');
+  });
+});

--- a/apps/web/src/components/layout/__tests__/UserCard.test.tsx
+++ b/apps/web/src/components/layout/__tests__/UserCard.test.tsx
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { UserCard } from '../UserCard';
+
+describe('UserCard', () => {
+  it('muestra el saludo con el primer nombre del usuario', () => {
+    render(<UserCard name="Alex Romero" subtitle="Cuenta personal" />);
+    expect(screen.getByText('Hola, Alex')).toBeInTheDocument();
+    expect(screen.getByText('Cuenta personal')).toBeInTheDocument();
+  });
+
+  it('expone el avatar con aria-label del nombre completo', () => {
+    render(<UserCard name="Ana Pérez" />);
+    expect(screen.getByRole('img', { name: 'Ana Pérez' })).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/ui/Avatar.tsx
+++ b/apps/web/src/components/ui/Avatar.tsx
@@ -1,0 +1,50 @@
+import type { ComponentPropsWithoutRef } from 'react';
+import { cn } from './cn';
+
+export type AvatarSize = 'sm' | 'md' | 'lg';
+
+export interface AvatarProps extends ComponentPropsWithoutRef<'span'> {
+  /** URL de la imagen. Si falta, se muestran las iniciales de `name`. */
+  src?: string;
+  /** Nombre completo usado para `alt` y fallback con iniciales. */
+  name: string;
+  size?: AvatarSize;
+}
+
+const SIZE_STYLES: Record<AvatarSize, string> = {
+  sm: 'h-8 w-8 text-xs',
+  md: 'h-10 w-10 text-sm',
+  lg: 'h-12 w-12 text-base',
+};
+
+function getInitials(name: string): string {
+  return name
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((part) => part[0]?.toUpperCase() ?? '')
+    .join('');
+}
+
+export function Avatar({ src, name, size = 'md', className, ...rest }: AvatarProps) {
+  const hasImage = Boolean(src);
+  return (
+    <span
+      role="img"
+      aria-label={name}
+      className={cn(
+        'inline-flex shrink-0 items-center justify-center overflow-hidden rounded-full',
+        'bg-brand-100 text-brand-700 font-semibold',
+        SIZE_STYLES[size],
+        className
+      )}
+      {...rest}
+    >
+      {hasImage ? (
+        <img src={src} alt="" className="h-full w-full object-cover" />
+      ) : (
+        <span aria-hidden="true">{getInitials(name)}</span>
+      )}
+    </span>
+  );
+}

--- a/apps/web/src/components/ui/Badge.tsx
+++ b/apps/web/src/components/ui/Badge.tsx
@@ -1,0 +1,38 @@
+import type { ComponentPropsWithoutRef } from 'react';
+import { cn } from './cn';
+
+export type BadgeTone = 'neutral' | 'brand' | 'success' | 'warning' | 'danger';
+
+export interface BadgeProps extends ComponentPropsWithoutRef<'span'> {
+  tone?: BadgeTone;
+  /** Si se habilita, muestra un punto a la izquierda indicando estado. */
+  dot?: boolean;
+}
+
+const TONE_STYLES: Record<BadgeTone, { bg: string; text: string; dot: string }> = {
+  neutral: { bg: 'bg-surface-muted', text: 'text-ink-700', dot: 'bg-ink-500' },
+  brand: { bg: 'bg-brand-100', text: 'text-brand-700', dot: 'bg-brand-500' },
+  success: { bg: 'bg-emerald-100', text: 'text-emerald-700', dot: 'bg-emerald-500' },
+  warning: { bg: 'bg-amber-100', text: 'text-amber-800', dot: 'bg-amber-500' },
+  danger: { bg: 'bg-rose-100', text: 'text-rose-700', dot: 'bg-rose-500' },
+};
+
+export function Badge({ tone = 'neutral', dot = false, className, children, ...rest }: BadgeProps) {
+  const palette = TONE_STYLES[tone];
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-xs font-semibold',
+        palette.bg,
+        palette.text,
+        className
+      )}
+      {...rest}
+    >
+      {dot ? (
+        <span aria-hidden="true" className={cn('h-1.5 w-1.5 rounded-full', palette.dot)} />
+      ) : null}
+      {children}
+    </span>
+  );
+}

--- a/apps/web/src/components/ui/Button.tsx
+++ b/apps/web/src/components/ui/Button.tsx
@@ -1,0 +1,70 @@
+import type { ComponentPropsWithoutRef, ReactNode } from 'react';
+import { cn } from './cn';
+
+export type ButtonVariant = 'primary' | 'secondary' | 'ghost' | 'subtle';
+export type ButtonSize = 'sm' | 'md' | 'lg';
+
+export interface ButtonProps extends ComponentPropsWithoutRef<'button'> {
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+  leadingIcon?: ReactNode;
+  trailingIcon?: ReactNode;
+  fullWidth?: boolean;
+}
+
+const VARIANT_STYLES: Record<ButtonVariant, string> = {
+  primary:
+    'bg-brand-500 text-white shadow-[0_10px_24px_-14px_rgba(16,185,129,0.65)] hover:bg-brand-600 active:bg-brand-700 disabled:bg-brand-300 disabled:text-white/80',
+  secondary:
+    'bg-white text-ink-700 border border-[color:var(--color-line-soft)] hover:border-brand-300 hover:text-brand-700 active:bg-surface-muted disabled:text-ink-300 disabled:border-[color:var(--color-line-soft)]',
+  ghost:
+    'bg-transparent text-ink-700 hover:bg-surface-muted active:bg-surface-muted/80 disabled:text-ink-300',
+  subtle:
+    'bg-brand-50 text-brand-700 hover:bg-brand-100 active:bg-brand-200 disabled:text-brand-300',
+};
+
+const SIZE_STYLES: Record<ButtonSize, string> = {
+  sm: 'h-8 px-3 text-sm gap-1.5',
+  md: 'h-10 px-4 text-sm gap-2',
+  lg: 'h-12 px-6 text-base gap-2.5',
+};
+
+export function Button({
+  variant = 'primary',
+  size = 'md',
+  leadingIcon,
+  trailingIcon,
+  fullWidth = false,
+  className,
+  type = 'button',
+  children,
+  ...rest
+}: ButtonProps) {
+  return (
+    <button
+      type={type}
+      className={cn(
+        'inline-flex items-center justify-center rounded-full font-medium transition-colors',
+        'focus-visible:ring-brand-300 focus-visible:ring-2 focus-visible:ring-offset-2',
+        'disabled:cursor-not-allowed',
+        VARIANT_STYLES[variant],
+        SIZE_STYLES[size],
+        fullWidth && 'w-full',
+        className
+      )}
+      {...rest}
+    >
+      {leadingIcon ? (
+        <span aria-hidden="true" className="inline-flex shrink-0">
+          {leadingIcon}
+        </span>
+      ) : null}
+      <span>{children}</span>
+      {trailingIcon ? (
+        <span aria-hidden="true" className="inline-flex shrink-0">
+          {trailingIcon}
+        </span>
+      ) : null}
+    </button>
+  );
+}

--- a/apps/web/src/components/ui/Card.tsx
+++ b/apps/web/src/components/ui/Card.tsx
@@ -1,0 +1,71 @@
+import type { ComponentPropsWithoutRef, ElementType, ReactNode } from 'react';
+import { cn } from './cn';
+
+export type CardTone = 'base' | 'soft' | 'brand' | 'outline';
+export type CardPadding = 'none' | 'sm' | 'md' | 'lg';
+
+export interface CardProps extends ComponentPropsWithoutRef<'div'> {
+  tone?: CardTone;
+  padding?: CardPadding;
+  interactive?: boolean;
+  as?: 'div' | 'section' | 'article' | 'aside';
+}
+
+const TONE_STYLES: Record<CardTone, string> = {
+  base: 'bg-white border border-[color:var(--color-line-soft)] shadow-[var(--shadow-card)]',
+  soft: 'bg-surface-raised border border-[color:var(--color-line-soft)]',
+  brand: 'bg-brand-500 text-white border border-brand-600',
+  outline: 'bg-transparent border border-[color:var(--color-line-soft)]',
+};
+
+const PADDING_STYLES: Record<CardPadding, string> = {
+  none: 'p-0',
+  sm: 'p-4',
+  md: 'p-6',
+  lg: 'p-8',
+};
+
+export function Card({
+  tone = 'base',
+  padding = 'md',
+  interactive = false,
+  as,
+  className,
+  children,
+  ...rest
+}: CardProps) {
+  const Component: ElementType = as ?? 'div';
+  return (
+    <Component
+      className={cn(
+        'rounded-3xl transition-shadow',
+        TONE_STYLES[tone],
+        PADDING_STYLES[padding],
+        interactive &&
+          'cursor-pointer focus-within:shadow-[var(--shadow-elevated)] hover:shadow-[var(--shadow-elevated)]',
+        className
+      )}
+      {...rest}
+    >
+      {children}
+    </Component>
+  );
+}
+
+export interface CardHeaderProps extends Omit<ComponentPropsWithoutRef<'div'>, 'title'> {
+  title: ReactNode;
+  subtitle?: ReactNode;
+  action?: ReactNode;
+}
+
+export function CardHeader({ title, subtitle, action, className, ...rest }: CardHeaderProps) {
+  return (
+    <div className={cn('flex items-start justify-between gap-4', className)} {...rest}>
+      <div>
+        <h3 className="font-display text-ink-900 text-base font-semibold">{title}</h3>
+        {subtitle ? <p className="text-ink-500 mt-1 text-sm">{subtitle}</p> : null}
+      </div>
+      {action ? <div className="shrink-0">{action}</div> : null}
+    </div>
+  );
+}

--- a/apps/web/src/components/ui/EmptyState.tsx
+++ b/apps/web/src/components/ui/EmptyState.tsx
@@ -1,0 +1,39 @@
+import type { ComponentPropsWithoutRef, ReactNode } from 'react';
+import { cn } from './cn';
+
+export interface EmptyStateProps extends ComponentPropsWithoutRef<'div'> {
+  title: string;
+  description?: ReactNode;
+  icon?: ReactNode;
+  action?: ReactNode;
+}
+
+export function EmptyState({
+  title,
+  description,
+  icon,
+  action,
+  className,
+  ...rest
+}: EmptyStateProps) {
+  return (
+    <div
+      role="status"
+      className={cn(
+        'flex flex-col items-center justify-center gap-3 rounded-3xl bg-white p-10 text-center',
+        'border border-dashed border-[color:var(--color-line-soft)]',
+        className
+      )}
+      {...rest}
+    >
+      {icon ? (
+        <span aria-hidden="true" className="bg-brand-50 text-brand-600 rounded-full p-3">
+          {icon}
+        </span>
+      ) : null}
+      <h3 className="font-display text-ink-900 text-lg font-semibold">{title}</h3>
+      {description ? <p className="text-ink-500 max-w-sm text-sm">{description}</p> : null}
+      {action ? <div className="mt-2">{action}</div> : null}
+    </div>
+  );
+}

--- a/apps/web/src/components/ui/ErrorState.tsx
+++ b/apps/web/src/components/ui/ErrorState.tsx
@@ -1,0 +1,39 @@
+import type { ComponentPropsWithoutRef, ReactNode } from 'react';
+import { cn } from './cn';
+
+export interface ErrorStateProps extends ComponentPropsWithoutRef<'div'> {
+  title: string;
+  description?: ReactNode;
+  icon?: ReactNode;
+  action?: ReactNode;
+}
+
+export function ErrorState({
+  title,
+  description,
+  icon,
+  action,
+  className,
+  ...rest
+}: ErrorStateProps) {
+  return (
+    <div
+      role="alert"
+      className={cn(
+        'flex flex-col items-center justify-center gap-3 rounded-3xl bg-rose-50 p-10 text-center',
+        'border border-rose-100',
+        className
+      )}
+      {...rest}
+    >
+      {icon ? (
+        <span aria-hidden="true" className="rounded-full bg-rose-100 p-3 text-rose-600">
+          {icon}
+        </span>
+      ) : null}
+      <h3 className="font-display text-lg font-semibold text-rose-700">{title}</h3>
+      {description ? <p className="max-w-sm text-sm text-rose-700/80">{description}</p> : null}
+      {action ? <div className="mt-2">{action}</div> : null}
+    </div>
+  );
+}

--- a/apps/web/src/components/ui/IconButton.tsx
+++ b/apps/web/src/components/ui/IconButton.tsx
@@ -1,0 +1,56 @@
+import type { ComponentPropsWithoutRef, ReactNode } from 'react';
+import { cn } from './cn';
+
+export type IconButtonVariant = 'primary' | 'secondary' | 'ghost';
+export type IconButtonSize = 'sm' | 'md' | 'lg';
+
+export interface IconButtonProps extends ComponentPropsWithoutRef<'button'> {
+  /** Etiqueta accesible obligatoria: el botón sólo contiene un icono. */
+  label: string;
+  icon: ReactNode;
+  variant?: IconButtonVariant;
+  size?: IconButtonSize;
+}
+
+const VARIANT_STYLES: Record<IconButtonVariant, string> = {
+  primary: 'bg-brand-500 text-white hover:bg-brand-600 active:bg-brand-700',
+  secondary:
+    'bg-white text-ink-700 border border-[color:var(--color-line-soft)] hover:border-brand-300 hover:text-brand-700',
+  ghost: 'bg-transparent text-ink-500 hover:bg-surface-muted hover:text-ink-900',
+};
+
+const SIZE_STYLES: Record<IconButtonSize, string> = {
+  sm: 'h-8 w-8 text-sm',
+  md: 'h-10 w-10 text-base',
+  lg: 'h-12 w-12 text-lg',
+};
+
+export function IconButton({
+  label,
+  icon,
+  variant = 'ghost',
+  size = 'md',
+  className,
+  type = 'button',
+  ...rest
+}: IconButtonProps) {
+  return (
+    <button
+      type={type}
+      aria-label={label}
+      className={cn(
+        'inline-flex shrink-0 items-center justify-center rounded-full transition-colors',
+        'focus-visible:ring-brand-300 focus-visible:ring-2 focus-visible:ring-offset-2',
+        'disabled:cursor-not-allowed disabled:opacity-60',
+        VARIANT_STYLES[variant],
+        SIZE_STYLES[size],
+        className
+      )}
+      {...rest}
+    >
+      <span aria-hidden="true" className="inline-flex">
+        {icon}
+      </span>
+    </button>
+  );
+}

--- a/apps/web/src/components/ui/Progress.tsx
+++ b/apps/web/src/components/ui/Progress.tsx
@@ -1,0 +1,79 @@
+import type { ComponentPropsWithoutRef } from 'react';
+import { cn } from './cn';
+
+export type ProgressTone = 'brand' | 'success' | 'warning' | 'danger';
+export type ProgressSize = 'sm' | 'md';
+
+export interface ProgressProps extends Omit<ComponentPropsWithoutRef<'div'>, 'children'> {
+  value: number;
+  max?: number;
+  min?: number;
+  tone?: ProgressTone;
+  size?: ProgressSize;
+  label: string;
+  /** Si `true`, esconde la etiqueta del nombre (sólo accesible). */
+  hideLabel?: boolean;
+  /** Texto mostrado a la derecha (por defecto `${value}%`). */
+  valueText?: string;
+}
+
+const TONE_STYLES: Record<ProgressTone, string> = {
+  brand: 'bg-gradient-to-r from-brand-400 to-brand-600',
+  success: 'bg-emerald-500',
+  warning: 'bg-amber-500',
+  danger: 'bg-rose-500',
+};
+
+const SIZE_STYLES: Record<ProgressSize, string> = {
+  sm: 'h-1.5',
+  md: 'h-2.5',
+};
+
+function clamp(value: number, min: number, max: number): number {
+  if (Number.isNaN(value)) return min;
+  return Math.min(Math.max(value, min), max);
+}
+
+export function Progress({
+  value,
+  max = 100,
+  min = 0,
+  tone = 'brand',
+  size = 'md',
+  label,
+  hideLabel = false,
+  valueText,
+  className,
+  style,
+  ...rest
+}: ProgressProps) {
+  const safeValue = clamp(value, min, max);
+  const percent = ((safeValue - min) / (max - min)) * 100;
+  const display = valueText ?? `${Math.round(percent)}%`;
+
+  return (
+    <div className={cn('flex flex-col gap-1.5', className)} {...rest}>
+      {hideLabel ? null : (
+        <div className="flex items-center justify-between text-xs">
+          <span className="text-ink-500 font-medium">{label}</span>
+          <span className="text-ink-900 font-semibold">{display}</span>
+        </div>
+      )}
+      <div
+        role="progressbar"
+        aria-label={label}
+        aria-valuemin={min}
+        aria-valuemax={max}
+        aria-valuenow={safeValue}
+        aria-valuetext={display}
+        className={cn('bg-surface-muted w-full overflow-hidden rounded-full', SIZE_STYLES[size])}
+        style={style}
+      >
+        <div
+          className={cn('h-full rounded-full transition-[width] duration-500', TONE_STYLES[tone])}
+          style={{ width: `${percent}%` }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/ui/Skeleton.tsx
+++ b/apps/web/src/components/ui/Skeleton.tsx
@@ -1,0 +1,31 @@
+import type { ComponentPropsWithoutRef } from 'react';
+import { cn } from './cn';
+
+export type SkeletonShape = 'rect' | 'circle' | 'text';
+
+export interface SkeletonProps extends ComponentPropsWithoutRef<'div'> {
+  shape?: SkeletonShape;
+}
+
+const SHAPE_STYLES: Record<SkeletonShape, string> = {
+  rect: 'rounded-2xl',
+  circle: 'rounded-full',
+  text: 'rounded-md',
+};
+
+export function Skeleton({ shape = 'rect', className, ...rest }: SkeletonProps) {
+  return (
+    <div
+      aria-hidden="true"
+      data-testid="skeleton"
+      className={cn(
+        'bg-surface-muted relative overflow-hidden',
+        'before:absolute before:inset-0 before:-translate-x-full before:animate-[shimmer_1.6s_infinite]',
+        'before:bg-gradient-to-r before:from-transparent before:via-white/70 before:to-transparent',
+        SHAPE_STYLES[shape],
+        className
+      )}
+      {...rest}
+    />
+  );
+}

--- a/apps/web/src/components/ui/Stat.tsx
+++ b/apps/web/src/components/ui/Stat.tsx
@@ -1,0 +1,40 @@
+import type { ComponentPropsWithoutRef, ReactNode } from 'react';
+import { cn } from './cn';
+
+export interface StatProps extends ComponentPropsWithoutRef<'div'> {
+  label: string;
+  value: ReactNode;
+  hint?: ReactNode;
+  trend?: {
+    direction: 'up' | 'down' | 'flat';
+    label: string;
+  };
+}
+
+const TREND_COLOR: Record<'up' | 'down' | 'flat', string> = {
+  up: 'text-emerald-600',
+  down: 'text-rose-600',
+  flat: 'text-ink-500',
+};
+
+export function Stat({ label, value, hint, trend, className, ...rest }: StatProps) {
+  return (
+    <div
+      className={cn(
+        'flex flex-col gap-1 rounded-2xl bg-white p-4',
+        'border border-[color:var(--color-line-soft)]',
+        className
+      )}
+      {...rest}
+    >
+      <span className="text-ink-500 text-xs font-medium tracking-wide uppercase">{label}</span>
+      <span className="font-display text-ink-900 text-2xl font-bold">{value}</span>
+      <div className="flex items-center gap-2 text-xs">
+        {trend ? (
+          <span className={cn('font-semibold', TREND_COLOR[trend.direction])}>{trend.label}</span>
+        ) : null}
+        {hint ? <span className="text-ink-500">{hint}</span> : null}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/ui/Tag.tsx
+++ b/apps/web/src/components/ui/Tag.tsx
@@ -1,0 +1,53 @@
+import type { ComponentPropsWithoutRef, ReactNode } from 'react';
+import { cn } from './cn';
+
+export type TagTone = 'neutral' | 'brand' | 'success' | 'warning' | 'danger' | 'info';
+export type TagSize = 'sm' | 'md';
+
+export interface TagProps extends ComponentPropsWithoutRef<'span'> {
+  tone?: TagTone;
+  size?: TagSize;
+  icon?: ReactNode;
+}
+
+const TONE_STYLES: Record<TagTone, string> = {
+  neutral: 'bg-surface-muted text-ink-700 border-[color:var(--color-line-soft)]',
+  brand: 'bg-brand-50 text-brand-700 border-brand-100',
+  success: 'bg-emerald-50 text-emerald-700 border-emerald-100',
+  warning: 'bg-amber-50 text-amber-700 border-amber-100',
+  danger: 'bg-rose-50 text-rose-700 border-rose-100',
+  info: 'bg-sky-50 text-sky-700 border-sky-100',
+};
+
+const SIZE_STYLES: Record<TagSize, string> = {
+  sm: 'h-6 px-2.5 text-xs gap-1',
+  md: 'h-7 px-3 text-sm gap-1.5',
+};
+
+export function Tag({
+  tone = 'neutral',
+  size = 'sm',
+  icon,
+  className,
+  children,
+  ...rest
+}: TagProps) {
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center rounded-full border font-medium whitespace-nowrap',
+        TONE_STYLES[tone],
+        SIZE_STYLES[size],
+        className
+      )}
+      {...rest}
+    >
+      {icon ? (
+        <span aria-hidden="true" className="inline-flex shrink-0">
+          {icon}
+        </span>
+      ) : null}
+      {children}
+    </span>
+  );
+}

--- a/apps/web/src/components/ui/__tests__/Avatar.test.tsx
+++ b/apps/web/src/components/ui/__tests__/Avatar.test.tsx
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { Avatar } from '../Avatar';
+
+describe('Avatar', () => {
+  it('usa el nombre como aria-label', () => {
+    render(<Avatar name="Alex Romero" />);
+    expect(screen.getByRole('img', { name: 'Alex Romero' })).toBeInTheDocument();
+  });
+
+  it('muestra iniciales cuando no hay imagen', () => {
+    render(<Avatar name="Ana Pérez" />);
+    expect(screen.getByText('AP')).toBeInTheDocument();
+  });
+
+  it('renderiza la imagen cuando se proporciona src', () => {
+    render(<Avatar name="Alex" src="/avatar.png" />);
+    const img = screen.getByRole('img', { name: 'Alex' }).querySelector('img');
+    expect(img).not.toBeNull();
+    expect(img).toHaveAttribute('src', '/avatar.png');
+  });
+});

--- a/apps/web/src/components/ui/__tests__/Button.test.tsx
+++ b/apps/web/src/components/ui/__tests__/Button.test.tsx
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Button } from '../Button';
+
+describe('Button', () => {
+  it('renderiza el texto y expone un nombre accesible', () => {
+    render(<Button>Nuevo análisis</Button>);
+    const button = screen.getByRole('button', { name: 'Nuevo análisis' });
+    expect(button).toBeInTheDocument();
+    expect(button).toHaveAttribute('type', 'button');
+  });
+
+  it('reacciona al clic y admite estado deshabilitado', async () => {
+    const user = userEvent.setup();
+    const onClick = vi.fn();
+    const { rerender } = render(<Button onClick={onClick}>Enviar</Button>);
+    await user.click(screen.getByRole('button', { name: 'Enviar' }));
+    expect(onClick).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <Button onClick={onClick} disabled>
+        Enviar
+      </Button>
+    );
+    await user.click(screen.getByRole('button', { name: 'Enviar' }));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('aplica estilos de variante primaria por defecto', () => {
+    render(<Button>Primario</Button>);
+    const button = screen.getByRole('button', { name: 'Primario' });
+    expect(button.className).toMatch(/bg-brand-500/);
+  });
+});

--- a/apps/web/src/components/ui/__tests__/Card.test.tsx
+++ b/apps/web/src/components/ui/__tests__/Card.test.tsx
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { Card, CardHeader } from '../Card';
+
+describe('Card', () => {
+  it('renderiza children en un contenedor con esquinas redondeadas', () => {
+    render(
+      <Card data-testid="card">
+        <p>Contenido</p>
+      </Card>
+    );
+    const card = screen.getByTestId('card');
+    expect(card).toBeInTheDocument();
+    expect(card.className).toMatch(/rounded-3xl/);
+    expect(screen.getByText('Contenido')).toBeInTheDocument();
+  });
+
+  it('CardHeader muestra título y subtítulo semánticos', () => {
+    render(
+      <Card>
+        <CardHeader title="Tendencias" subtitle="Últimos 12 meses" />
+      </Card>
+    );
+    expect(screen.getByRole('heading', { level: 3, name: 'Tendencias' })).toBeInTheDocument();
+    expect(screen.getByText('Últimos 12 meses')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/ui/__tests__/IconButton.test.tsx
+++ b/apps/web/src/components/ui/__tests__/IconButton.test.tsx
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { IconButton } from '../IconButton';
+
+describe('IconButton', () => {
+  it('usa label como aria-label', () => {
+    render(<IconButton label="Notificaciones" icon={<span data-testid="icon" />} />);
+    const button = screen.getByRole('button', { name: 'Notificaciones' });
+    expect(button).toBeInTheDocument();
+    expect(screen.getByTestId('icon')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/ui/__tests__/Progress.test.tsx
+++ b/apps/web/src/components/ui/__tests__/Progress.test.tsx
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { Progress } from '../Progress';
+
+describe('Progress', () => {
+  it('expone role="progressbar" con valores ARIA correctos', () => {
+    render(<Progress label="Índice de oportunidad" value={72} />);
+    const bar = screen.getByRole('progressbar', { name: 'Índice de oportunidad' });
+    expect(bar).toHaveAttribute('aria-valuemin', '0');
+    expect(bar).toHaveAttribute('aria-valuemax', '100');
+    expect(bar).toHaveAttribute('aria-valuenow', '72');
+  });
+
+  it('limita valores fuera de rango', () => {
+    render(<Progress label="Test" value={150} hideLabel />);
+    const bar = screen.getByRole('progressbar', { name: 'Test' });
+    expect(bar).toHaveAttribute('aria-valuenow', '100');
+  });
+});

--- a/apps/web/src/components/ui/__tests__/Tag.test.tsx
+++ b/apps/web/src/components/ui/__tests__/Tag.test.tsx
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { Tag } from '../Tag';
+
+describe('Tag', () => {
+  it('muestra el contenido con el tono por defecto', () => {
+    render(<Tag>Demo</Tag>);
+    const tag = screen.getByText('Demo');
+    expect(tag).toBeInTheDocument();
+    expect(tag.className).toMatch(/rounded-full/);
+  });
+
+  it('aplica la paleta cuando tono=brand', () => {
+    render(<Tag tone="brand">Recomendado</Tag>);
+    const tag = screen.getByText('Recomendado');
+    expect(tag.className).toMatch(/bg-brand-50/);
+  });
+});

--- a/apps/web/src/components/ui/cn.ts
+++ b/apps/web/src/components/ui/cn.ts
@@ -1,0 +1,9 @@
+import clsx, { type ClassValue } from 'clsx';
+
+/**
+ * Combina clases usando `clsx` manteniendo el orden estable que espera
+ * `prettier-plugin-tailwindcss`. Es el helper canónico del sistema.
+ */
+export function cn(...inputs: ClassValue[]): string {
+  return clsx(...inputs);
+}

--- a/apps/web/src/components/ui/index.ts
+++ b/apps/web/src/components/ui/index.ts
@@ -1,0 +1,24 @@
+export { cn } from './cn';
+export { Avatar, type AvatarProps, type AvatarSize } from './Avatar';
+export { Badge, type BadgeProps, type BadgeTone } from './Badge';
+export { Button, type ButtonProps, type ButtonSize, type ButtonVariant } from './Button';
+export {
+  Card,
+  CardHeader,
+  type CardHeaderProps,
+  type CardPadding,
+  type CardProps,
+  type CardTone,
+} from './Card';
+export { EmptyState, type EmptyStateProps } from './EmptyState';
+export { ErrorState, type ErrorStateProps } from './ErrorState';
+export {
+  IconButton,
+  type IconButtonProps,
+  type IconButtonSize,
+  type IconButtonVariant,
+} from './IconButton';
+export { Progress, type ProgressProps, type ProgressSize, type ProgressTone } from './Progress';
+export { Skeleton, type SkeletonProps, type SkeletonShape } from './Skeleton';
+export { Stat, type StatProps } from './Stat';
+export { Tag, type TagProps, type TagSize, type TagTone } from './Tag';

--- a/apps/web/src/features/dashboard/DashboardShell.tsx
+++ b/apps/web/src/features/dashboard/DashboardShell.tsx
@@ -1,19 +1,192 @@
+import { useMemo, useState } from 'react';
+import {
+  Activity,
+  BarChart3,
+  Building2,
+  GitCompareArrows,
+  Map as MapIcon,
+  Sparkles,
+  Wallet,
+  Wifi,
+  Wrench,
+} from 'lucide-react';
+import { ActionCards, type ActionCardItem } from '@/components/layout/ActionCards';
+import { ChipFilters, type ChipFilterOption } from '@/components/layout/ChipFilters';
+import { DashboardLayout } from '@/components/layout/DashboardLayout';
+import { OpportunityIndex } from '@/components/layout/OpportunityIndex';
+import { Badge } from '@/components/ui/Badge';
+import { Card, CardHeader } from '@/components/ui/Card';
+import { Tag } from '@/components/ui/Tag';
+import { Skeleton } from '@/components/ui/Skeleton';
+
+const CHIP_OPTIONS: ChipFilterOption[] = [
+  { id: 'quality', label: 'Calidad de vida', icon: <Sparkles size={14} /> },
+  { id: 'housing', label: 'Vivienda asequible', icon: <Building2 size={14} /> },
+  { id: 'jobs', label: 'Empleo', icon: <Wallet size={14} /> },
+  { id: 'connectivity', label: 'Conectividad', icon: <Wifi size={14} /> },
+  { id: 'more', label: 'Más filtros', icon: <Wrench size={14} /> },
+];
+
+const ACTION_ITEMS: ActionCardItem[] = [
+  {
+    id: 'explore',
+    title: 'Explorar',
+    description: 'Recorre el mapa y descubre municipios que encajan con tu perfil.',
+    icon: <MapIcon size={18} />,
+    accent: 'brand',
+    href: '#mapa',
+  },
+  {
+    id: 'recommend',
+    title: 'Recomendar',
+    description: 'Obtén sugerencias personalizadas con explicaciones claras.',
+    icon: <Sparkles size={18} />,
+    accent: 'emerald',
+    href: '#recomendador',
+  },
+  {
+    id: 'compare',
+    title: 'Comparar',
+    description: 'Pon dos o más territorios cara a cara con indicadores medibles.',
+    icon: <GitCompareArrows size={18} />,
+    accent: 'sky',
+    href: '#comparador',
+  },
+  {
+    id: 'analyze',
+    title: 'Analizar',
+    description: 'Entra al modo técnico para SPARQL, SHACL y reportes avanzados.',
+    icon: <BarChart3 size={18} />,
+    accent: 'amber',
+    href: '#modo-tecnico',
+  },
+];
+
+/**
+ * Dashboard principal. Ensambla el layout con Sidebar + Topbar + hero + panel
+ * lateral + cards de acción. Usa datos mock y expone slots para que otros
+ * teammates introduzcan el mapa real, el ranking y los widgets de tendencias.
+ */
 export function DashboardShell() {
-  return (
-    <main className="flex min-h-screen items-center justify-center p-12">
-      <div className="shadow-card mx-auto max-w-xl rounded-2xl bg-white p-10">
-        <p className="text-brand-600 text-xs font-semibold tracking-[0.18em] uppercase">
-          AtlasHabita
-        </p>
-        <h1 className="font-display text-ink-900 mt-3 text-3xl font-bold">
-          Brújula territorial para decidir dónde vivir
-        </h1>
-        <p className="text-ink-500 mt-4">
-          Esqueleto inicial del frontend. La pantalla principal con sidebar, mapa, ranking y panel
-          de tendencias se construye en las issues #21-#26 según el sistema de diseño extraído de la
-          captura de referencia.
-        </p>
-      </div>
-    </main>
+  const [activeChips, setActiveChips] = useState<string[]>(['quality']);
+
+  const hero = useMemo(
+    () => (
+      <section
+        aria-labelledby="dashboard-title"
+        className="from-brand-500 via-brand-500 to-brand-600 relative overflow-hidden rounded-3xl bg-gradient-to-br p-8 text-white shadow-[var(--shadow-elevated)]"
+      >
+        <div
+          aria-hidden="true"
+          className="pointer-events-none absolute -top-24 -right-20 h-64 w-64 rounded-full bg-white/20 blur-3xl"
+        />
+        <div
+          aria-hidden="true"
+          className="pointer-events-none absolute -bottom-32 -left-10 h-80 w-80 rounded-full bg-emerald-300/30 blur-3xl"
+        />
+        <div className="relative flex flex-col gap-6">
+          <div className="flex flex-wrap items-center gap-3">
+            <Tag tone="brand" size="md" className="border-transparent bg-white/15 text-white">
+              <Sparkles size={14} aria-hidden="true" />
+              Demo con datos abiertos
+            </Tag>
+            <Badge tone="success" className="border border-white/20 bg-white/15 text-white">
+              Modelo explicable
+            </Badge>
+          </div>
+          <div className="flex flex-col gap-3">
+            <h1
+              id="dashboard-title"
+              className="font-display max-w-3xl text-3xl leading-tight font-bold sm:text-4xl"
+            >
+              Descubre el <span className="text-emerald-100">mejor lugar</span> para vivir en España
+            </h1>
+            <p className="max-w-xl text-base text-white/80">
+              Explora, compara y encuentra tu lugar ideal con datos abiertos y tecnología semántica.
+              Todo con explicaciones claras, sin cajas negras.
+            </p>
+          </div>
+          <ChipFilters
+            options={CHIP_OPTIONS}
+            value={activeChips}
+            tone="onBrand"
+            onToggle={(id) =>
+              setActiveChips((prev) =>
+                prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]
+              )
+            }
+          />
+          <Card
+            tone="base"
+            padding="none"
+            className="text-ink-500 mt-2 flex min-h-72 items-center justify-center overflow-hidden"
+          >
+            <div className="flex w-full flex-col items-center gap-2 p-10 text-center">
+              <MapIcon aria-hidden="true" size={28} className="text-brand-500" />
+              <p className="text-ink-700 text-sm font-medium">Mapa interactivo en preparación</p>
+              <p className="text-ink-500 text-xs">
+                El slot del mapa y el ranking se enchufa desde otros módulos. Esta vista renderiza
+                el shell, los tokens y las primitivas.
+              </p>
+            </div>
+          </Card>
+        </div>
+      </section>
+    ),
+    [activeChips]
   );
+
+  const side = (
+    <>
+      <Card tone="base" padding="md" className="flex flex-col gap-4">
+        <CardHeader
+          title="Recomendación destacada"
+          subtitle="Coincide con tu perfil actual"
+          action={<Badge tone="brand">Top 3</Badge>}
+        />
+        <div className="flex items-center gap-3">
+          <span
+            aria-hidden="true"
+            className="bg-brand-50 text-brand-600 inline-flex h-12 w-12 items-center justify-center rounded-2xl"
+          >
+            <Building2 size={22} />
+          </span>
+          <div>
+            <p className="font-display text-ink-900 text-base font-semibold">
+              San Sebastián, Guipúzcoa
+            </p>
+            <p className="text-ink-500 text-xs">
+              Conectividad alta · Calidad de vida · Entorno natural
+            </p>
+          </div>
+        </div>
+        <OpportunityIndex value={86} description="Encaja con tus prioridades actuales." />
+      </Card>
+
+      <Card tone="base" padding="md" className="flex flex-col gap-3">
+        <CardHeader title="Tendencias" subtitle="Últimos 12 meses" />
+        <Skeleton className="h-36 w-full" />
+        <div className="text-ink-500 flex items-center justify-between text-xs">
+          <span>Índice medio</span>
+          <span className="font-semibold text-emerald-600">+4.2%</span>
+        </div>
+      </Card>
+
+      <Card tone="soft" padding="md" className="flex flex-col gap-3">
+        <CardHeader title="Actividad reciente" subtitle="Sincronización ETL" />
+        <ul className="text-ink-700 flex flex-col gap-2 text-sm">
+          <li className="flex items-center gap-2">
+            <Activity size={14} aria-hidden="true" className="text-brand-500" />
+            Dataset INE actualizado hace 2 h
+          </li>
+          <li className="flex items-center gap-2">
+            <Activity size={14} aria-hidden="true" className="text-brand-500" />
+            Nueva validación SHACL completada
+          </li>
+        </ul>
+      </Card>
+    </>
+  );
+
+  return <DashboardLayout hero={hero} side={side} footer={<ActionCards items={ACTION_ITEMS} />} />;
 }

--- a/apps/web/src/features/dashboard/__tests__/DashboardShell.test.tsx
+++ b/apps/web/src/features/dashboard/__tests__/DashboardShell.test.tsx
@@ -3,8 +3,17 @@ import { describe, expect, it } from 'vitest';
 import { DashboardShell } from '../DashboardShell';
 
 describe('DashboardShell', () => {
-  it('muestra el titular inicial del proyecto', () => {
+  it('muestra el hero con el titular principal de AtlasHabita', () => {
     render(<DashboardShell />);
-    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(/brújula territorial/i);
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(
+      /mejor lugar para vivir en España/i
+    );
+  });
+
+  it('compone el shell con sidebar, topbar y panel lateral', () => {
+    render(<DashboardShell />);
+    expect(screen.getByRole('navigation', { name: 'Navegación principal' })).toBeInTheDocument();
+    expect(screen.getByRole('searchbox', { name: 'Buscar en AtlasHabita' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Nuevo análisis/i })).toBeInTheDocument();
   });
 });

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -1,4 +1,5 @@
 @import 'tailwindcss';
+@import './tokens.css';
 
 @theme {
   --color-brand-50: #ecfdf5;

--- a/apps/web/src/styles/tokens.css
+++ b/apps/web/src/styles/tokens.css
@@ -1,0 +1,32 @@
+/**
+ * Tokens de diseño complementarios para AtlasHabita.
+ *
+ * Extienden los definidos en `globals.css` siguiendo la paleta verde-turquesa,
+ * las tipografías Plus Jakarta Sans / Inter y la densidad generosa de la
+ * captura de referencia. Esta capa no sustituye los tokens previos: los
+ * reutiliza y añade rampas y semánticos adicionales que consumen las
+ * primitivas UI y el shell del dashboard.
+ */
+
+@theme {
+  /* Alias semánticos sobre la rampa "brand" existente. */
+  --color-brand-primary: var(--color-brand-500);
+  --color-brand-strong: var(--color-brand-600);
+  --color-brand-contrast: #ffffff;
+
+  /* Colores semánticos para estados. */
+  --color-success-500: #10b981;
+  --color-warning-500: #f59e0b;
+  --color-danger-500: #ef4444;
+  --color-info-500: #0ea5e9;
+
+  /* Bordes suaves para tarjetas y paneles. */
+  --color-line-soft: #e6ebe8;
+  --color-line-strong: #cdd5d0;
+}
+
+@keyframes shimmer {
+  100% {
+    transform: translateX(100%);
+  }
+}


### PR DESCRIPTION
## Resumen

Sistema de diseño AtlasHabita alineado a la captura de referencia: tokens ampliados, 11 primitivas UI (Card, Button, Tag, Badge, Avatar, Stat, Skeleton, EmptyState, ErrorState, Progress, IconButton), layout (Sidebar, Topbar, DashboardLayout, LayersPanel, UserCard, OpportunityIndex, ActionCards, ChipFilters) y `DashboardShell` ensamblado con slots.

## Issues

Closes #21
Closes #22
Closes #25
Closes #26

## Verificación

- `pnpm format:check`, `pnpm lint`, `pnpm test` (24 tests) y `pnpm vite build` en verde.
- Accesibilidad AA: landmarks, `aria-current`, focus ring con token `--color-brand-300`.
- Sin dependencias nuevas.

## Notas

- `pnpm build` (`tsc --noEmit && vite build`) falla por un conflicto de tipos vite 5/6 preexistente en `vitest.config.ts` (fuera del alcance de esta PR). El build real con `vite build` produce `254 kB` (78 kB gz).