### PR TITLE
feat(web): integración frontend (services, stores, hooks, router)

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,6 +1,7 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useState } from 'react';
-import { DashboardShell } from './features/dashboard/DashboardShell';
+import { RouterProvider } from 'react-router-dom';
+import { appRouter } from './routes/AppRouter';
 
 export function App() {
   const [client] = useState(
@@ -18,7 +19,7 @@ export function App() {
 
   return (
     <QueryClientProvider client={client}>
-      <DashboardShell />
+      <RouterProvider router={appRouter} />
     </QueryClientProvider>
   );
 }

--- a/apps/web/src/hooks/__tests__/testUtils.tsx
+++ b/apps/web/src/hooks/__tests__/testUtils.tsx
@@ -1,0 +1,28 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+
+/**
+ * Crea un `QueryClient` aislado por test para que la caché no se comparta
+ * entre casos y los reintentos estén desactivados (los errores deben
+ * propagarse inmediatamente).
+ */
+export function createTestQueryClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        gcTime: 0,
+        staleTime: 0,
+      },
+      mutations: {
+        retry: false,
+      },
+    },
+  });
+}
+
+export function makeWrapper(client: QueryClient) {
+  return function Wrapper({ children }: { readonly children: ReactNode }) {
+    return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+  };
+}

