### PR TITLE
feat(web): mapa, tendencias, actividad y recomendación destacada

### DIFF
--- a/apps/web/src/data/mock.ts
+++ b/apps/web/src/data/mock.ts
@@ -1,0 +1,216 @@
+/**
+ * Mock data para los primeros hitos del dashboard de AtlasHabita.
+ *
+ * Los municipios y coordenadas proceden de `data/seed/territories.csv` y
+ * corresponden a centroides reales. Este fichero debe desaparecer cuando la
+ * capa de servicios (`/api/map`, `/api/recommendations`, etc.) esté operativa;
+ * entre tanto permite maquetar la UI sin acoplarse al backend.
+ */
+
+export type MapPoint = {
+  /** Identificador INE del municipio. */
+  id: string;
+  /** Nombre del territorio mostrado al usuario. */
+  name: string;
+  /** Latitud WGS84 del centroide. */
+  lat: number;
+  /** Longitud WGS84 del centroide. */
+  lon: number;
+  /**
+   * Indicador principal representado en el mapa (p.ej. renta bruta media,
+   * precio de alquiler, etc.). Se expresa en euros cuando no se indica otra
+   * unidad.
+   */
+  value: number;
+  /**
+   * Score agregado en el rango [0, 100]. Se usa para colorear el círculo en
+   * una escala verde oscuro → verde claro.
+   */
+  score: number;
+};
+
+export type TrendPoint = {
+  month: string;
+  score: number;
+  rentIndex: number;
+};
+
+export type ActivityItem = {
+  id: string;
+  title: string;
+  description: string;
+  timestamp: string;
+  icon: 'map' | 'sparkles' | 'chart' | 'bookmark' | 'users';
+};
+
+export type HighlightAttribute = {
+  label: string;
+  value: string;
+};
+
+export type Highlight = {
+  id: string;
+  name: string;
+  region: string;
+  headline: string;
+  description: string;
+  score: number;
+  attributes: HighlightAttribute[];
+};
+
+/**
+ * 10 municipios reales con centroides tomados de `data/seed/territories.csv`.
+ * El orden refleja aproximadamente el ranking visible en la captura de
+ * referencia.
+ */
+export const mockPoints: MapPoint[] = [
+  {
+    id: '20069',
+    name: 'Donostia / San Sebastián',
+    lat: 43.3183,
+    lon: -1.9812,
+    value: 1280,
+    score: 92,
+  },
+  {
+    id: '29067',
+    name: 'Málaga',
+    lat: 36.7213,
+    lon: -4.4213,
+    value: 950,
+    score: 87,
+  },
+  {
+    id: '41091',
+    name: 'Sevilla',
+    lat: 37.3886,
+    lon: -5.9823,
+    value: 820,
+    score: 81,
+  },
+  {
+    id: '20036',
+    name: 'Irún',
+    lat: 43.3384,
+    lon: -1.7886,
+    value: 870,
+    score: 76,
+  },
+  {
+    id: '29069',
+    name: 'Marbella',
+    lat: 36.5108,
+    lon: -4.8824,
+    value: 1120,
+    score: 72,
+  },
+  {
+    id: '20038',
+    name: 'Hondarribia',
+    lat: 43.36,
+    lon: -1.7956,
+    value: 910,
+    score: 68,
+  },
+  {
+    id: '41038',
+    name: 'Dos Hermanas',
+    lat: 37.2833,
+    lon: -5.925,
+    value: 720,
+    score: 63,
+  },
+  {
+    id: '29054',
+    name: 'Fuengirola',
+    lat: 36.5397,
+    lon: -4.625,
+    value: 980,
+    score: 58,
+  },
+  {
+    id: '41004',
+    name: 'Alcalá de Guadaíra',
+    lat: 37.3372,
+    lon: -5.8428,
+    value: 690,
+    score: 49,
+  },
+  {
+    id: '20071',
+    name: 'Tolosa',
+    lat: 43.1361,
+    lon: -2.0783,
+    value: 780,
+    score: 41,
+  },
+];
+
+export const mockTrends: TrendPoint[] = [
+  { month: 'May', score: 62, rentIndex: 71 },
+  { month: 'Jun', score: 64, rentIndex: 72 },
+  { month: 'Jul', score: 66, rentIndex: 73 },
+  { month: 'Ago', score: 68, rentIndex: 74 },
+  { month: 'Sep', score: 70, rentIndex: 76 },
+  { month: 'Oct', score: 71, rentIndex: 77 },
+  { month: 'Nov', score: 73, rentIndex: 78 },
+  { month: 'Dic', score: 74, rentIndex: 79 },
+  { month: 'Ene', score: 75, rentIndex: 80 },
+  { month: 'Feb', score: 78, rentIndex: 82 },
+  { month: 'Mar', score: 81, rentIndex: 83 },
+  { month: 'Abr', score: 84, rentIndex: 85 },
+];
+
+export const mockActivity: ActivityItem[] = [
+  {
+    id: 'act-1',
+    title: 'Nuevo ranking para Donostia / San Sebastián',
+    description: 'El score de calidad de vida subió 4 puntos tras la última ingesta del INE.',
+    timestamp: 'hace 5 min',
+    icon: 'sparkles',
+  },
+  {
+    id: 'act-2',
+    title: 'Capa de conectividad actualizada',
+    description: 'Cobertura de fibra óptica re-procesada para 318 municipios.',
+    timestamp: 'hace 42 min',
+    icon: 'map',
+  },
+  {
+    id: 'act-3',
+    title: 'Tendencia de alquiler en Málaga',
+    description: 'El precio medio creció un 1,8% mensual en el último trimestre.',
+    timestamp: 'hace 2 h',
+    icon: 'chart',
+  },
+  {
+    id: 'act-4',
+    title: 'Territorio guardado',
+    description: 'Sevilla se añadió a tu lista “Candidatos 2026”.',
+    timestamp: 'hace 1 d',
+    icon: 'bookmark',
+  },
+  {
+    id: 'act-5',
+    title: '12 nuevos perfiles comparables',
+    description: 'Detectamos municipios con patrón socioeconómico similar al tuyo.',
+    timestamp: 'hace 2 d',
+    icon: 'users',
+  },
+];
+
+export const mockHighlight: Highlight = {
+  id: '20069',
+  name: 'Donostia / San Sebastián',
+  region: 'Guipúzcoa · País Vasco',
+  headline: 'Recomendación destacada para teletrabajo',
+  description:
+    'Combina conectividad de fibra casi universal, servicios cotidianos abundantes y un entorno natural excepcional frente al Cantábrico.',
+  score: 92,
+  attributes: [
+    { label: 'Calidad de vida', value: 'Alta' },
+    { label: 'Conectividad', value: '98% fibra' },
+    { label: 'Alquiler medio', value: '1.280 €' },
+    { label: 'Transporte', value: 'Excelente' },
+  ],
+};

--- a/apps/web/src/features/activity/ActivityFeed.tsx
+++ b/apps/web/src/features/activity/ActivityFeed.tsx
@@ -1,0 +1,71 @@
+import {
+  Bookmark,
+  LineChart,
+  Map as MapIcon,
+  Sparkles,
+  Users,
+  type LucideIcon,
+} from 'lucide-react';
+
+import type { ActivityItem } from '@/data/mock';
+
+export type ActivityFeedProps = {
+  items: ActivityItem[];
+  title?: string;
+  className?: string;
+};
+
+const ICONS: Record<ActivityItem['icon'], LucideIcon> = {
+  map: MapIcon,
+  sparkles: Sparkles,
+  chart: LineChart,
+  bookmark: Bookmark,
+  users: Users,
+};
+
+/**
+ * Feed vertical de actividad reciente. Cada entrada contiene un icono, un
+ * título, una descripción breve y un timestamp relativo. El componente es
+ * accesible: se anuncia como lista y cada icono va marcado como decorativo.
+ */
+export function ActivityFeed({
+  items,
+  title = 'Actividad reciente',
+  className,
+}: ActivityFeedProps) {
+  return (
+    <section
+      aria-label={title}
+      className={['rounded-2xl bg-white p-6 shadow-[var(--shadow-card)]', className ?? '']
+        .filter(Boolean)
+        .join(' ')}
+    >
+      <header className="mb-4 flex items-center justify-between">
+        <h3 className="font-display text-ink-900 text-lg font-semibold">{title}</h3>
+        <button type="button" className="text-brand-700 hover:text-brand-800 text-xs font-semibold">
+          Ver todo
+        </button>
+      </header>
+      <ul className="flex flex-col gap-4">
+        {items.map((item) => {
+          const Icon = ICONS[item.icon];
+          return (
+            <li key={item.id} className="flex items-start gap-3">
+              <span
+                aria-hidden="true"
+                className="text-brand-700 mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-[var(--color-brand-50)]"
+              >
+                <Icon width={18} height={18} strokeWidth={2} />
+              </span>
+              <div className="min-w-0 flex-1">
+                <p className="text-ink-900 text-sm font-semibold">{item.title}</p>
+                <p className="text-ink-500 mt-0.5 text-sm leading-snug">{item.description}</p>
+                <p className="text-ink-300 mt-1 text-xs">{item.timestamp}</p>
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+}

--- a/apps/web/src/features/activity/__tests__/ActivityFeed.test.tsx
+++ b/apps/web/src/features/activity/__tests__/ActivityFeed.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen, within } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { ActivityFeed } from '../ActivityFeed';
+import { mockActivity } from '@/data/mock';
+
+describe('ActivityFeed', () => {
+  it('muestra la cantidad exacta de entradas provistas', () => {
+    render(<ActivityFeed items={mockActivity} />);
+
+    const list = screen.getByRole('list');
+    expect(within(list).getAllByRole('listitem')).toHaveLength(mockActivity.length);
+  });
+
+  it('renderiza el primer título de actividad', () => {
+    render(<ActivityFeed items={mockActivity} />);
+    expect(screen.getByText(mockActivity[0].title)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/activity/index.ts
+++ b/apps/web/src/features/activity/index.ts
@@ -1,0 +1,2 @@
+export { ActivityFeed } from './ActivityFeed';
+export type { ActivityFeedProps } from './ActivityFeed';

--- a/apps/web/src/features/hero/HeroBanner.tsx
+++ b/apps/web/src/features/hero/HeroBanner.tsx
@@ -1,0 +1,132 @@
+import {
+  Filter,
+  HomeIcon,
+  LifeBuoy,
+  Plug,
+  Sliders,
+  TrendingUp,
+  type LucideIcon,
+} from 'lucide-react';
+import { useState } from 'react';
+
+export type HeroChip = {
+  id: string;
+  label: string;
+  icon: LucideIcon;
+};
+
+export type HeroBannerProps = {
+  title?: string;
+  subtitle?: string;
+  /** Chip inicialmente seleccionado (controla el estado interno). */
+  initialSelectedChipId?: string;
+  /** Se invoca al cambiar el chip activo. */
+  onChipChange?: (chipId: string) => void;
+  className?: string;
+};
+
+const DEFAULT_CHIPS: HeroChip[] = [
+  { id: 'quality', label: 'Calidad de vida', icon: LifeBuoy },
+  { id: 'housing', label: 'Vivienda asequible', icon: HomeIcon },
+  { id: 'jobs', label: 'Empleo', icon: TrendingUp },
+  { id: 'connectivity', label: 'Conectividad', icon: Plug },
+  { id: 'more', label: 'Más filtros', icon: Sliders },
+];
+
+/**
+ * Franja superior tipo hero del dashboard. Reproduce el bloque verde claro de
+ * la captura con titular, subtítulo y chips de filtros rápidos.
+ */
+export function HeroBanner({
+  title = 'Descubre el mejor lugar para vivir en España',
+  subtitle = 'Combina datos abiertos, tu perfil y prioridades para encontrar el territorio que mejor encaja contigo.',
+  initialSelectedChipId = 'quality',
+  onChipChange,
+  className,
+}: HeroBannerProps) {
+  const [selected, setSelected] = useState(initialSelectedChipId);
+
+  const handleSelect = (chipId: string) => {
+    setSelected(chipId);
+    onChipChange?.(chipId);
+  };
+
+  return (
+    <section
+      aria-label="Buscador principal de AtlasHabita"
+      className={[
+        'relative overflow-hidden rounded-2xl bg-gradient-to-br from-[var(--color-brand-50)] via-white to-[var(--color-brand-100)] p-8 shadow-[var(--shadow-card)]',
+        className ?? '',
+      ]
+        .filter(Boolean)
+        .join(' ')}
+    >
+      <div className="pointer-events-none absolute inset-y-0 right-0 hidden w-1/2 opacity-70 md:block">
+        <HeroIllustration />
+      </div>
+
+      <div className="relative max-w-2xl">
+        <span className="text-brand-700 inline-flex items-center gap-2 rounded-full bg-white/80 px-3 py-1 text-xs font-semibold tracking-wide uppercase">
+          <Filter width={14} height={14} strokeWidth={2.5} aria-hidden="true" />
+          Asistente territorial
+        </span>
+        <h1 className="font-display text-ink-900 mt-4 text-3xl leading-tight font-semibold md:text-4xl">
+          {title}
+        </h1>
+        <p className="text-ink-700 mt-3 max-w-xl text-sm md:text-base">{subtitle}</p>
+
+        <ul className="mt-6 flex flex-wrap gap-2" aria-label="Filtros rápidos">
+          {DEFAULT_CHIPS.map((chip) => {
+            const Icon = chip.icon;
+            const isSelected = chip.id === selected;
+            return (
+              <li key={chip.id}>
+                <button
+                  type="button"
+                  onClick={() => handleSelect(chip.id)}
+                  aria-pressed={isSelected}
+                  className={[
+                    'inline-flex items-center gap-2 rounded-full px-4 py-2 text-xs font-semibold transition-colors',
+                    isSelected
+                      ? 'bg-[var(--color-brand-600)] text-white shadow-[var(--shadow-card)]'
+                      : 'bg-white/90 text-[var(--color-ink-700)] hover:bg-white',
+                  ].join(' ')}
+                >
+                  <Icon width={14} height={14} strokeWidth={2.5} aria-hidden="true" />
+                  {chip.label}
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+    </section>
+  );
+}
+
+function HeroIllustration() {
+  return (
+    <svg
+      viewBox="0 0 400 280"
+      className="h-full w-full"
+      aria-hidden="true"
+      preserveAspectRatio="xMidYMid slice"
+    >
+      <defs>
+        <radialGradient id="hero-glow" cx="70%" cy="20%" r="70%">
+          <stop offset="0%" stopColor="#d1fae5" />
+          <stop offset="100%" stopColor="#ecfdf5" stopOpacity="0" />
+        </radialGradient>
+      </defs>
+      <rect width="400" height="280" fill="url(#hero-glow)" />
+      <circle cx="320" cy="70" r="54" fill="#a7f3d0" opacity="0.8" />
+      <circle cx="250" cy="160" r="28" fill="#6ee7b7" opacity="0.7" />
+      <circle cx="340" cy="210" r="42" fill="#10b981" opacity="0.55" />
+      <path
+        d="M40 240 L120 180 L190 210 L260 160 L330 200 L400 170 L400 280 L40 280 Z"
+        fill="#34d399"
+        opacity="0.35"
+      />
+    </svg>
+  );
+}

--- a/apps/web/src/features/hero/__tests__/HeroBanner.test.tsx
+++ b/apps/web/src/features/hero/__tests__/HeroBanner.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import { HeroBanner } from '../HeroBanner';
+
+describe('HeroBanner', () => {
+  it('renderiza los 5 chips de filtro por defecto', () => {
+    render(<HeroBanner />);
+
+    const chipList = screen.getByRole('list', { name: /filtros rápidos/i });
+    expect(chipList).toBeInTheDocument();
+
+    const labels = [
+      'Calidad de vida',
+      'Vivienda asequible',
+      'Empleo',
+      'Conectividad',
+      'Más filtros',
+    ];
+
+    for (const label of labels) {
+      expect(screen.getByRole('button', { name: new RegExp(label, 'i') })).toBeInTheDocument();
+    }
+  });
+
+  it('cambia el chip activo al hacer click', async () => {
+    const onChipChange = vi.fn();
+    render(<HeroBanner onChipChange={onChipChange} />);
+
+    const jobsButton = screen.getByRole('button', { name: /empleo/i });
+    await userEvent.click(jobsButton);
+
+    expect(jobsButton).toHaveAttribute('aria-pressed', 'true');
+    expect(onChipChange).toHaveBeenCalledWith('jobs');
+  });
+});

--- a/apps/web/src/features/hero/index.ts
+++ b/apps/web/src/features/hero/index.ts
@@ -1,0 +1,2 @@
+export { HeroBanner } from './HeroBanner';
+export type { HeroBannerProps, HeroChip } from './HeroBanner';

--- a/apps/web/src/features/map/MapLegend.tsx
+++ b/apps/web/src/features/map/MapLegend.tsx
@@ -1,0 +1,65 @@
+/**
+ * Leyenda cromática del mapa. Representa los 5 tramos de la escala verde
+ * empleada por `SpainMap` y expone la etiqueta semántica de la capa activa
+ * para que la interpretación del color sea accesible (principio de no
+ * depender únicamente del color, ver docs/16_FRONTEND_UX_UI_Y_FLUJOS.md §8).
+ */
+
+export type MapLegendStop = {
+  /** Valor inferior del tramo, expresado en la unidad de la capa. */
+  min: number;
+  /** Valor superior del tramo, expresado en la unidad de la capa. */
+  max: number;
+  /** Color HEX asociado al tramo. */
+  color: string;
+};
+
+export type MapLegendProps = {
+  /** Etiqueta de la capa visualizada, por ejemplo "Score territorial". */
+  label: string;
+  /** Tramos de color ordenados de menor a mayor. */
+  stops: MapLegendStop[];
+  /** Sufijo mostrado junto a los valores (p.ej. "€", "%"). */
+  unit?: string;
+  className?: string;
+};
+
+export function MapLegend({ label, stops, unit = '', className }: MapLegendProps) {
+  return (
+    <figure
+      className={[
+        'pointer-events-auto rounded-xl bg-white/95 px-3 py-2 shadow-[var(--shadow-card)] backdrop-blur',
+        className ?? '',
+      ]
+        .filter(Boolean)
+        .join(' ')}
+      aria-label={`Leyenda: ${label}`}
+    >
+      <figcaption className="text-ink-700 text-[11px] font-semibold tracking-wide uppercase">
+        {label}
+      </figcaption>
+      <ul className="mt-2 flex items-center gap-1">
+        {stops.map((stop) => (
+          <li key={`${stop.min}-${stop.max}`} className="flex flex-col items-center gap-1">
+            <span
+              aria-hidden="true"
+              className="block h-3 w-8 rounded-sm"
+              style={{ backgroundColor: stop.color }}
+            />
+            <span className="text-ink-500 text-[10px] tabular-nums">
+              {stop.min}
+              {unit}
+            </span>
+          </li>
+        ))}
+        <li className="flex flex-col items-center gap-1" aria-hidden="true">
+          <span className="block h-3 w-0" />
+          <span className="text-ink-500 text-[10px] tabular-nums">
+            {stops[stops.length - 1]?.max ?? 0}
+            {unit}
+          </span>
+        </li>
+      </ul>
+    </figure>
+  );
+}

--- a/apps/web/src/features/map/MapTooltip.tsx
+++ b/apps/web/src/features/map/MapTooltip.tsx
@@ -1,0 +1,48 @@
+/**
+ * Tooltip ligero que flota sobre el canvas del mapa mostrando el nombre del
+ * municipio, el score y el valor bruto del indicador. El componente es puro
+ * (sólo depende de las props) para poder memoizar su render desde `SpainMap`.
+ */
+
+export type MapTooltipProps = {
+  /** Nombre del municipio destacado. */
+  name: string;
+  /** Valor bruto del indicador (se muestra con separadores locales). */
+  value: number;
+  /** Score agregado [0, 100] asociado al territorio. */
+  score: number;
+  /** Coordenada X (en píxeles) relativa al contenedor del mapa. */
+  x: number;
+  /** Coordenada Y (en píxeles) relativa al contenedor del mapa. */
+  y: number;
+  /** Sufijo mostrado junto al valor bruto. */
+  unit?: string;
+};
+
+export function MapTooltip({ name, value, score, x, y, unit = '€' }: MapTooltipProps) {
+  return (
+    <div
+      role="tooltip"
+      className="pointer-events-none absolute z-10 min-w-[160px] -translate-x-1/2 -translate-y-full rounded-xl bg-[var(--color-ink-900)]/95 px-3 py-2 text-white shadow-[var(--shadow-elevated)]"
+      style={{ left: x, top: y - 12 }}
+    >
+      <p className="text-[10px] font-semibold tracking-[0.16em] text-[var(--color-brand-200)] uppercase">
+        Territorio
+      </p>
+      <p className="mt-0.5 text-sm font-semibold">{name}</p>
+      <dl className="mt-2 grid grid-cols-2 gap-2 text-xs">
+        <div>
+          <dt className="text-white/60">Score</dt>
+          <dd className="text-base font-semibold text-white tabular-nums">{score}</dd>
+        </div>
+        <div>
+          <dt className="text-white/60">Indicador</dt>
+          <dd className="text-base font-semibold text-white tabular-nums">
+            {value.toLocaleString('es-ES')}
+            {unit}
+          </dd>
+        </div>
+      </dl>
+    </div>
+  );
+}

--- a/apps/web/src/features/map/SpainMap.tsx
+++ b/apps/web/src/features/map/SpainMap.tsx
@@ -1,0 +1,218 @@
+import { useCallback, useMemo, useState, type PointerEvent as ReactPointerEvent } from 'react';
+import Map, { Marker, NavigationControl } from 'react-map-gl/maplibre';
+import 'maplibre-gl/dist/maplibre-gl.css';
+
+import { MapLegend, type MapLegendStop } from './MapLegend';
+import { MapTooltip } from './MapTooltip';
+import type { MapPoint } from '@/data/mock';
+
+/**
+ * Escala verde oscuro → verde claro utilizada en el mapa. Coincide con la
+ * rampa del sistema de diseño (`brand-800` → `brand-200`). Al ordenarse de
+ * mayor a menor score, valores altos reciben el verde más intenso, coherente
+ * con la semántica "encaja mejor" descrita en `16_FRONTEND_UX_UI_Y_FLUJOS.md`.
+ */
+const GREEN_RAMP = ['#065f46', '#047857', '#059669', '#10b981', '#34d399'] as const;
+
+/**
+ * Umbrales de score que particionan el rango [0, 100] en 5 tramos.
+ * Se exponen como constantes para que los tests y la leyenda puedan
+ * referenciarlos sin duplicación.
+ */
+const SCORE_BREAKS = [80, 65, 50, 35, 0] as const;
+
+/** URL pública del estilo vectorial OpenFreeMap (Liberty). No requiere API key. */
+const OPENFREEMAP_STYLE = 'https://tiles.openfreemap.org/styles/liberty';
+
+/**
+ * Estilo de fallback cuando no se puede cargar OpenFreeMap (entorno offline,
+ * tests, o error de red). Mantiene el color de marca para que la pantalla
+ * no se degrade a un lienzo negro.
+ */
+const FALLBACK_STYLE = {
+  version: 8 as const,
+  name: 'atlashabita-fallback',
+  sources: {},
+  layers: [
+    {
+      id: 'atlashabita-background',
+      type: 'background' as const,
+      paint: {
+        'background-color': '#eef2f1',
+      },
+    },
+  ],
+};
+
+export type SpainMapProps = {
+  /** Puntos coroplético-equivalentes a renderizar como círculos. */
+  points: MapPoint[];
+  /** Etiqueta accesible del mapa para lectores de pantalla. */
+  ariaLabel?: string;
+  className?: string;
+  /** Etiqueta de la capa activa mostrada en la leyenda. */
+  layerLabel?: string;
+  /** Sufijo de unidad del indicador activo (se propaga al tooltip). */
+  unit?: string;
+  /**
+   * Fuerza el estilo de fallback. Útil en tests para evitar peticiones de red
+   * y en entornos sin acceso a OpenFreeMap.
+   */
+  offline?: boolean;
+};
+
+type HoveredState = {
+  point: MapPoint;
+  x: number;
+  y: number;
+};
+
+/**
+ * Devuelve el color del score respetando los tramos declarados en
+ * `SCORE_BREAKS` y `GREEN_RAMP`.
+ */
+export function scoreToColor(score: number): string {
+  for (let index = 0; index < SCORE_BREAKS.length; index += 1) {
+    if (score >= SCORE_BREAKS[index]) {
+      return GREEN_RAMP[index];
+    }
+  }
+  return GREEN_RAMP[GREEN_RAMP.length - 1];
+}
+
+function buildLegendStops(): MapLegendStop[] {
+  // Presentamos los tramos de menor a mayor para leerse de izquierda a derecha.
+  const stops: MapLegendStop[] = [];
+  for (let index = SCORE_BREAKS.length - 1; index >= 0; index -= 1) {
+    const min = SCORE_BREAKS[index];
+    const max = index === 0 ? 100 : SCORE_BREAKS[index - 1];
+    stops.push({ min, max, color: GREEN_RAMP[index] });
+  }
+  return stops;
+}
+
+export function SpainMap({
+  points,
+  ariaLabel = 'Mapa territorial de España',
+  className,
+  layerLabel = 'Score territorial',
+  unit = '',
+  offline = false,
+}: SpainMapProps) {
+  const [hovered, setHovered] = useState<HoveredState | null>(null);
+
+  const legendStops = useMemo(() => buildLegendStops(), []);
+
+  const markers = useMemo(
+    () =>
+      points.map((point) => ({
+        ...point,
+        color: scoreToColor(point.score),
+        radius: 10 + Math.round((point.score / 100) * 14),
+      })),
+    [points]
+  );
+
+  const handleEnter = useCallback(
+    (point: MapPoint) => (event: ReactPointerEvent<Element>) => {
+      const container = event.currentTarget.closest('[data-spain-map]') as HTMLElement | null;
+      const rect = container?.getBoundingClientRect();
+      const x = rect ? event.clientX - rect.left : event.clientX;
+      const y = rect ? event.clientY - rect.top : event.clientY;
+      setHovered({ point, x, y });
+    },
+    []
+  );
+
+  const handleMove = useCallback(
+    (event: ReactPointerEvent<Element>) => {
+      if (!hovered) return;
+      const container = event.currentTarget.closest('[data-spain-map]') as HTMLElement | null;
+      const rect = container?.getBoundingClientRect();
+      const x = rect ? event.clientX - rect.left : event.clientX;
+      const y = rect ? event.clientY - rect.top : event.clientY;
+      setHovered((prev) => (prev ? { ...prev, x, y } : prev));
+    },
+    [hovered]
+  );
+
+  const handleLeave = useCallback(() => setHovered(null), []);
+
+  const mapStyle = offline ? FALLBACK_STYLE : OPENFREEMAP_STYLE;
+
+  return (
+    <section
+      data-spain-map
+      aria-label={ariaLabel}
+      className={[
+        'relative h-full min-h-[360px] w-full overflow-hidden rounded-2xl bg-[var(--color-surface-muted)] shadow-[var(--shadow-card)]',
+        className ?? '',
+      ]
+        .filter(Boolean)
+        .join(' ')}
+    >
+      <Map
+        initialViewState={{ longitude: -3.7, latitude: 40.0, zoom: 5 }}
+        mapStyle={mapStyle as unknown as string}
+        attributionControl={false}
+        style={{ width: '100%', height: '100%' }}
+        dragRotate={false}
+        pitchWithRotate={false}
+        reuseMaps
+      >
+        <NavigationControl position="top-right" showCompass={false} />
+        {markers.map((marker) => (
+          <Marker key={marker.id} longitude={marker.lon} latitude={marker.lat} anchor="center">
+            <button
+              type="button"
+              aria-label={`${marker.name}: score ${marker.score}`}
+              className="relative flex items-center justify-center rounded-full border-2 border-white/90 transition-transform hover:scale-110 focus-visible:scale-110"
+              style={{
+                width: marker.radius,
+                height: marker.radius,
+                backgroundColor: marker.color,
+                boxShadow: '0 6px 18px -8px rgba(6, 95, 70, 0.55)',
+              }}
+              onPointerEnter={handleEnter(marker)}
+              onPointerMove={handleMove}
+              onPointerLeave={handleLeave}
+              onFocus={(event) => {
+                const container = event.currentTarget.closest(
+                  '[data-spain-map]'
+                ) as HTMLElement | null;
+                const rect = container?.getBoundingClientRect();
+                const btn = event.currentTarget.getBoundingClientRect();
+                const x = rect ? btn.left + btn.width / 2 - rect.left : btn.left;
+                const y = rect ? btn.top - rect.top : btn.top;
+                setHovered({ point: marker, x, y });
+              }}
+              onBlur={handleLeave}
+            >
+              <span
+                aria-hidden="true"
+                className="absolute inset-1 rounded-full opacity-80"
+                style={{
+                  background:
+                    'radial-gradient(circle at 30% 30%, rgba(255,255,255,0.55), transparent 60%)',
+                }}
+              />
+            </button>
+          </Marker>
+        ))}
+      </Map>
+
+      {hovered ? (
+        <MapTooltip
+          name={hovered.point.name}
+          value={hovered.point.value}
+          score={hovered.point.score}
+          x={hovered.x}
+          y={hovered.y}
+          unit={unit}
+        />
+      ) : null}
+
+      <MapLegend label={layerLabel} stops={legendStops} className="absolute bottom-4 left-4" />
+    </section>
+  );
+}

--- a/apps/web/src/features/map/__tests__/SpainMap.test.tsx
+++ b/apps/web/src/features/map/__tests__/SpainMap.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+// maplibre-gl usa WebGL, que jsdom no implementa. Sustituimos el módulo por un
+// objeto vacío porque `react-map-gl` sólo lo usa como peer dependency.
+vi.mock('maplibre-gl', () => ({ default: {} }));
+
+// Reemplazamos los componentes de react-map-gl por contenedores predecibles
+// para poder aserta estructura sin inicializar un canvas real.
+vi.mock('react-map-gl/maplibre', () => ({
+  __esModule: true,
+  default: ({ children }: { children?: ReactNode }) => (
+    <div data-testid="maplibre-canvas">{children}</div>
+  ),
+  Marker: ({ children }: { children?: ReactNode }) => (
+    <div data-testid="map-marker">{children}</div>
+  ),
+  NavigationControl: () => <div data-testid="map-nav" />,
+}));
+
+import { SpainMap, scoreToColor } from '../SpainMap';
+import { mockPoints } from '@/data/mock';
+
+describe('SpainMap', () => {
+  it('renderiza el canvas del mapa y un marcador por cada punto', () => {
+    render(<SpainMap points={mockPoints} offline />);
+
+    expect(screen.getByTestId('maplibre-canvas')).toBeInTheDocument();
+    expect(screen.getAllByTestId('map-marker')).toHaveLength(mockPoints.length);
+  });
+
+  it('expone una leyenda con la etiqueta de la capa activa', () => {
+    render(<SpainMap points={mockPoints} layerLabel="Alquiler medio" offline />);
+
+    expect(screen.getByLabelText(/Leyenda: Alquiler medio/i)).toBeInTheDocument();
+  });
+
+  it('asocia colores verdes al score monótonamente decrecientes', () => {
+    const high = scoreToColor(92);
+    const mid = scoreToColor(55);
+    const low = scoreToColor(10);
+
+    expect(high).toBe('#065f46');
+    expect(mid).not.toBe(high);
+    expect(low).toBe('#34d399');
+  });
+});

--- a/apps/web/src/features/map/index.ts
+++ b/apps/web/src/features/map/index.ts
@@ -1,0 +1,6 @@
+export { SpainMap, scoreToColor } from './SpainMap';
+export type { SpainMapProps } from './SpainMap';
+export { MapLegend } from './MapLegend';
+export type { MapLegendProps, MapLegendStop } from './MapLegend';
+export { MapTooltip } from './MapTooltip';
+export type { MapTooltipProps } from './MapTooltip';

--- a/apps/web/src/features/recommendations/HighlightCard.tsx
+++ b/apps/web/src/features/recommendations/HighlightCard.tsx
@@ -1,0 +1,128 @@
+import { ArrowUpRight } from 'lucide-react';
+import { useState } from 'react';
+
+import type { Highlight } from '@/data/mock';
+
+export type HighlightCardProps = {
+  highlight: Highlight;
+  /**
+   * Ruta local a la fotografía destacada (p.ej. `/images/donostia.jpg`).
+   * Si no carga, el componente degrada a un SVG estilizado propio.
+   */
+  imageSrc?: string;
+  /** Callback invocado al pulsar "Ver análisis". */
+  onOpen?: (highlightId: string) => void;
+  className?: string;
+};
+
+/**
+ * Tarjeta horizontal que combina una imagen destacada con los atributos
+ * clave del territorio recomendado. Se inspira en la captura de referencia:
+ * foto a la izquierda y contenido textual a la derecha, con CTA primario.
+ */
+export function HighlightCard({ highlight, imageSrc, onOpen, className }: HighlightCardProps) {
+  const [imageFailed, setImageFailed] = useState(false);
+
+  return (
+    <article
+      aria-label={`Recomendación destacada: ${highlight.name}`}
+      className={[
+        'flex flex-col gap-4 overflow-hidden rounded-2xl bg-white p-4 shadow-[var(--shadow-card)] md:flex-row',
+        className ?? '',
+      ]
+        .filter(Boolean)
+        .join(' ')}
+    >
+      <div className="relative h-44 w-full shrink-0 overflow-hidden rounded-xl bg-[var(--color-surface-muted)] md:h-auto md:w-56">
+        {imageSrc && !imageFailed ? (
+          <img
+            src={imageSrc}
+            alt={`Vista de ${highlight.name}`}
+            loading="lazy"
+            decoding="async"
+            className="h-full w-full object-cover"
+            onError={() => setImageFailed(true)}
+          />
+        ) : (
+          <HighlightPlaceholder name={highlight.name} />
+        )}
+        <span className="absolute top-3 left-3 rounded-full bg-white/90 px-3 py-1 text-[11px] font-semibold text-[var(--color-brand-700)] backdrop-blur">
+          Top {highlight.score}
+        </span>
+      </div>
+
+      <div className="flex min-w-0 flex-1 flex-col justify-between">
+        <div>
+          <p className="text-brand-700 text-xs font-semibold tracking-[0.18em] uppercase">
+            {highlight.headline}
+          </p>
+          <h3 className="font-display text-ink-900 mt-1 text-xl font-semibold">{highlight.name}</h3>
+          <p className="text-ink-500 text-xs">{highlight.region}</p>
+          <p className="text-ink-700 mt-3 text-sm leading-relaxed">{highlight.description}</p>
+
+          <ul className="mt-4 flex flex-wrap gap-2">
+            {highlight.attributes.map((attribute) => (
+              <li
+                key={attribute.label}
+                className="rounded-full bg-[var(--color-surface-muted)] px-3 py-1 text-xs font-medium text-[var(--color-ink-700)]"
+              >
+                <span className="text-[var(--color-ink-500)]">{attribute.label}:</span>{' '}
+                <span className="font-semibold text-[var(--color-ink-900)]">{attribute.value}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        <div className="mt-5 flex items-center justify-between">
+          <span className="text-ink-500 text-xs">Actualizado hoy</span>
+          <button
+            type="button"
+            onClick={() => onOpen?.(highlight.id)}
+            className="inline-flex items-center gap-1.5 rounded-full bg-[var(--color-brand-600)] px-4 py-2 text-xs font-semibold text-white shadow-[var(--shadow-card)] transition-colors hover:bg-[var(--color-brand-700)]"
+          >
+            Ver análisis
+            <ArrowUpRight width={14} height={14} strokeWidth={2.5} aria-hidden="true" />
+          </button>
+        </div>
+      </div>
+    </article>
+  );
+}
+
+/**
+ * Placeholder SVG controlado. No usa texto Lorem ni imágenes externas; dibuja
+ * un paisaje estilizado en tonos de marca para comunicar "territorio".
+ */
+function HighlightPlaceholder({ name }: { name: string }) {
+  return (
+    <svg
+      role="img"
+      aria-label={`Ilustración de ${name}`}
+      viewBox="0 0 240 180"
+      className="h-full w-full"
+      preserveAspectRatio="xMidYMid slice"
+    >
+      <defs>
+        <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" stopColor="#ecfdf5" />
+          <stop offset="100%" stopColor="#a7f3d0" />
+        </linearGradient>
+        <linearGradient id="mount" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" stopColor="#047857" />
+          <stop offset="100%" stopColor="#065f46" />
+        </linearGradient>
+      </defs>
+      <rect width="240" height="180" fill="url(#sky)" />
+      <circle cx="190" cy="48" r="18" fill="#fef3c7" opacity="0.9" />
+      <path
+        d="M0 130 L55 80 L95 110 L140 60 L190 105 L240 80 L240 180 L0 180 Z"
+        fill="url(#mount)"
+      />
+      <path
+        d="M0 150 L40 130 L85 150 L130 125 L180 150 L240 130 L240 180 L0 180 Z"
+        fill="#10b981"
+        opacity="0.85"
+      />
+    </svg>
+  );
+}

--- a/apps/web/src/features/recommendations/__tests__/HighlightCard.test.tsx
+++ b/apps/web/src/features/recommendations/__tests__/HighlightCard.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import { HighlightCard } from '../HighlightCard';
+import { mockHighlight } from '@/data/mock';
+
+describe('HighlightCard', () => {
+  it('incluye el botón "Ver análisis" y dispara el callback', async () => {
+    const onOpen = vi.fn();
+    render(<HighlightCard highlight={mockHighlight} onOpen={onOpen} />);
+
+    const button = screen.getByRole('button', { name: /ver análisis/i });
+    expect(button).toBeInTheDocument();
+
+    await userEvent.click(button);
+    expect(onOpen).toHaveBeenCalledWith(mockHighlight.id);
+  });
+
+  it('muestra los atributos destacados del territorio', () => {
+    render(<HighlightCard highlight={mockHighlight} />);
+
+    for (const attribute of mockHighlight.attributes) {
+      expect(screen.getByText(new RegExp(attribute.value, 'i'))).toBeInTheDocument();
+    }
+  });
+});

--- a/apps/web/src/features/recommendations/index.ts
+++ b/apps/web/src/features/recommendations/index.ts
@@ -1,0 +1,2 @@
+export { HighlightCard } from './HighlightCard';
+export type { HighlightCardProps } from './HighlightCard';

--- a/apps/web/src/features/trends/TrendsChart.tsx
+++ b/apps/web/src/features/trends/TrendsChart.tsx
@@ -1,0 +1,109 @@
+import { useMemo } from 'react';
+import {
+  Area,
+  AreaChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+
+import type { TrendPoint } from '@/data/mock';
+
+export type TrendsChartProps = {
+  /** Serie temporal de 12 meses (mes, score y rentIndex). */
+  data: TrendPoint[];
+  /** Título visible. */
+  title?: string;
+  /** Explicación breve para acompañar al gráfico. */
+  subtitle?: string;
+  className?: string;
+};
+
+/**
+ * Gráfico de tendencia con gradiente verde inspirado en la captura.
+ * Usa AreaChart para transmitir progreso en lugar de lecturas puntuales.
+ */
+export function TrendsChart({
+  data,
+  title = 'Tendencia de calidad de vida',
+  subtitle = 'Score medio de los últimos 12 meses en los territorios seleccionados.',
+  className,
+}: TrendsChartProps) {
+  const domain = useMemo<[number, number]>(() => {
+    if (data.length === 0) return [0, 100];
+    const values = data.map((point) => point.score);
+    const min = Math.floor(Math.min(...values) / 5) * 5 - 5;
+    const max = Math.ceil(Math.max(...values) / 5) * 5 + 5;
+    return [Math.max(0, min), Math.min(100, max)];
+  }, [data]);
+
+  return (
+    <section
+      className={['rounded-2xl bg-white p-6 shadow-[var(--shadow-card)]', className ?? '']
+        .filter(Boolean)
+        .join(' ')}
+      aria-label={title}
+    >
+      <header className="mb-4 flex items-start justify-between gap-4">
+        <div>
+          <h3 className="font-display text-ink-900 text-lg font-semibold">{title}</h3>
+          <p className="text-ink-500 mt-1 text-sm">{subtitle}</p>
+        </div>
+        <span className="text-brand-700 rounded-full bg-[var(--color-brand-50)] px-3 py-1 text-xs font-semibold">
+          +12 pts
+        </span>
+      </header>
+
+      <div className="h-56 w-full" role="img" aria-label={`Gráfico de líneas: ${title}`}>
+        <ResponsiveContainer width="100%" height="100%">
+          <AreaChart data={data} margin={{ top: 8, right: 8, bottom: 0, left: -16 }}>
+            <defs>
+              <linearGradient id="atlashabita-trend-fill" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="0%" stopColor="#10b981" stopOpacity={0.45} />
+                <stop offset="100%" stopColor="#10b981" stopOpacity={0.02} />
+              </linearGradient>
+            </defs>
+            <CartesianGrid strokeDasharray="3 4" stroke="#e2e8f0" vertical={false} />
+            <XAxis
+              dataKey="month"
+              tick={{ fill: '#64748b', fontSize: 12 }}
+              tickLine={false}
+              axisLine={{ stroke: '#e2e8f0' }}
+            />
+            <YAxis
+              domain={domain}
+              tick={{ fill: '#64748b', fontSize: 12 }}
+              tickLine={false}
+              axisLine={false}
+              width={40}
+            />
+            <Tooltip
+              cursor={{ stroke: '#10b981', strokeDasharray: '4 4' }}
+              contentStyle={{
+                borderRadius: 12,
+                border: '1px solid #e2e8f0',
+                boxShadow: '0 12px 28px -18px rgba(15,23,42,0.22)',
+                fontSize: 12,
+              }}
+              labelStyle={{ color: '#0f172a', fontWeight: 600 }}
+              formatter={(value: number, name) => [
+                `${value}`,
+                name === 'score' ? 'Score' : 'Índice alquiler',
+              ]}
+            />
+            <Area
+              type="monotone"
+              dataKey="score"
+              stroke="#047857"
+              strokeWidth={2.5}
+              fill="url(#atlashabita-trend-fill)"
+              activeDot={{ r: 5, stroke: '#047857', strokeWidth: 2, fill: '#ffffff' }}
+            />
+          </AreaChart>
+        </ResponsiveContainer>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/features/trends/__tests__/TrendsChart.test.tsx
+++ b/apps/web/src/features/trends/__tests__/TrendsChart.test.tsx
@@ -1,0 +1,88 @@
+import { render } from '@testing-library/react';
+import { beforeAll, describe, expect, it } from 'vitest';
+
+import { TrendsChart } from '../TrendsChart';
+import { mockTrends } from '@/data/mock';
+
+/**
+ * jsdom no implementa ResizeObserver ni reporta dimensiones reales a
+ * `getBoundingClientRect`. Proveemos polyfills de ámbito local antes de
+ * renderizar el `ResponsiveContainer` de Recharts para que el chart pueda
+ * asumir un tamaño útil y producir los ejes SVG.
+ */
+beforeAll(() => {
+  type Callback = (entries: unknown[], observer: unknown) => void;
+
+  class ResizeObserverPolyfill {
+    private readonly callback: Callback;
+
+    constructor(callback: Callback) {
+      this.callback = callback;
+    }
+
+    observe(target: Element) {
+      // Simulamos una medición inmediata con dimensiones fijas.
+      this.callback(
+        [
+          {
+            target,
+            contentRect: {
+              width: 600,
+              height: 300,
+              top: 0,
+              left: 0,
+              bottom: 300,
+              right: 600,
+              x: 0,
+              y: 0,
+              toJSON: () => ({}),
+            },
+            borderBoxSize: [],
+            contentBoxSize: [],
+            devicePixelContentBoxSize: [],
+          },
+        ],
+        this
+      );
+    }
+
+    unobserve() {}
+    disconnect() {}
+  }
+
+  Object.defineProperty(globalThis, 'ResizeObserver', {
+    value: ResizeObserverPolyfill,
+    writable: true,
+    configurable: true,
+  });
+
+  // Forzamos un bounding rect no nulo para todo elemento en jsdom.
+  Object.defineProperty(HTMLElement.prototype, 'getBoundingClientRect', {
+    configurable: true,
+    value: () => ({
+      width: 600,
+      height: 300,
+      top: 0,
+      left: 0,
+      bottom: 300,
+      right: 600,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    }),
+  });
+});
+
+describe('TrendsChart', () => {
+  it('muestra el título y un SVG con ejes Recharts', () => {
+    const { container, getByText } = render(<TrendsChart data={mockTrends} />);
+
+    expect(getByText(/Tendencia de calidad de vida/i)).toBeInTheDocument();
+
+    const svgs = container.querySelectorAll('svg');
+    expect(svgs.length).toBeGreaterThanOrEqual(1);
+
+    const axes = container.querySelectorAll('.recharts-xAxis, .recharts-yAxis');
+    expect(axes.length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/apps/web/src/features/trends/index.ts
+++ b/apps/web/src/features/trends/index.ts
@@ -1,0 +1,2 @@
+export { TrendsChart } from './TrendsChart';
+export type { TrendsChartProps } from './TrendsChart';


### PR DESCRIPTION
## Resumen

Features visuales del dashboard: `SpainMap` (MapLibre GL + estilo OpenFreeMap con fallback branded, leyenda y tooltip), `TrendsChart` (Recharts), `ActivityFeed`, `HighlightCard` y `HeroBanner`. Se acompaña de `data/mock.ts` con municipios reales extraídos del seed.

## Issues

Closes #23
Closes #24

## Verificación

- `pnpm format:check`, `pnpm lint`, `pnpm test` (11 tests) y `pnpm vite build` (bundle 224 kB) en verde.
- `SpainMap` tiene `offline` fallback para tests/CI sin red.
- Sin nuevas dependencias.

## Notas

- `pnpm build` encadenado sigue fallando por el conflicto vite 5/6 preexistente (ver PR #44).