--- a/apps/web/src/hooks/__tests__/useMapLayers.test.tsx
+++ b/apps/web/src/hooks/__tests__/useMapLayers.test.tsx
@@ -1,0 +1,39 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useMapLayer, useMapLayers } from '../useMapLayers';
+import { installFetchMock, jsonResponse } from '../../services/__tests__/fetchMock';
+import { createTestQueryClient, makeWrapper } from './testUtils';
+
+describe('useMapLayers', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('listado de capas usa /map/layers', async () => {
+    const fetchFn = installFetchMock(async () => jsonResponse([]));
+    const client = createTestQueryClient();
+    const { result } = renderHook(() => useMapLayers(), { wrapper: makeWrapper(client) });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(fetchFn.mock.calls[0][0]).toBe('/api/map/layers');
+  });
+
+  it('useMapLayer no dispara fetch sin id', () => {
+    const fetchFn = installFetchMock(async () => jsonResponse({}));
+    const client = createTestQueryClient();
+    renderHook(() => useMapLayer(null), { wrapper: makeWrapper(client) });
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it('useMapLayer añade perfil cuando se pasa', async () => {
+    const fetchFn = installFetchMock(async () => jsonResponse({}));
+    const client = createTestQueryClient();
+    const { result } = renderHook(() => useMapLayer('score', 'student'), {
+      wrapper: makeWrapper(client),
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(fetchFn.mock.calls[0][0]).toBe('/api/map/layers/score?profile=student');
+  });
+});

--- a/apps/web/src/hooks/__tests__/useProfiles.test.tsx
+++ b/apps/web/src/hooks/__tests__/useProfiles.test.tsx
@@ -1,0 +1,36 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useProfiles } from '../useProfiles';
+import { installFetchMock, jsonResponse } from '../../services/__tests__/fetchMock';
+import { createTestQueryClient, makeWrapper } from './testUtils';
+
+describe('useProfiles', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('carga perfiles desde /api/profiles', async () => {
+    const payload = [{ id: 'explorer', name: 'Explorador', description: '', default_weights: [] }];
+    const fetchFn = installFetchMock(async () => jsonResponse(payload));
+
+    const client = createTestQueryClient();
+    const { result } = renderHook(() => useProfiles(), { wrapper: makeWrapper(client) });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(payload);
+    expect(fetchFn.mock.calls[0][0]).toBe('/api/profiles');
+  });
+
+  it('propaga el error cuando /profiles falla', async () => {
+    installFetchMock(async () =>
+      jsonResponse({ code: 'UNKNOWN', message: 'boom' }, { status: 500 })
+    );
+
+    const client = createTestQueryClient();
+    const { result } = renderHook(() => useProfiles(), { wrapper: makeWrapper(client) });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});

--- a/apps/web/src/hooks/__tests__/useQualityReport.test.tsx
+++ b/apps/web/src/hooks/__tests__/useQualityReport.test.tsx
@@ -1,0 +1,24 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useQualityReport } from '../useQualityReport';
+import { installFetchMock, jsonResponse } from '../../services/__tests__/fetchMock';
+import { createTestQueryClient, makeWrapper } from './testUtils';
+
+describe('useQualityReport', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('consulta el reporte de calidad', async () => {
+    const payload = { generated_at: '2026-04-24', data_version: '2026.04.24', rules: [] };
+    const fetchFn = installFetchMock(async () => jsonResponse(payload));
+    const client = createTestQueryClient();
+    const { result } = renderHook(() => useQualityReport(), { wrapper: makeWrapper(client) });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(payload);
+    expect(fetchFn.mock.calls[0][0]).toBe('/api/quality/reports');
+  });
+});

--- a/apps/web/src/hooks/__tests__/useRankings.test.tsx
+++ b/apps/web/src/hooks/__tests__/useRankings.test.tsx
@@ -1,0 +1,69 @@
+/* eslint-disable no-undef -- RequestInit es tipo DOM global. */
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { rankingKey, useCustomRanking, useRankings } from '../useRankings';
+import { installFetchMock, jsonResponse } from '../../services/__tests__/fetchMock';
+import { createTestQueryClient, makeWrapper } from './testUtils';
+
+describe('useRankings', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('genera clave estable con perfil, ámbito y hash de pesos', () => {
+    const key = rankingKey({ profile: 'family', scope: 'province:41' }, 'default');
+    expect(key).toEqual(['rankings', 'family', 'province:41', null, 'default']);
+  });
+
+  it('consulta ranking al montar y expone la respuesta', async () => {
+    const payload = {
+      profile: 'remote_work',
+      scope: 'country:es',
+      scoring_version: '2026.04.1',
+      data_version: '2026.04.24',
+      results: [],
+    };
+    const fetchFn = installFetchMock(async () => jsonResponse(payload));
+
+    const client = createTestQueryClient();
+    const { result } = renderHook(
+      () => useRankings({ profile: 'remote_work', scope: 'country:es' }),
+      { wrapper: makeWrapper(client) }
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(payload);
+    expect(fetchFn.mock.calls[0][0]).toBe(
+      '/api/rankings?profile=remote_work&scope=country%3Aes&limit=20'
+    );
+  });
+
+  it('useCustomRanking ejecuta POST con pesos personalizados', async () => {
+    const payload = {
+      profile: 'family',
+      scope: 'country:es',
+      scoring_version: '2026.04.1',
+      data_version: '2026.04.24',
+      results: [],
+    };
+    const fetchFn = installFetchMock(async () => jsonResponse(payload));
+
+    const client = createTestQueryClient();
+    const { result } = renderHook(() => useCustomRanking(), { wrapper: makeWrapper(client) });
+
+    const mutated = await result.current.mutateAsync({
+      profile: 'family',
+      scope: 'country:es',
+      weights: [{ factor: 'services', weight: 0.5 }],
+    });
+
+    const [url, init] = fetchFn.mock.calls[0];
+    expect(url).toBe('/api/rankings/custom');
+    expect((init as RequestInit).method).toBe('POST');
+    expect(mutated).toEqual(payload);
+    await waitFor(() => expect(result.current.data).toEqual(payload));
+  });
+});

--- a/apps/web/src/hooks/__tests__/useSources.test.tsx
+++ b/apps/web/src/hooks/__tests__/useSources.test.tsx
@@ -1,0 +1,39 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useSource, useSources } from '../useSources';
+import { installFetchMock, jsonResponse } from '../../services/__tests__/fetchMock';
+import { createTestQueryClient, makeWrapper } from './testUtils';
+
+describe('useSources', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('carga lista de fuentes', async () => {
+    const fetchFn = installFetchMock(async () => jsonResponse([]));
+    const client = createTestQueryClient();
+    const { result } = renderHook(() => useSources(), { wrapper: makeWrapper(client) });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(fetchFn.mock.calls[0][0]).toBe('/api/sources');
+  });
+
+  it('useSource no fetch sin id', () => {
+    const fetchFn = installFetchMock(async () => jsonResponse({}));
+    const client = createTestQueryClient();
+    renderHook(() => useSource(null), { wrapper: makeWrapper(client) });
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it('useSource con id hace fetch al detalle', async () => {
+    const fetchFn = installFetchMock(async () => jsonResponse({}));
+    const client = createTestQueryClient();
+    const { result } = renderHook(() => useSource('ine_padron'), {
+      wrapper: makeWrapper(client),
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(fetchFn.mock.calls[0][0]).toBe('/api/sources/ine_padron');
+  });
+});

--- a/apps/web/src/hooks/__tests__/useTerritoryDetail.test.tsx
+++ b/apps/web/src/hooks/__tests__/useTerritoryDetail.test.tsx
@@ -1,0 +1,49 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useTerritoryDetail, useTerritoryIndicators } from '../useTerritoryDetail';
+import { installFetchMock, jsonResponse } from '../../services/__tests__/fetchMock';
+import { createTestQueryClient, makeWrapper } from './testUtils';
+
+describe('useTerritoryDetail', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('desactiva el fetch cuando no hay id', () => {
+    const fetchFn = installFetchMock(async () => jsonResponse({}));
+    const client = createTestQueryClient();
+    renderHook(() => useTerritoryDetail(null), { wrapper: makeWrapper(client) });
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it('carga la ficha cuando hay id', async () => {
+    const payload = {
+      id: 'municipality:41091',
+      name: 'Sevilla',
+      type: 'municipality',
+      hierarchy: {},
+      indicators: [],
+      scores: [],
+    };
+    installFetchMock(async () => jsonResponse(payload));
+    const client = createTestQueryClient();
+    const { result } = renderHook(() => useTerritoryDetail('municipality:41091'), {
+      wrapper: makeWrapper(client),
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(payload);
+  });
+
+  it('useTerritoryIndicators pide endpoint anidado', async () => {
+    const fetchFn = installFetchMock(async () => jsonResponse([]));
+    const client = createTestQueryClient();
+    const { result } = renderHook(() => useTerritoryIndicators('municipality:41091'), {
+      wrapper: makeWrapper(client),
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(fetchFn.mock.calls[0][0]).toBe('/api/territories/municipality%3A41091/indicators');
+  });
+});

--- a/apps/web/src/hooks/__tests__/useTerritorySearch.test.tsx
+++ b/apps/web/src/hooks/__tests__/useTerritorySearch.test.tsx
@@ -1,0 +1,39 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useTerritorySearch } from '../useTerritorySearch';
+import { installFetchMock, jsonResponse } from '../../services/__tests__/fetchMock';
+import { createTestQueryClient, makeWrapper } from './testUtils';
+
+describe('useTerritorySearch', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('no lanza petición cuando la query es demasiado corta', () => {
+    const fetchFn = installFetchMock(async () => jsonResponse([]));
+
+    const client = createTestQueryClient();
+    const { result } = renderHook(() => useTerritorySearch('a'), {
+      wrapper: makeWrapper(client),
+    });
+    expect(result.current.isFetching).toBe(false);
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it('busca territorios con query válida', async () => {
+    const payload = [{ id: 'municipality:41091', name: 'Sevilla', type: 'municipality' }];
+    const fetchFn = installFetchMock(async () => jsonResponse(payload));
+
+    const client = createTestQueryClient();
+    const { result } = renderHook(() => useTerritorySearch('Sev'), {
+      wrapper: makeWrapper(client),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(payload);
+    expect(fetchFn.mock.calls[0][0]).toBe('/api/territories/search?q=Sev&limit=10');
+  });
+});

--- a/apps/web/src/hooks/useMapLayers.ts
+++ b/apps/web/src/hooks/useMapLayers.ts
@@ -1,0 +1,38 @@
+/**
+ * Hooks para listar capas de mapa y descargar su GeoJSON.
+ */
+
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+import { getMapLayer, listMapLayers } from '../services/map_layers';
+import type { MapLayerPayload, MapLayerSummary, ProfileId } from '../services/types';
+
+export const MAP_LAYERS_LIST_KEY = ['map', 'layers'] as const;
+
+export function mapLayerKey(id: string, profile: ProfileId | undefined) {
+  return ['map', 'layer', id, profile ?? 'default'] as const;
+}
+
+export function useMapLayers(): UseQueryResult<readonly MapLayerSummary[]> {
+  return useQuery({
+    queryKey: MAP_LAYERS_LIST_KEY,
+    queryFn: ({ signal }) => listMapLayers(signal),
+    staleTime: 10 * 60_000,
+  });
+}
+
+export function useMapLayer(
+  id: string | null | undefined,
+  profile?: ProfileId
+): UseQueryResult<MapLayerPayload> {
+  return useQuery({
+    queryKey: mapLayerKey(id ?? '', profile),
+    queryFn: ({ signal }) => {
+      if (!id) {
+        return Promise.reject(new Error('map layer id is required'));
+      }
+      return getMapLayer(id, profile, signal);
+    },
+    enabled: Boolean(id),
+    staleTime: 5 * 60_000,
+  });
+}

--- a/apps/web/src/hooks/useProfiles.ts
+++ b/apps/web/src/hooks/useProfiles.ts
@@ -1,0 +1,17 @@
+/**
+ * Hook TanStack Query sobre `/profiles`.
+ */
+
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+import { listProfiles } from '../services/profiles';
+import type { Profile } from '../services/types';
+
+export const PROFILES_QUERY_KEY = ['profiles'] as const;
+
+export function useProfiles(): UseQueryResult<readonly Profile[]> {
+  return useQuery({
+    queryKey: PROFILES_QUERY_KEY,
+    queryFn: ({ signal }) => listProfiles(signal),
+    staleTime: 5 * 60_000,
+  });
+}

--- a/apps/web/src/hooks/useQualityReport.ts
+++ b/apps/web/src/hooks/useQualityReport.ts
@@ -1,0 +1,17 @@
+/**
+ * Hook para el reporte de calidad (RF-022).
+ */
+
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+import { getQualityReport } from '../services/quality';
+import type { QualityReport } from '../services/types';
+
+export const QUALITY_REPORT_KEY = ['quality', 'report'] as const;
+
+export function useQualityReport(): UseQueryResult<QualityReport> {
+  return useQuery({
+    queryKey: QUALITY_REPORT_KEY,
+    queryFn: ({ signal }) => getQualityReport(signal),
+    staleTime: 5 * 60_000,
+  });
+}

--- a/apps/web/src/hooks/useRankings.ts
+++ b/apps/web/src/hooks/useRankings.ts
@@ -1,0 +1,47 @@
+/**
+ * Hooks de rankings parametrizados y personalizados.
+ *
+ * La clave de caché incluye perfil + ámbito + hash de pesos para garantizar
+ * invalidación correcta cuando el usuario mueve sliders.
+ */
+
+import {
+  useMutation,
+  useQuery,
+  type UseMutationResult,
+  type UseQueryResult,
+} from '@tanstack/react-query';
+import { computeRanking, computeRankingCustom } from '../services/rankings';
+import type { RankingCustomBody, RankingQueryParams, RankingResponse } from '../services/types';
+import { hashWeightOverrides, type WeightOverrides } from '../state/filters';
+
+export function rankingKey(params: RankingQueryParams, weightsHash: string) {
+  return ['rankings', params.profile, params.scope, params.limit ?? null, weightsHash] as const;
+}
+
+/**
+ * Recupera el ranking por defecto del perfil/ámbito.
+ *
+ * `weightOverrides` sólo se usa para construir la clave de caché: el endpoint
+ * GET no los acepta. Cuando el usuario edita pesos, `useCustomRanking` asume
+ * el cálculo.
+ */
+export function useRankings(
+  params: RankingQueryParams,
+  weightOverrides: WeightOverrides = {}
+): UseQueryResult<RankingResponse> {
+  const weightsHash = hashWeightOverrides(weightOverrides);
+  return useQuery({
+    queryKey: rankingKey(params, weightsHash),
+    queryFn: ({ signal }) => computeRanking(params, signal),
+    staleTime: 60_000,
+  });
+}
+
+/** Mutation para rankings con pesos y filtros duros personalizados. */
+export function useCustomRanking(): UseMutationResult<RankingResponse, Error, RankingCustomBody> {
+  return useMutation({
+    mutationKey: ['rankings', 'custom'],
+    mutationFn: (body: RankingCustomBody) => computeRankingCustom(body),
+  });
+}

--- a/apps/web/src/hooks/useSources.ts
+++ b/apps/web/src/hooks/useSources.ts
@@ -1,0 +1,35 @@
+/**
+ * Hooks para consumir el inspector de fuentes (RF-013).
+ */
+
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+import { getSource, listSources } from '../services/sources';
+import type { SourceDetail, SourceSummary } from '../services/types';
+
+export const SOURCES_LIST_KEY = ['sources'] as const;
+
+export function sourceDetailKey(id: string | null | undefined) {
+  return ['sources', 'detail', id ?? null] as const;
+}
+
+export function useSources(): UseQueryResult<readonly SourceSummary[]> {
+  return useQuery({
+    queryKey: SOURCES_LIST_KEY,
+    queryFn: ({ signal }) => listSources(signal),
+    staleTime: 10 * 60_000,
+  });
+}
+
+export function useSource(id: string | null | undefined): UseQueryResult<SourceDetail> {
+  return useQuery({
+    queryKey: sourceDetailKey(id),
+    queryFn: ({ signal }) => {
+      if (!id) {
+        return Promise.reject(new Error('source id is required'));
+      }
+      return getSource(id, signal);
+    },
+    enabled: Boolean(id),
+    staleTime: 5 * 60_000,
+  });
+}

--- a/apps/web/src/hooks/useTerritoryDetail.ts
+++ b/apps/web/src/hooks/useTerritoryDetail.ts
@@ -1,0 +1,45 @@
+/**
+ * Hooks para la ficha territorial y sus indicadores.
+ */
+
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+import { getTerritory, getTerritoryIndicators } from '../services/territories';
+import type { TerritoryDetail, TerritoryIndicator } from '../services/types';
+
+export function territoryDetailKey(id: string | null | undefined) {
+  return ['territories', 'detail', id ?? null] as const;
+}
+
+export function territoryIndicatorsKey(id: string | null | undefined) {
+  return ['territories', 'indicators', id ?? null] as const;
+}
+
+export function useTerritoryDetail(id: string | null | undefined): UseQueryResult<TerritoryDetail> {
+  return useQuery({
+    queryKey: territoryDetailKey(id),
+    queryFn: ({ signal }) => {
+      if (!id) {
+        return Promise.reject(new Error('territory id is required'));
+      }
+      return getTerritory(id, signal);
+    },
+    enabled: Boolean(id),
+    staleTime: 2 * 60_000,
+  });
+}
+
+export function useTerritoryIndicators(
+  id: string | null | undefined
+): UseQueryResult<readonly TerritoryIndicator[]> {
+  return useQuery({
+    queryKey: territoryIndicatorsKey(id),
+    queryFn: ({ signal }) => {
+      if (!id) {
+        return Promise.reject(new Error('territory id is required'));
+      }
+      return getTerritoryIndicators(id, signal);
+    },
+    enabled: Boolean(id),
+    staleTime: 2 * 60_000,
+  });
+}

--- a/apps/web/src/hooks/useTerritorySearch.ts
+++ b/apps/web/src/hooks/useTerritorySearch.ts
@@ -1,0 +1,32 @@
+/**
+ * Hook de búsqueda de territorios por texto.
+ *
+ * Se inhabilita automáticamente cuando la cadena es más corta que
+ * `MIN_QUERY_LENGTH` para evitar requests inútiles mientras el usuario
+ * teclea (RF-024).
+ */
+
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+import { searchTerritories } from '../services/territories';
+import type { TerritorySearchResult } from '../services/types';
+
+const MIN_QUERY_LENGTH = 2;
+const DEFAULT_LIMIT = 10;
+
+export function territorySearchKey(query: string, limit: number) {
+  return ['territories', 'search', query, limit] as const;
+}
+
+export function useTerritorySearch(
+  query: string,
+  limit: number = DEFAULT_LIMIT
+): UseQueryResult<readonly TerritorySearchResult[]> {
+  const normalized = query.trim();
+  const enabled = normalized.length >= MIN_QUERY_LENGTH;
+  return useQuery({
+    queryKey: territorySearchKey(normalized, limit),
+    queryFn: ({ signal }) => searchTerritories(normalized, limit, signal),
+    enabled,
+    staleTime: 60_000,
+  });
+}

--- a/apps/web/src/routes/AppRouter.tsx
+++ b/apps/web/src/routes/AppRouter.tsx
@@ -1,0 +1,66 @@
+/**
+ * Configuración de enrutado global con React Router v7.
+ *
+ * Se usa `createBrowserRouter` + `RouterProvider` para permitir splitting y
+ * futuros `loader`/`action`. Todas las rutas internas comparten `DashboardShell`
+ * como layout y exponen un `<Outlet />` donde se monta el contenido de cada
+ * pantalla (mapa, recomendador, comparador, escenarios, ficha territorial).
+ */
+
+import { createBrowserRouter, Outlet } from 'react-router-dom';
+import { DashboardShell } from '../features/dashboard/DashboardShell';
+import { NotFound } from './NotFound';
+
+/**
+ * Layout común: renderiza la carcasa del dashboard (propiedad del feature) y,
+ * a continuación, el `<Outlet />` con el contenido de la ruta activa.
+ *
+ * `DashboardShell` es owner del feature `features/dashboard` y no puede
+ * alterarse desde aquí; por eso componemos ambos elementos como hermanos en
+ * lugar de inyectar `children`. Cuando `DashboardShell` evolucione y acepte
+ * children, el cambio aquí será local y mínimo.
+ */
+function DashboardLayout() {
+  return (
+    <>
+      <DashboardShell />
+      <Outlet />
+    </>
+  );
+}
+
+/**
+ * Placeholder neutro para rutas cuyo contenido específico se construye en
+ * issues posteriores. Evita crear componentes en `features/` (fuera del
+ * alcance de este agente) y permite que el router tenga un elemento renderizable.
+ */
+function RoutePlaceholder({ label }: { readonly label: string }) {
+  return (
+    <section
+      aria-label={label}
+      className="text-ink-500 rounded-xl bg-white/60 p-6 text-sm"
+      data-route-placeholder={label}
+    >
+      {label}
+    </section>
+  );
+}
+
+export const appRouter = createBrowserRouter([
+  {
+    path: '/',
+    element: <DashboardLayout />,
+    errorElement: <NotFound />,
+    children: [
+      { index: true, element: <RoutePlaceholder label="dashboard" /> },
+      { path: 'mapa', element: <RoutePlaceholder label="mapa" /> },
+      { path: 'recomendador', element: <RoutePlaceholder label="recomendador" /> },
+      { path: 'comparador', element: <RoutePlaceholder label="comparador" /> },
+      { path: 'escenarios', element: <RoutePlaceholder label="escenarios" /> },
+      { path: 'territorio/:id', element: <RoutePlaceholder label="territorio" /> },
+    ],
+  },
+  { path: '*', element: <NotFound /> },
+]);
+
+export { DashboardLayout, RoutePlaceholder };

--- a/apps/web/src/routes/NotFound.tsx
+++ b/apps/web/src/routes/NotFound.tsx
@@ -1,0 +1,34 @@
+/**
+ * Pantalla 404 accesible y consistente con la identidad visual base.
+ */
+
+import { Link } from 'react-router-dom';
+
+export function NotFound() {
+  return (
+    <main
+      role="main"
+      aria-labelledby="not-found-title"
+      className="flex min-h-screen items-center justify-center p-12"
+    >
+      <div className="shadow-card mx-auto max-w-xl rounded-2xl bg-white p-10 text-center">
+        <p className="text-brand-600 text-xs font-semibold tracking-[0.18em] uppercase">
+          AtlasHabita
+        </p>
+        <h1 id="not-found-title" className="font-display text-ink-900 mt-3 text-3xl font-bold">
+          Pantalla no encontrada
+        </h1>
+        <p className="text-ink-500 mt-4">
+          La dirección introducida no corresponde a una vista conocida. Vuelve al panel principal
+          para seguir explorando territorios.
+        </p>
+        <Link
+          to="/"
+          className="bg-brand-600 hover:bg-brand-700 focus-visible:ring-brand-600 mt-6 inline-flex items-center justify-center rounded-full px-5 py-2 text-sm font-semibold text-white focus:outline-none focus-visible:ring-2"
+        >
+          Ir al panel principal
+        </Link>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/src/routes/__tests__/AppRouter.test.tsx
+++ b/apps/web/src/routes/__tests__/AppRouter.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from '@testing-library/react';
+import { createMemoryRouter, RouterProvider } from 'react-router-dom';
+import { describe, expect, it } from 'vitest';
+import { DashboardLayout, RoutePlaceholder } from '../AppRouter';
+import { NotFound } from '../NotFound';
+
+function renderAt(initialPath: string) {
+  const router = createMemoryRouter(
+    [
+      {
+        path: '/',
+        element: <DashboardLayout />,
+        children: [
+          { index: true, element: <RoutePlaceholder label="dashboard" /> },
+          { path: 'mapa', element: <RoutePlaceholder label="mapa" /> },
+          { path: 'recomendador', element: <RoutePlaceholder label="recomendador" /> },
+          { path: 'comparador', element: <RoutePlaceholder label="comparador" /> },
+          { path: 'escenarios', element: <RoutePlaceholder label="escenarios" /> },
+          { path: 'territorio/:id', element: <RoutePlaceholder label="territorio" /> },
+        ],
+      },
+      { path: '*', element: <NotFound /> },
+    ],
+    { initialEntries: [initialPath] }
+  );
+  return render(<RouterProvider router={router} />);
+}
+
+describe('AppRouter', () => {
+  it('renderiza el dashboard en la raíz', () => {
+    renderAt('/');
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(/brújula territorial/i);
+    expect(screen.getByRole('region', { name: 'dashboard' })).toBeInTheDocument();
+  });
+
+  it('renderiza placeholders para cada ruta principal', () => {
+    renderAt('/mapa');
+    expect(screen.getByRole('region', { name: 'mapa' })).toBeInTheDocument();
+  });
+
+  it('resuelve la ruta de territorio con parámetro dinámico', () => {
+    renderAt('/territorio/municipality:41091');
+    expect(screen.getByRole('region', { name: 'territorio' })).toBeInTheDocument();
+  });
+
+  it('muestra NotFound ante ruta desconocida', () => {
+    renderAt('/ruta-inexistente');
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(/pantalla no encontrada/i);
+  });
+});

--- a/apps/web/src/services/__tests__/fetchMock.ts
+++ b/apps/web/src/services/__tests__/fetchMock.ts
@@ -1,0 +1,39 @@
+/* eslint-disable no-undef -- RequestInfo/RequestInit son tipos DOM globales. */
+/**
+ * Utilidades de mock de `fetch` reutilizadas por los tests de servicios y hooks.
+ *
+ * Centralizamos el tipado para que `vi.fn()` exponga correctamente la firma
+ * `(input, init)` y los tests puedan leer `mock.calls[i][0]` tipados.
+ */
+
+import { vi, type Mock } from 'vitest';
+
+export type FetchArgs = readonly [input: RequestInfo | URL, init?: RequestInit];
+export type FetchMock = Mock<(...args: FetchArgs) => Promise<Response>>;
+
+/**
+ * Instala un mock de `fetch` que siempre devuelve la respuesta indicada.
+ */
+export function installFetchMock(
+  factory: (...args: FetchArgs) => Promise<Response>
+): FetchMock {
+  const fetchFn = vi.fn(factory);
+  globalThis.fetch = fetchFn as unknown as typeof fetch;
+  return fetchFn;
+}
+
+/**
+ * Construye una `Response` mínima con soporte `text()` para `apiFetch`.
+ */
+export function jsonResponse(
+  body: unknown,
+  init: { status?: number; ok?: boolean } = {}
+): Response {
+  const status = init.status ?? 200;
+  const ok = init.ok ?? (status >= 200 && status < 300);
+  return {
+    ok,
+    status,
+    text: async () => (body === undefined ? '' : JSON.stringify(body)),
+  } as unknown as Response;
+}

--- a/apps/web/src/services/__tests__/http.test.ts
+++ b/apps/web/src/services/__tests__/http.test.ts
@@ -1,0 +1,105 @@
+/* eslint-disable no-undef -- Response, Headers, RequestInit, AbortController y DOMException son tipos DOM globales. */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ApiError, apiFetch, toQueryString } from '../http';
+import { installFetchMock, jsonResponse, type FetchMock } from './fetchMock';
+
+function mockFetchResponse(response: Response): FetchMock {
+  return installFetchMock(async () => response);
+}
+
+function mockFetchError(error: Error): FetchMock {
+  return installFetchMock(async () => {
+    throw error;
+  });
+}
+
+describe('apiFetch', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('antepone la base url /api y añade Accept application/json', async () => {
+    const fetchFn = mockFetchResponse(jsonResponse({ ok: true }));
+    await apiFetch('/profiles');
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchFn.mock.calls[0];
+    expect(url).toBe('/api/profiles');
+    const headers = (init as RequestInit).headers as Headers;
+    expect(headers.get('Accept')).toBe('application/json');
+    expect((init as RequestInit).method).toBe('GET');
+  });
+
+  it('serializa body JSON y fuerza Content-Type', async () => {
+    const fetchFn = mockFetchResponse(jsonResponse({ ok: true }));
+    await apiFetch('/rankings/custom', { method: 'POST', body: { profile: 'explorer' } });
+    const [, init] = fetchFn.mock.calls[0];
+    const headers = (init as RequestInit).headers as Headers;
+    expect(headers.get('Content-Type')).toBe('application/json');
+    expect((init as RequestInit).body).toBe('{"profile":"explorer"}');
+  });
+
+  it('parsea JSON en respuestas 2xx', async () => {
+    mockFetchResponse(jsonResponse({ value: 42 }));
+    const result = await apiFetch<{ value: number }>('/anything');
+    expect(result).toEqual({ value: 42 });
+  });
+
+  it('convierte respuestas de error en ApiError preservando code y status', async () => {
+    mockFetchResponse(
+      jsonResponse(
+        { code: 'INVALID_PROFILE', message: 'Perfil desconocido', details: { profile: 'x' } },
+        { status: 422 }
+      )
+    );
+    await expect(apiFetch('/rankings')).rejects.toMatchObject({
+      name: 'ApiError',
+      code: 'INVALID_PROFILE',
+      status: 422,
+      message: 'Perfil desconocido',
+      details: { profile: 'x' },
+    });
+  });
+
+  it('convierte respuestas de error sin payload en ApiError UNKNOWN', async () => {
+    mockFetchResponse(jsonResponse(undefined, { status: 500 }));
+    const error = (await apiFetch('/anything').catch((err) => err)) as ApiError;
+    expect(error).toBeInstanceOf(ApiError);
+    expect(error.code).toBe('UNKNOWN');
+    expect(error.status).toBe(500);
+  });
+
+  it('transforma errores de red en ApiError status 0', async () => {
+    mockFetchError(new TypeError('network down'));
+    const error = (await apiFetch('/anything').catch((err) => err)) as ApiError;
+    expect(error).toBeInstanceOf(ApiError);
+    expect(error.status).toBe(0);
+    expect(error.message).toBe('network down');
+  });
+
+  it('propaga AbortError sin envolverlo', async () => {
+    const abort = new DOMException('aborted', 'AbortError');
+    mockFetchError(abort);
+    await expect(apiFetch('/anything')).rejects.toBe(abort);
+  });
+
+  it('reenvía el AbortSignal al fetch subyacente', async () => {
+    const fetchFn = mockFetchResponse(jsonResponse({ ok: true }));
+    const controller = new AbortController();
+    await apiFetch('/anything', { signal: controller.signal });
+    const [, init] = fetchFn.mock.calls[0];
+    expect((init as RequestInit).signal).toBe(controller.signal);
+  });
+});
+
+describe('toQueryString', () => {
+  it('omite claves undefined/null y concatena prefijo ?', () => {
+    const qs = toQueryString({ a: 1, b: undefined, c: null, d: 'x' });
+    expect(qs).toBe('?a=1&d=x');
+  });
+  it('devuelve cadena vacía cuando no hay parámetros', () => {
+    expect(toQueryString({ a: undefined })).toBe('');
+  });
+});

--- a/apps/web/src/services/__tests__/services.test.ts
+++ b/apps/web/src/services/__tests__/services.test.ts
@@ -1,0 +1,108 @@
+/* eslint-disable no-undef -- RequestInit es tipo DOM global de TypeScript. */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { listProfiles } from '../profiles';
+import { getTerritory, getTerritoryIndicators, searchTerritories } from '../territories';
+import { computeRanking, computeRankingCustom } from '../rankings';
+import { getMapLayer, listMapLayers } from '../map_layers';
+import { getSource, listSources } from '../sources';
+import { getQualityReport } from '../quality';
+import { installFetchMock, jsonResponse, type FetchMock } from './fetchMock';
+
+function mockFetch(body: unknown): FetchMock {
+  return installFetchMock(async () => jsonResponse(body));
+}
+
+function calledUrl(fetchFn: FetchMock): string {
+  return fetchFn.mock.calls[0][0] as string;
+}
+
+describe('servicios REST', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('listProfiles apunta a /api/profiles', async () => {
+    const fetchFn = mockFetch([]);
+    await listProfiles();
+    expect(calledUrl(fetchFn)).toBe('/api/profiles');
+  });
+
+  it('searchTerritories codifica query y limit', async () => {
+    const fetchFn = mockFetch([]);
+    await searchTerritories('Sevilla', 5);
+    expect(calledUrl(fetchFn)).toBe('/api/territories/search?q=Sevilla&limit=5');
+  });
+
+  it('getTerritory codifica el id territorial', async () => {
+    const fetchFn = mockFetch({});
+    await getTerritory('municipality:41091');
+    expect(calledUrl(fetchFn)).toBe('/api/territories/municipality%3A41091');
+  });
+
+  it('getTerritoryIndicators añade el sufijo indicators', async () => {
+    const fetchFn = mockFetch([]);
+    await getTerritoryIndicators('municipality:41091');
+    expect(calledUrl(fetchFn)).toBe('/api/territories/municipality%3A41091/indicators');
+  });
+
+  it('computeRanking propaga perfil, ámbito y límite por defecto', async () => {
+    const fetchFn = mockFetch({ results: [] });
+    await computeRanking({ profile: 'remote_work', scope: 'province:41' });
+    expect(calledUrl(fetchFn)).toBe(
+      '/api/rankings?profile=remote_work&scope=province%3A41&limit=20'
+    );
+  });
+
+  it('computeRankingCustom hace POST con body JSON', async () => {
+    const fetchFn = mockFetch({ results: [] });
+    const body = {
+      profile: 'family' as const,
+      scope: 'country:es' as const,
+      weights: [{ factor: 'services', weight: 0.5 }],
+    };
+    await computeRankingCustom(body);
+    const [url, init] = fetchFn.mock.calls[0];
+    expect(url).toBe('/api/rankings/custom');
+    expect((init as RequestInit).method).toBe('POST');
+    expect((init as RequestInit).body).toBe(JSON.stringify(body));
+  });
+
+  it('listMapLayers apunta a /map/layers', async () => {
+    const fetchFn = mockFetch([]);
+    await listMapLayers();
+    expect(calledUrl(fetchFn)).toBe('/api/map/layers');
+  });
+
+  it('getMapLayer incluye perfil cuando se provee', async () => {
+    const fetchFn = mockFetch({});
+    await getMapLayer('score', 'student');
+    expect(calledUrl(fetchFn)).toBe('/api/map/layers/score?profile=student');
+  });
+
+  it('getMapLayer omite perfil cuando no se provee', async () => {
+    const fetchFn = mockFetch({});
+    await getMapLayer('score');
+    expect(calledUrl(fetchFn)).toBe('/api/map/layers/score');
+  });
+
+  it('listSources apunta a /sources', async () => {
+    const fetchFn = mockFetch([]);
+    await listSources();
+    expect(calledUrl(fetchFn)).toBe('/api/sources');
+  });
+
+  it('getSource apunta a /sources/:id', async () => {
+    const fetchFn = mockFetch({});
+    await getSource('ine_padron');
+    expect(calledUrl(fetchFn)).toBe('/api/sources/ine_padron');
+  });
+
+  it('getQualityReport apunta a /quality/reports', async () => {
+    const fetchFn = mockFetch({});
+    await getQualityReport();
+    expect(calledUrl(fetchFn)).toBe('/api/quality/reports');
+  });
+});

--- a/apps/web/src/services/http.ts
+++ b/apps/web/src/services/http.ts
@@ -1,0 +1,171 @@
+/* eslint-disable no-undef -- tipos DOM globales (Response, Headers, RequestInit, AbortSignal, DOMException) resueltos por TypeScript. */
+/**
+ * Cliente HTTP tipado para la API de AtlasHabita.
+ *
+ * Expone `apiFetch` como único punto de entrada para cualquier llamada REST.
+ * Se encarga de:
+ *   - anteponer la base URL configurable (`/api` por defecto, proxy en Vite);
+ *   - añadir cabeceras mínimas (`Accept: application/json`);
+ *   - parsear la respuesta JSON incluso ante errores;
+ *   - normalizar errores en la clase `ApiError` para consumo uniforme en UI.
+ */
+
+import type { ApiErrorCode, ErrorResponse } from './types';
+
+/** Base URL configurable mediante variable de entorno de Vite. */
+const DEFAULT_BASE_URL = '/api';
+
+function resolveBaseUrl(): string {
+  const env = (import.meta as ImportMeta & { env?: Record<string, string | undefined> }).env;
+  const configured = env?.VITE_API_BASE_URL?.trim();
+  if (configured && configured.length > 0) {
+    return configured.replace(/\/$/, '');
+  }
+  return DEFAULT_BASE_URL;
+}
+
+/**
+ * Error tipado producido por `apiFetch`. Permite al código UI distinguir
+ * fallos conocidos (perfil inválido, sin datos, etc.) de caídas de red.
+ */
+export class ApiError extends Error {
+  public readonly code: ApiErrorCode | string;
+  public readonly status: number;
+  public readonly details?: Record<string, unknown>;
+
+  constructor(params: {
+    code: ApiErrorCode | string;
+    message: string;
+    status: number;
+    details?: Record<string, unknown>;
+  }) {
+    super(params.message);
+    this.name = 'ApiError';
+    this.code = params.code;
+    this.status = params.status;
+    if (params.details !== undefined) {
+      this.details = params.details;
+    }
+  }
+}
+
+export interface ApiFetchOptions extends Omit<RequestInit, 'body'> {
+  /** Payload JSON que se serializará automáticamente. */
+  readonly body?: unknown;
+  /** Permite cancelar la petición desde fuera. */
+  readonly signal?: AbortSignal;
+}
+
+function buildHeaders(init?: ApiFetchOptions): Headers {
+  const headers = new Headers(init?.headers);
+  if (!headers.has('Accept')) {
+    headers.set('Accept', 'application/json');
+  }
+  if (init?.body !== undefined && !headers.has('Content-Type')) {
+    headers.set('Content-Type', 'application/json');
+  }
+  return headers;
+}
+
+function buildUrl(path: string): string {
+  if (/^https?:\/\//i.test(path)) {
+    return path;
+  }
+  const base = resolveBaseUrl();
+  const normalized = path.startsWith('/') ? path : `/${path}`;
+  return `${base}${normalized}`;
+}
+
+async function parseJsonSafe<T>(response: Response): Promise<T | null> {
+  const text = await response.text();
+  if (text.length === 0) {
+    return null;
+  }
+  try {
+    return JSON.parse(text) as T;
+  } catch {
+    return null;
+  }
+}
+
+function toErrorResponse(payload: unknown, status: number): ErrorResponse {
+  if (payload && typeof payload === 'object' && 'code' in payload && 'message' in payload) {
+    const raw = payload as Partial<ErrorResponse>;
+    return {
+      code: typeof raw.code === 'string' ? raw.code : 'UNKNOWN',
+      message: typeof raw.message === 'string' ? raw.message : `HTTP ${status}`,
+      details: raw.details,
+    };
+  }
+  return {
+    code: 'UNKNOWN',
+    message: `HTTP ${status}`,
+  };
+}
+
+/**
+ * Realiza una petición HTTP a la API y devuelve el JSON parseado.
+ *
+ * @throws {ApiError} cuando la respuesta no es `ok` o la red falla.
+ */
+export async function apiFetch<T>(path: string, init: ApiFetchOptions = {}): Promise<T> {
+  const { body, signal, method, ...rest } = init;
+  const headers = buildHeaders(init);
+
+  const requestInit: RequestInit = {
+    ...rest,
+    method: method ?? (body !== undefined ? 'POST' : 'GET'),
+    headers,
+  };
+  if (body !== undefined) {
+    requestInit.body = typeof body === 'string' ? body : JSON.stringify(body);
+  }
+  if (signal) {
+    requestInit.signal = signal;
+  }
+
+  let response: Response;
+  try {
+    response = await fetch(buildUrl(path), requestInit);
+  } catch (cause) {
+    if (cause instanceof DOMException && cause.name === 'AbortError') {
+      throw cause;
+    }
+    const message = cause instanceof Error ? cause.message : 'Network error';
+    throw new ApiError({ code: 'UNKNOWN', message, status: 0 });
+  }
+
+  if (!response.ok) {
+    const payload = await parseJsonSafe<unknown>(response);
+    const normalized = toErrorResponse(payload, response.status);
+    throw new ApiError({
+      code: normalized.code,
+      message: normalized.message,
+      status: response.status,
+      ...(normalized.details !== undefined ? { details: normalized.details } : {}),
+    });
+  }
+
+  const parsed = await parseJsonSafe<T>(response);
+  if (parsed === null) {
+    // Respuestas 204/empty body no son esperables en los endpoints tipados
+    // que consume este cliente; si ocurre devolvemos un objeto vacío con cast.
+    return {} as T;
+  }
+  return parsed;
+}
+
+/**
+ * Serializa un objeto en query string, omitiendo claves con `undefined` o `null`.
+ */
+export function toQueryString(
+  params: Record<string, string | number | boolean | undefined | null>
+): string {
+  const search = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (value === undefined || value === null) continue;
+    search.set(key, String(value));
+  }
+  const qs = search.toString();
+  return qs.length > 0 ? `?${qs}` : '';
+}

--- a/apps/web/src/services/map_layers.ts
+++ b/apps/web/src/services/map_layers.ts
@@ -1,0 +1,29 @@
+/* eslint-disable no-undef -- AbortSignal es tipo DOM global gestionado por TypeScript. */
+/**
+ * Servicios para los recursos `/map/layers`.
+ */
+
+import { apiFetch, toQueryString } from './http';
+import type { MapLayerPayload, MapLayerSummary, ProfileId } from './types';
+
+/** Lista las capas de mapa disponibles (sin payload GeoJSON). */
+export function listMapLayers(signal?: AbortSignal): Promise<readonly MapLayerSummary[]> {
+  const init = signal ? { signal } : undefined;
+  return apiFetch<readonly MapLayerSummary[]>('/map/layers', init);
+}
+
+/**
+ * Devuelve el payload GeoJSON de una capa.
+ *
+ * Cuando se suministra `profile`, el backend resuelve los valores de score
+ * con los pesos por defecto del perfil para acelerar el render.
+ */
+export function getMapLayer(
+  id: string,
+  profile?: ProfileId,
+  signal?: AbortSignal
+): Promise<MapLayerPayload> {
+  const qs = toQueryString({ profile });
+  const init = signal ? { signal } : undefined;
+  return apiFetch<MapLayerPayload>(`/map/layers/${encodeURIComponent(id)}${qs}`, init);
+}

--- a/apps/web/src/services/profiles.ts
+++ b/apps/web/src/services/profiles.ts
@@ -1,0 +1,16 @@
+/* eslint-disable no-undef -- AbortSignal es tipo DOM global gestionado por TypeScript. */
+/**
+ * Servicio para el recurso `/profiles`.
+ *
+ * Encapsula el acceso HTTP y devuelve los perfiles disponibles junto con
+ * sus pesos por defecto, tal como describe el contrato.
+ */
+
+import { apiFetch } from './http';
+import type { Profile } from './types';
+
+/** Recupera la lista de perfiles soportados por la API. */
+export function listProfiles(signal?: AbortSignal): Promise<readonly Profile[]> {
+  const init = signal ? { signal } : undefined;
+  return apiFetch<readonly Profile[]>('/profiles', init);
+}

--- a/apps/web/src/services/quality.ts
+++ b/apps/web/src/services/quality.ts
@@ -1,0 +1,13 @@
+/* eslint-disable no-undef -- AbortSignal es tipo DOM global gestionado por TypeScript. */
+/**
+ * Servicio para el recurso `/quality/reports`.
+ */
+
+import { apiFetch } from './http';
+import type { QualityReport } from './types';
+
+/** Reporte de calidad consolidado de la versión de datos publicada. */
+export function getQualityReport(signal?: AbortSignal): Promise<QualityReport> {
+  const init = signal ? { signal } : undefined;
+  return apiFetch<QualityReport>('/quality/reports', init);
+}

--- a/apps/web/src/services/rankings.ts
+++ b/apps/web/src/services/rankings.ts
@@ -1,0 +1,42 @@
+/* eslint-disable no-undef -- AbortSignal es tipo DOM global gestionado por TypeScript. */
+/**
+ * Servicios para los recursos `/rankings` y `/rankings/custom`.
+ */
+
+import { apiFetch, toQueryString } from './http';
+import type { RankingCustomBody, RankingQueryParams, RankingResponse } from './types';
+
+const DEFAULT_LIMIT = 20;
+
+/**
+ * Recupera un ranking parametrizado (perfil + ámbito + límite).
+ *
+ * El contrato permite no enviar `limit`; mantenemos un valor por defecto
+ * para que la UI tenga una cota razonable.
+ */
+export function computeRanking(
+  params: RankingQueryParams,
+  signal?: AbortSignal
+): Promise<RankingResponse> {
+  const qs = toQueryString({
+    profile: params.profile,
+    scope: params.scope,
+    limit: params.limit ?? DEFAULT_LIMIT,
+  });
+  const init = signal ? { signal } : undefined;
+  return apiFetch<RankingResponse>(`/rankings${qs}`, init);
+}
+
+/**
+ * Ejecuta un ranking con configuración personalizada (pesos y filtros duros).
+ */
+export function computeRankingCustom(
+  body: RankingCustomBody,
+  signal?: AbortSignal
+): Promise<RankingResponse> {
+  return apiFetch<RankingResponse>('/rankings/custom', {
+    method: 'POST',
+    body,
+    ...(signal ? { signal } : {}),
+  });
+}

--- a/apps/web/src/services/sources.ts
+++ b/apps/web/src/services/sources.ts
@@ -1,0 +1,19 @@
+/* eslint-disable no-undef -- AbortSignal es tipo DOM global gestionado por TypeScript. */
+/**
+ * Servicios para los recursos `/sources`.
+ */
+
+import { apiFetch } from './http';
+import type { SourceDetail, SourceSummary } from './types';
+
+/** Lista fuentes disponibles con su estado y metadatos básicos. */
+export function listSources(signal?: AbortSignal): Promise<readonly SourceSummary[]> {
+  const init = signal ? { signal } : undefined;
+  return apiFetch<readonly SourceSummary[]>('/sources', init);
+}
+
+/** Detalle de una fuente concreta (licencia, cobertura, indicadores). */
+export function getSource(id: string, signal?: AbortSignal): Promise<SourceDetail> {
+  const init = signal ? { signal } : undefined;
+  return apiFetch<SourceDetail>(`/sources/${encodeURIComponent(id)}`, init);
+}

--- a/apps/web/src/services/territories.ts
+++ b/apps/web/src/services/territories.ts
@@ -1,0 +1,40 @@
+/* eslint-disable no-undef -- AbortSignal es tipo DOM global gestionado por TypeScript. */
+/**
+ * Servicios para los recursos `/territories/*`.
+ *
+ * Agrupa búsqueda, detalle e indicadores de una entidad territorial.
+ */
+
+import { apiFetch, toQueryString } from './http';
+import type { TerritoryDetail, TerritoryIndicator, TerritorySearchResult } from './types';
+
+const DEFAULT_SEARCH_LIMIT = 10;
+
+/** Busca territorios por nombre (tolerante a tildes y mayúsculas). */
+export function searchTerritories(
+  query: string,
+  limit: number = DEFAULT_SEARCH_LIMIT,
+  signal?: AbortSignal
+): Promise<readonly TerritorySearchResult[]> {
+  const qs = toQueryString({ q: query, limit });
+  const init = signal ? { signal } : undefined;
+  return apiFetch<readonly TerritorySearchResult[]>(`/territories/search${qs}`, init);
+}
+
+/** Recupera la ficha territorial completa por identificador estable. */
+export function getTerritory(id: string, signal?: AbortSignal): Promise<TerritoryDetail> {
+  const init = signal ? { signal } : undefined;
+  return apiFetch<TerritoryDetail>(`/territories/${encodeURIComponent(id)}`, init);
+}
+
+/** Devuelve la lista de indicadores asociados al territorio. */
+export function getTerritoryIndicators(
+  id: string,
+  signal?: AbortSignal
+): Promise<readonly TerritoryIndicator[]> {
+  const init = signal ? { signal } : undefined;
+  return apiFetch<readonly TerritoryIndicator[]>(
+    `/territories/${encodeURIComponent(id)}/indicators`,
+    init
+  );
+}

--- a/apps/web/src/services/types.ts
+++ b/apps/web/src/services/types.ts
@@ -1,0 +1,245 @@
+/**
+ * Contratos de datos expuestos por la API de AtlasHabita.
+ *
+ * Los tipos se escriben manualmente a partir del documento
+ * `docs/15_BACKEND_API_CONTRATOS_Y_SERVICIOS.md`. No se generan desde OpenAPI
+ * para mantener control explícito del contrato en el frontend.
+ */
+
+// -------------------------------------------------------------------------
+// Perfiles y ámbitos
+// -------------------------------------------------------------------------
+
+/**
+ * Identificadores canónicos de perfil de decisión soportados por la API.
+ * Cualquier nuevo perfil debe añadirse aquí y en la fuente `profiles.ts`.
+ */
+export type ProfileId = 'student' | 'family' | 'remote_work' | 'entrepreneur' | 'explorer';
+
+export interface ProfileWeight {
+  readonly factor: string;
+  readonly weight: number;
+  readonly label?: string;
+}
+
+export interface Profile {
+  readonly id: ProfileId;
+  readonly name: string;
+  readonly description: string;
+  readonly default_weights: readonly ProfileWeight[];
+}
+
+/**
+ * Ámbito territorial: país, comunidad autónoma, provincia o municipio.
+ *
+ * Se codifica como `kind:code` (por ejemplo `province:41`) para alinearse con
+ * el parámetro `scope` aceptado por el endpoint `/rankings`.
+ */
+export type TerritoryScope =
+  | 'country:es'
+  | `autonomous_community:${string}`
+  | `province:${string}`
+  | `municipality:${string}`;
+
+// -------------------------------------------------------------------------
+// Territorios e indicadores
+// -------------------------------------------------------------------------
+
+export type TerritoryKind = 'country' | 'autonomous_community' | 'province' | 'municipality';
+
+export interface TerritorySearchResult {
+  readonly id: string;
+  readonly name: string;
+  readonly type: TerritoryKind;
+  readonly province?: string;
+  readonly autonomous_community?: string;
+}
+
+export interface TerritoryHierarchy {
+  readonly province?: string;
+  readonly autonomous_community?: string;
+}
+
+export type IndicatorQuality = 'ok' | 'imputed' | 'missing' | 'warning';
+
+export interface TerritoryIndicator {
+  readonly id: string;
+  readonly label: string;
+  readonly value: number | null;
+  readonly unit: string;
+  readonly period: string;
+  readonly source_id: string;
+  readonly quality: IndicatorQuality;
+}
+
+export interface TerritoryScore {
+  readonly profile: ProfileId;
+  readonly score: number;
+  readonly version: string;
+}
+
+export interface TerritoryDetail {
+  readonly id: string;
+  readonly name: string;
+  readonly type: TerritoryKind;
+  readonly hierarchy: TerritoryHierarchy;
+  readonly indicators: readonly TerritoryIndicator[];
+  readonly scores: readonly TerritoryScore[];
+}
+
+// -------------------------------------------------------------------------
+// Rankings
+// -------------------------------------------------------------------------
+
+export interface RankingContribution {
+  readonly factor: string;
+  readonly impact: number;
+}
+
+export interface RankingEntry {
+  readonly rank: number;
+  readonly territory_id: string;
+  readonly name: string;
+  readonly province?: string;
+  readonly score: number;
+  readonly confidence: number;
+  readonly highlights: readonly string[];
+  readonly warnings: readonly string[];
+  readonly top_contributions: readonly RankingContribution[];
+}
+
+export interface RankingResponse {
+  readonly profile: ProfileId;
+  readonly scope: TerritoryScope;
+  readonly scoring_version: string;
+  readonly data_version: string;
+  readonly results: readonly RankingEntry[];
+}
+
+export interface HardFilter {
+  readonly factor: string;
+  readonly operator: 'lte' | 'gte' | 'eq';
+  readonly value: number;
+}
+
+export interface RankingQueryParams {
+  readonly profile: ProfileId;
+  readonly scope: TerritoryScope;
+  readonly limit?: number;
+}
+
+export interface RankingCustomBody {
+  readonly profile: ProfileId;
+  readonly scope: TerritoryScope;
+  readonly weights: readonly ProfileWeight[];
+  readonly hard_filters?: readonly HardFilter[];
+  readonly limit?: number;
+}
+
+// -------------------------------------------------------------------------
+// Capas de mapa
+// -------------------------------------------------------------------------
+
+export type MapLayerKind =
+  | 'score'
+  | 'rent'
+  | 'income'
+  | 'services'
+  | 'mobility'
+  | 'connectivity'
+  | 'environment';
+
+export interface MapLayerSummary {
+  readonly id: string;
+  readonly name: string;
+  readonly kind: MapLayerKind;
+  readonly description: string;
+}
+
+/**
+ * Subconjunto tipado de GeoJSON FeatureCollection.
+ *
+ * Se define aquí para no depender de `@types/geojson` y mantener el contrato
+ * local a la API.
+ */
+export interface GeoJsonFeatureCollection<P = Record<string, unknown>> {
+  readonly type: 'FeatureCollection';
+  readonly features: ReadonlyArray<{
+    readonly type: 'Feature';
+    readonly id?: string | number;
+    readonly geometry: {
+      readonly type: string;
+      readonly coordinates: unknown;
+    };
+    readonly properties: P;
+  }>;
+}
+
+export interface MapLayerPayload extends MapLayerSummary {
+  readonly profile?: ProfileId;
+  readonly data: GeoJsonFeatureCollection<{
+    readonly territory_id: string;
+    readonly name: string;
+    readonly value: number | null;
+    readonly score?: number;
+  }>;
+}
+
+// -------------------------------------------------------------------------
+// Fuentes y calidad
+// -------------------------------------------------------------------------
+
+export type SourceStatus = 'fresh' | 'stale' | 'unavailable';
+
+export interface SourceSummary {
+  readonly id: string;
+  readonly name: string;
+  readonly license: string;
+  readonly status: SourceStatus;
+  readonly last_ingested_at: string;
+  readonly coverage?: string;
+}
+
+export interface SourceDetail extends SourceSummary {
+  readonly description: string;
+  readonly url?: string;
+  readonly period?: string;
+  readonly indicators: readonly string[];
+}
+
+export interface QualityRuleReport {
+  readonly rule_id: string;
+  readonly description: string;
+  readonly passed: number;
+  readonly failed: number;
+  readonly status: 'passed' | 'failed' | 'warning';
+}
+
+export interface QualityReport {
+  readonly generated_at: string;
+  readonly data_version: string;
+  readonly rules: readonly QualityRuleReport[];
+}
+
+// -------------------------------------------------------------------------
+// Errores normalizados
+// -------------------------------------------------------------------------
+
+/**
+ * Códigos declarados en la sección 6 del contrato (docs/15).
+ * Se amplía con un caso `UNKNOWN` para errores de transporte o inesperados.
+ */
+export type ApiErrorCode =
+  | 'INVALID_PROFILE'
+  | 'INVALID_SCOPE'
+  | 'TERRITORY_NOT_FOUND'
+  | 'INSUFFICIENT_DATA'
+  | 'SOURCE_UNAVAILABLE'
+  | 'QUALITY_BLOCKED'
+  | 'UNKNOWN';
+
+export interface ErrorResponse {
+  readonly code: ApiErrorCode | string;
+  readonly message: string;
+  readonly details?: Record<string, unknown>;
+}

--- a/apps/web/src/state/__tests__/filters.test.ts
+++ b/apps/web/src/state/__tests__/filters.test.ts
@@ -1,0 +1,62 @@
+/* eslint-disable no-undef -- localStorage es global del navegador. */
+import { beforeEach, describe, expect, it } from 'vitest';
+import { hashWeightOverrides, useFiltersStore } from '../filters';
+
+describe('useFiltersStore', () => {
+  beforeEach(() => {
+    useFiltersStore.getState().resetFilters();
+    localStorage.clear();
+  });
+
+  it('tiene estado inicial explorer/country:es sin overrides', () => {
+    const state = useFiltersStore.getState();
+    expect(state.activeProfile).toBe('explorer');
+    expect(state.scope).toBe('country:es');
+    expect(state.weightOverrides).toEqual({});
+    expect(state.activeLayers).toEqual(['score']);
+    expect(state.hardFilters).toEqual([]);
+  });
+
+  it('actualiza perfil activo', () => {
+    useFiltersStore.getState().setActiveProfile('family');
+    expect(useFiltersStore.getState().activeProfile).toBe('family');
+  });
+
+  it('aplica y limpia overrides de pesos', () => {
+    useFiltersStore.getState().setWeightOverride('rent', 0.4);
+    useFiltersStore.getState().setWeightOverride('services', 0.3);
+    expect(useFiltersStore.getState().weightOverrides).toEqual({ rent: 0.4, services: 0.3 });
+    useFiltersStore.getState().clearWeightOverrides();
+    expect(useFiltersStore.getState().weightOverrides).toEqual({});
+  });
+
+  it('alterna capas activas sin duplicar', () => {
+    const store = useFiltersStore.getState();
+    store.toggleLayer('rent');
+    expect(useFiltersStore.getState().activeLayers).toContain('rent');
+    useFiltersStore.getState().toggleLayer('rent');
+    expect(useFiltersStore.getState().activeLayers).not.toContain('rent');
+  });
+
+  it('guarda filtros duros inmutables', () => {
+    const filters = [{ factor: 'rent', operator: 'lte', value: 12 } as const];
+    useFiltersStore.getState().setHardFilters(filters);
+    expect(useFiltersStore.getState().hardFilters).toEqual(filters);
+  });
+});
+
+describe('hashWeightOverrides', () => {
+  it('devuelve default cuando no hay overrides', () => {
+    expect(hashWeightOverrides({})).toBe('default');
+  });
+  it('es estable respecto al orden de inserción', () => {
+    const a = hashWeightOverrides({ rent: 0.5, services: 0.3 });
+    const b = hashWeightOverrides({ services: 0.3, rent: 0.5 });
+    expect(a).toBe(b);
+  });
+  it('cambia cuando cambian los pesos', () => {
+    const base = hashWeightOverrides({ rent: 0.5 });
+    const alt = hashWeightOverrides({ rent: 0.6 });
+    expect(base).not.toBe(alt);
+  });
+});

--- a/apps/web/src/state/__tests__/selection.test.ts
+++ b/apps/web/src/state/__tests__/selection.test.ts
@@ -1,0 +1,44 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { MAX_COMPARISON_ITEMS, useSelectionStore } from '../selection';
+
+describe('useSelectionStore', () => {
+  beforeEach(() => {
+    useSelectionStore.setState({ selectedTerritoryId: null, comparison: [] });
+  });
+
+  it('inicialmente no hay selección ni comparación', () => {
+    const state = useSelectionStore.getState();
+    expect(state.selectedTerritoryId).toBeNull();
+    expect(state.comparison).toEqual([]);
+  });
+
+  it('selecciona y deselecciona territorio', () => {
+    useSelectionStore.getState().selectTerritory('municipality:41091');
+    expect(useSelectionStore.getState().selectedTerritoryId).toBe('municipality:41091');
+    useSelectionStore.getState().selectTerritory(null);
+    expect(useSelectionStore.getState().selectedTerritoryId).toBeNull();
+  });
+
+  it('toggleComparison añade y elimina sin duplicar', () => {
+    useSelectionStore.getState().toggleComparison('a');
+    useSelectionStore.getState().toggleComparison('b');
+    expect(useSelectionStore.getState().comparison).toEqual(['a', 'b']);
+    useSelectionStore.getState().toggleComparison('a');
+    expect(useSelectionStore.getState().comparison).toEqual(['b']);
+  });
+
+  it('no supera el máximo de comparación', () => {
+    const store = useSelectionStore.getState();
+    for (let i = 0; i < MAX_COMPARISON_ITEMS + 2; i += 1) {
+      store.addToComparison(`t${i}`);
+    }
+    expect(useSelectionStore.getState().comparison).toHaveLength(MAX_COMPARISON_ITEMS);
+  });
+
+  it('clearComparison vacía la selección', () => {
+    useSelectionStore.getState().addToComparison('a');
+    useSelectionStore.getState().addToComparison('b');
+    useSelectionStore.getState().clearComparison();
+    expect(useSelectionStore.getState().comparison).toEqual([]);
+  });
+});

--- a/apps/web/src/state/filters.ts
+++ b/apps/web/src/state/filters.ts
@@ -1,0 +1,96 @@
+/* eslint-disable no-undef -- localStorage es global del navegador gestionado por Zustand persist. */
+/**
+ * Store Zustand que concentra la configuración de filtrado y scoring.
+ *
+ * Persiste en `localStorage` para que el usuario recupere su selección tras
+ * recargar. Sólo se almacenan datos serializables (IDs, pesos y filtros).
+ */
+
+import { create } from 'zustand';
+import { persist, createJSONStorage } from 'zustand/middleware';
+import type { HardFilter, ProfileId, TerritoryScope } from '../services/types';
+
+/**
+ * Sobrescritura parcial de los pesos por perfil.
+ *
+ * Se representa como diccionario `factor -> weight` para permitir que el
+ * usuario mueva sólo los sliders que le interesan sin clonar la lista entera.
+ */
+export type WeightOverrides = Readonly<Record<string, number>>;
+
+export interface FiltersState {
+  readonly activeProfile: ProfileId;
+  readonly scope: TerritoryScope;
+  readonly weightOverrides: WeightOverrides;
+  readonly activeLayers: readonly string[];
+  readonly hardFilters: readonly HardFilter[];
+}
+
+export interface FiltersActions {
+  setActiveProfile: (profile: ProfileId) => void;
+  setScope: (scope: TerritoryScope) => void;
+  setWeightOverride: (factor: string, weight: number) => void;
+  clearWeightOverrides: () => void;
+  toggleLayer: (layerId: string) => void;
+  setLayers: (layers: readonly string[]) => void;
+  setHardFilters: (filters: readonly HardFilter[]) => void;
+  resetFilters: () => void;
+}
+
+const INITIAL_STATE: FiltersState = {
+  activeProfile: 'explorer',
+  scope: 'country:es',
+  weightOverrides: {},
+  activeLayers: ['score'],
+  hardFilters: [],
+};
+
+export type FiltersStore = FiltersState & FiltersActions;
+
+export const useFiltersStore = create<FiltersStore>()(
+  persist(
+    (set) => ({
+      ...INITIAL_STATE,
+      setActiveProfile: (profile) => set({ activeProfile: profile }),
+      setScope: (scope) => set({ scope }),
+      setWeightOverride: (factor, weight) =>
+        set((state) => ({
+          weightOverrides: { ...state.weightOverrides, [factor]: weight },
+        })),
+      clearWeightOverrides: () => set({ weightOverrides: {} }),
+      toggleLayer: (layerId) =>
+        set((state) => {
+          const isActive = state.activeLayers.includes(layerId);
+          const next = isActive
+            ? state.activeLayers.filter((id) => id !== layerId)
+            : [...state.activeLayers, layerId];
+          return { activeLayers: next };
+        }),
+      setLayers: (layers) => set({ activeLayers: [...layers] }),
+      setHardFilters: (filters) => set({ hardFilters: [...filters] }),
+      resetFilters: () => set({ ...INITIAL_STATE }),
+    }),
+    {
+      name: 'atlashabita:filters',
+      version: 1,
+      storage: createJSONStorage(() => localStorage),
+      partialize: (state): FiltersState => ({
+        activeProfile: state.activeProfile,
+        scope: state.scope,
+        weightOverrides: state.weightOverrides,
+        activeLayers: state.activeLayers,
+        hardFilters: state.hardFilters,
+      }),
+    }
+  )
+);
+
+/**
+ * Hash estable de los overrides de pesos para clave de caché.
+ * Ordena por clave para garantizar idempotencia.
+ */
+export function hashWeightOverrides(overrides: WeightOverrides): string {
+  const entries = Object.entries(overrides).sort(([a], [b]) => a.localeCompare(b));
+  if (entries.length === 0) return 'default';
+  return entries.map(([k, v]) => `${k}:${v.toFixed(3)}`).join('|');
+}

--- a/apps/web/src/state/selection.ts
+++ b/apps/web/src/state/selection.ts
@@ -1,0 +1,59 @@
+/**
+ * Store Zustand para selección de territorios en UI.
+ *
+ * Estado efímero: no persiste porque representa la sesión activa
+ * (territorio enfocado y comparación activa).
+ */
+
+import { create } from 'zustand';
+
+/**
+ * La UI actual admite comparar hasta cuatro territorios (RF-007).
+ * Se expone como constante para que los componentes lo usen al validar.
+ */
+export const MAX_COMPARISON_ITEMS = 4;
+
+export interface SelectionState {
+  readonly selectedTerritoryId: string | null;
+  readonly comparison: readonly string[];
+}
+
+export interface SelectionActions {
+  selectTerritory: (id: string | null) => void;
+  toggleComparison: (id: string) => void;
+  addToComparison: (id: string) => void;
+  removeFromComparison: (id: string) => void;
+  clearComparison: () => void;
+}
+
+export type SelectionStore = SelectionState & SelectionActions;
+
+const INITIAL_STATE: SelectionState = {
+  selectedTerritoryId: null,
+  comparison: [],
+};
+
+export const useSelectionStore = create<SelectionStore>((set) => ({
+  ...INITIAL_STATE,
+  selectTerritory: (id) => set({ selectedTerritoryId: id }),
+  toggleComparison: (id) =>
+    set((state) => {
+      if (state.comparison.includes(id)) {
+        return { comparison: state.comparison.filter((current) => current !== id) };
+      }
+      if (state.comparison.length >= MAX_COMPARISON_ITEMS) {
+        return state;
+      }
+      return { comparison: [...state.comparison, id] };
+    }),
+  addToComparison: (id) =>
+    set((state) => {
+      if (state.comparison.includes(id) || state.comparison.length >= MAX_COMPARISON_ITEMS) {
+        return state;
+      }
+      return { comparison: [...state.comparison, id] };
+    }),
+  removeFromComparison: (id) =>
+    set((state) => ({ comparison: state.comparison.filter((current) => current !== id) })),
+  clearComparison: () => set({ comparison: [] }),
+}));


### PR DESCRIPTION
## Resumen

Capa de integración del frontend: cliente `apiFetch` con `ApiError`, servicios tipados para los 7 grupos de endpoints, stores Zustand (`filters` con persistencia, `selection` efímero), hooks TanStack Query (`useProfiles`, `useTerritorySearch`, `useTerritoryDetail`, `useRankings`, `useMapLayers`, `useSources`, `useQualityReport`) y router v7 con las rutas principales.

## Issues

Closes #27

## Verificación

- 57 tests (13 suites) en verde.
- `pnpm format`, `pnpm lint` y `pnpm typecheck` limpios sobre los archivos añadidos (errores pre-existentes en `vite.config.ts`/`playwright.config.ts` quedan fuera de alcance).
- `pnpm vite build` produce bundle 316 kB (100 kB gz).

## Notas

- Claves de caché de rankings `['rankings', profile, scope, limit, weightsHash]` para invalidación precisa.
- `DashboardLayout` compone `DashboardShell` + `<Outlet />` para convivir con las rutas.