### PR TITLE
docs: arquitectura, pipeline, modelo RDF, API, testing y E2E Playwright

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,48 +1,352 @@
-# AtlasHabita — Paquete de documentación técnica y de producto
+# AtlasHabita
 
-**Versión:** 1.0  
-**Fecha:** 2026-04-24  
-**Formato:** Markdown modular  
-**Nombre anterior:** ViveEspaña RDF  
-**Nombre recomendado de trabajo:** AtlasHabita
+> **Plataforma SIG-semántica de recomendación territorial explicable para España**, construida sobre un Knowledge Graph RDF y un motor de scoring transparente.
 
-Este paquete contiene la documentación separada en ficheros independientes para que el proyecto pueda estudiarse, implementarse, defenderse y evolucionar sin depender de documentos monolíticos. La documentación está orientada a un proyecto académico de Complementos de Bases de Datos y a una implementación realista de software: aplicación web geoespacial, Knowledge Graph RDF, motor de recomendación, ingesta ETL/ELT, validación semántica, interfaz de mapa y trazabilidad de fuentes.
+[![Licencia](https://img.shields.io/badge/licencia-MIT-green.svg)](LICENSE)
+[![Python](https://img.shields.io/badge/python-3.12-blue.svg)](https://www.python.org/)
+[![Node](https://img.shields.io/badge/node-20%2B-green.svg)](https://nodejs.org/)
+[![Estado](https://img.shields.io/badge/estado-MVP%20en%20construcción-orange.svg)]()
 
-## Estructura
+AtlasHabita convierte datos abiertos heterogéneos del territorio español en decisiones comprensibles mediante un **mapa interactivo**, un **ranking personalizable por perfil** y una **explicación trazable** de cada recomendación. El sistema integra ingesta ETL/ELT, normalización tabular y geoespacial, construcción de un grafo RDF con RDFLib, validación SHACL con pySHACL, scoring explicable y una interfaz React con MapLibre GL.
+
+---
+
+## Tabla de contenidos
+
+1. [Producto y capturas de referencia](#producto-y-capturas-de-referencia)
+2. [Arquitectura](#arquitectura)
+3. [Stack tecnológico](#stack-tecnológico)
+4. [Requisitos previos](#requisitos-previos)
+5. [Instalación](#instalación)
+6. [Ejecución local](#ejecución-local)
+7. [Pipeline de datos](#pipeline-de-datos)
+8. [Modelo RDF](#modelo-rdf)
+9. [API REST](#api-rest)
+10. [Testing](#testing)
+11. [Roadmap por fases e issues](#roadmap-por-fases-e-issues)
+12. [Flujo GitHub](#flujo-github)
+13. [Documentación complementaria](#documentación-complementaria)
+14. [Créditos y licencia](#créditos-y-licencia)
+
+---
+
+## Producto y capturas de referencia
+
+AtlasHabita resuelve la pregunta **«¿dónde me conviene vivir, estudiar, teletrabajar o emprender en España según lo que valoro?»**. La interfaz reproduce la captura de referencia incluida en `docs/16_FRONTEND_UX_UI_Y_FLUJOS.md` y se compone de:
+
+| Zona | Contenido |
+|---|---|
+| Barra lateral (sidebar) | Navegación principal (mapa, ranking, ficha, comparador, inspector de fuentes, modo técnico). |
+| Barra superior (topbar) | Selector de perfil activo y botón **«Nuevo análisis»** para reiniciar la sesión. |
+| Mapa coroplético | Territorios coloreados por score o capa temática activa (MapLibre GL + GeoJSON). |
+| Ranking lateral | Lista ordenada con score, nombre, provincia y factores destacados. |
+| Panel de tendencias | Tarjetas con indicadores, comparativas históricas y alertas de calidad. |
+| Inspector de fuentes | Procedencia, periodo, licencia y fecha de ingesta por indicador. |
+
+Los flujos principales y los textos de explicación están descritos en [`docs/16_FRONTEND_UX_UI_Y_FLUJOS.md`](docs/16_FRONTEND_UX_UI_Y_FLUJOS.md). Las capturas esperadas para pruebas E2E se documentan en [`apps/web/tests/e2e/fixtures/screenshots.md`](apps/web/tests/e2e/fixtures/screenshots.md).
+
+---
+
+## Arquitectura
+
+El repositorio adopta una **arquitectura screaming por dominios** ([ADR 0002](docs/adr/0002-arquitectura-screaming.md)): el árbol de carpetas expresa el lenguaje del problema (territorios, indicadores, grafo, scoring, fuentes) antes que los frameworks técnicos.
 
 ```text
-AtlasHabita_Documentacion_MD_Completa/
-└── docs/
-    ├── 00_INDICE_GENERAL.md
-    ├── 01_NOMBRES_DEL_PROYECTO.md
-    ├── 02_CONTEXTO_ACADEMICO_Y_OBJETIVOS.md
-    ├── 03_PRD_PRODUCT_REQUIREMENTS_DOCUMENT.md
-    ├── 04_SRS_SOFTWARE_REQUIREMENTS_SPECIFICATION.md
-    ├── 05_REQUISITOS_FUNCIONALES.md
-    ├── 06_REQUISITOS_NO_FUNCIONALES.md
-    ├── 07_REGLAS_DE_NEGOCIO_Y_CRITERIOS_ACEPTACION.md
-    ├── 08_CASOS_DE_USO_E_HISTORIAS_DE_USUARIO.md
-    ├── 09_MODELO_CONCEPTUAL_DEL_DOMINIO.md
-    ├── 10_ARQUITECTURA_DE_SOFTWARE.md
-    ├── 11_MODELO_DE_DATOS_RDF_Y_ONTOLOGIA.md
-    ├── 12_INGESTA_ETL_ELT_Y_CALIDAD_DE_DATOS.md
-    ├── 13_SIG_MAPA_CAPAS_Y_CONSULTAS_ESPACIALES.md
-    ├── 14_MOTOR_DE_RECOMENDACION_Y_DATA_MINING.md
-    ├── 15_BACKEND_API_CONTRATOS_Y_SERVICIOS.md
-    ├── 16_FRONTEND_UX_UI_Y_FLUJOS.md
-    ├── 17_SEGURIDAD_PRIVACIDAD_Y_CUMPLIMIENTO.md
-    ├── 18_PLAN_DE_PRUEBAS_VALIDACION_Y_CALIDAD.md
-    ├── 19_PLAN_DE_IMPLEMENTACION_Y_ENTREGA.md
-    ├── 20_OPERACION_MANTENIMIENTO_Y_OBSERVABILIDAD.md
-    ├── 21_TRAZABILIDAD_REQUISITOS_MODULOS_PRUEBAS.md
-    ├── 22_MEMORIA_ACADEMICA_Y_DEFENSA.md
-    └── 23_GLOSARIO.md
+atlashabita/
+├── apps/
+│   ├── api/                 # Backend Python (FastAPI, RDFLib, pySHACL)
+│   │   └── src/atlashabita/
+│   │       ├── domain/          # Entidades puras y reglas de negocio
+│   │       ├── application/     # Casos de uso
+│   │       ├── infrastructure/  # Adaptadores (RDF, filesystem, HTTP)
+│   │       ├── interfaces/api/  # Routers FastAPI
+│   │       ├── config/          # Configuración tipada
+│   │       └── observability/   # Logging estructurado y errores
+│   └── web/                 # Frontend React 19 + Tailwind v4
+│       └── src/
+│           ├── features/        # Dashboard, mapa, ranking, ficha
+│           ├── components/      # Primitivas UI
+│           ├── services/        # Cliente API tipado
+│           ├── state/           # Stores Zustand
+│           └── styles/          # Tokens Tailwind v4
+├── data/                    # raw/ · normalized/ · analytics/ · rdf/ · seed/
+├── ontology/                # atlashabita.ttl, shapes.ttl
+├── docs/                    # PRD, SRS, arquitectura, ADR, guías
+├── scripts/                 # Utilidades reproducibles
+└── .github/                 # CI, templates, CODEOWNERS
 ```
 
-## Cómo leerlo
+Detalles completos en [`docs/architecture.md`](docs/architecture.md) y en el documento extendido [`docs/10_ARQUITECTURA_DE_SOFTWARE.md`](docs/10_ARQUITECTURA_DE_SOFTWARE.md).
 
-Para entender el producto, empieza por `02`, `03`, `05` y `08`. Para implementar, usa `04`, `10`, `11`, `12`, `15` y `18`. Para preparar la defensa académica, usa `02`, `13`, `14`, `21` y `22`.
+---
 
-## Decisión de naming
+## Stack tecnológico
 
-Los documentos usan **AtlasHabita** como nombre recomendado, manteniendo la equivalencia con el nombre anterior **ViveEspaña RDF**. El fichero `01_NOMBRES_DEL_PROYECTO.md` contiene alternativas y una matriz de decisión.
+Decisión consolidada en [ADR 0003](docs/adr/0003-stack-tecnologico.md):
+
+### Backend
+
+| Aspecto | Elección |
+|---|---|
+| Lenguaje | Python 3.12 |
+| Framework web | FastAPI ≥ 0.115 |
+| RDF / SPARQL | RDFLib 7 |
+| Validación semántica | pySHACL |
+| Datos tabulares | Pandas + Pydantic v2 |
+| HTTP cliente | httpx + tenacity |
+| Logs | structlog |
+| Tests | pytest + pytest-cov |
+| Lint / formato | ruff |
+| Tipado estricto | mypy |
+
+### Frontend
+
+| Aspecto | Elección |
+|---|---|
+| Bundler | Vite 6 |
+| Lenguaje | TypeScript strict |
+| UI | React 19 + Tailwind CSS v4 |
+| Mapas | MapLibre GL JS + react-map-gl |
+| Gráficos | Recharts |
+| Estado servidor | TanStack Query 5 |
+| Estado UI | Zustand 5 |
+| Enrutado | React Router v7 |
+| Tests unitarios | Vitest + Testing Library |
+| Tests E2E | Playwright |
+
+### Infraestructura
+
+- Makefile con objetivos reproducibles (`bootstrap`, `dev`, `lint`, `test`, `build`, `e2e`).
+- Docker Compose opcional para aislar el entorno.
+- GitHub Actions: `ci-quality`, `ci-backend`, `ci-frontend`, `ci-build`, `ci-security`, `ci-rdf`, `ci-e2e`, `ci-docs`.
+
+---
+
+## Requisitos previos
+
+| Herramienta | Versión mínima | Uso |
+|---|---|---|
+| Python | 3.12 | Backend, ingesta, RDF. |
+| Node.js | 20.11 LTS | Frontend Vite + Playwright. |
+| pnpm | 9.15 | Gestor de paquetes del frontend. |
+| GNU Make | 4.x | Orquestación de tareas (opcional pero recomendado). |
+| Docker + Compose | 24.x | Entorno aislado (opcional). |
+
+En Windows se recomienda **Git Bash** o **WSL2** para ejecutar el `Makefile` y los scripts.
+
+---
+
+## Instalación
+
+Clona el repositorio y arranca `develop`:
+
+```bash
+git clone https://github.com/GonxKZ/atllashabita.git
+cd atllashabita
+git switch develop
+```
+
+### Opción A · Instalación guiada con Make
+
+```bash
+make bootstrap       # Backend (.venv + apps/api[dev]) y frontend (pnpm install)
+```
+
+### Opción B · Instalación manual
+
+```bash
+# Backend
+python -m venv .venv
+source .venv/bin/activate          # En Windows: .venv\Scripts\activate
+pip install --upgrade pip
+pip install -e "apps/api[dev]"
+
+# Frontend
+cd apps/web
+pnpm install --frozen-lockfile
+pnpm exec playwright install chromium
+cd ../..
+```
+
+### Opción C · Docker Compose
+
+```bash
+cp .env.example .env
+docker compose up --build
+```
+
+---
+
+## Ejecución local
+
+### Arranque conjunto
+
+```bash
+make dev            # Backend en :8000 y frontend en :5173
+```
+
+### Arranque independiente
+
+```bash
+make dev-api        # uvicorn atlashabita.interfaces.api:create_app --factory --reload
+make dev-web        # pnpm -C apps/web dev
+```
+
+La UI estará disponible en `http://localhost:5173` y proxyea `/api/*` al backend en `http://127.0.0.1:8000`. El endpoint de salud es [`GET /health`](http://127.0.0.1:8000/health) y la documentación OpenAPI en [`/docs`](http://127.0.0.1:8000/docs).
+
+### Variables de entorno relevantes
+
+| Variable | Descripción | Valor por defecto |
+|---|---|---|
+| `ATLASHABITA_ENV` | Entorno lógico (`local`, `dev`, `prod`). | `local` |
+| `ATLASHABITA_CORS_ALLOW_ORIGINS` | Orígenes permitidos separados por coma. | `http://localhost:5173` |
+| `VITE_API_BASE_URL` | Base URL que el frontend usa para hablar con la API. | `http://127.0.0.1:8000` |
+| `E2E_BACKEND` | Si `1`, los tests E2E asumen backend disponible. | `0` |
+
+Consulta [`.env.example`](.env.example) para la lista completa.
+
+---
+
+## Pipeline de datos
+
+El pipeline sigue un flujo `ingest → validate → normalize → build RDF → SHACL → serialize → consultar`, descrito en detalle en [`docs/data-pipeline.md`](docs/data-pipeline.md) y en el documento académico [`docs/12_INGESTA_ETL_ELT_Y_CALIDAD_DE_DATOS.md`](docs/12_INGESTA_ETL_ELT_Y_CALIDAD_DE_DATOS.md).
+
+```mermaid
+flowchart LR
+    A[Descubrimiento de fuente] --> B[Descarga o lectura]
+    B --> C[data/raw/]
+    C --> D[Validación inicial]
+    D --> E[data/normalized/]
+    E --> F[Agregación territorial]
+    F --> G[data/analytics/]
+    G --> H[Construcción RDF]
+    H --> I[Validación SHACL]
+    I --> J[data/rdf/*.ttl]
+    J --> K[API /rankings · /territories · /sources]
+```
+
+El dataset demo (versionado en `data/seed/`) incluye 15 territorios, 5 fuentes, 5 indicadores, 50 observaciones y 3 perfiles que permiten ejecutar todo el pipeline y los tests sin acceso a fuentes externas.
+
+---
+
+## Modelo RDF
+
+La ontología propia reside en [`ontology/atlashabita.ttl`](ontology/atlashabita.ttl) y las restricciones de validación en [`ontology/shapes.ttl`](ontology/shapes.ttl). El resumen ejecutivo con fragmentos y ejemplos SPARQL se encuentra en [`docs/rdf-model.md`](docs/rdf-model.md); el desarrollo completo en [`docs/11_MODELO_DE_DATOS_RDF_Y_ONTOLOGIA.md`](docs/11_MODELO_DE_DATOS_RDF_Y_ONTOLOGIA.md).
+
+Clases principales: `ah:Territory`, `ah:AutonomousCommunity`, `ah:Province`, `ah:Municipality`, `ah:Indicator`, `ah:IndicatorObservation`, `ah:DataSource`, `ah:DecisionProfile`, `ah:Score`, `ah:ScoreContribution`.
+
+```turtle
+@prefix ah:  <https://data.atlashabita.example/ontology/> .
+@prefix ahr: <https://data.atlashabita.example/resource/> .
+
+ahr:territory/municipality/41091
+    a ah:Municipality ;
+    dct:identifier "41091" ;
+    rdfs:label "Sevilla"@es ;
+    ah:belongsTo ahr:territory/province/41 ;
+    ah:hasIndicatorObservation ahr:observation/rent_median/41091/2025 .
+```
+
+---
+
+## API REST
+
+La API expone recursos versionados bajo el prefijo `/`. Contratos completos con request/response y códigos de error en [`docs/api.md`](docs/api.md) y en el documento académico [`docs/15_BACKEND_API_CONTRATOS_Y_SERVICIOS.md`](docs/15_BACKEND_API_CONTRATOS_Y_SERVICIOS.md).
+
+| Método | Ruta | Estado |
+|---|---|---|
+| GET | `/health` | completado |
+| GET | `/profiles` | ready (fase 4) |
+| GET | `/territories/search?q=` | ready (fase 4) |
+| GET | `/territories/{id}` | ready (fase 4) |
+| GET | `/territories/{id}/indicators` | ready (fase 4) |
+| GET | `/rankings` | ready (fase 4) |
+| POST | `/rankings/custom` | ready (fase 4) |
+| GET | `/map/layers` · `/map/layers/{layer_id}` | ready (fase 4) |
+| GET | `/sources` · `/sources/{id}` | ready (fase 4) |
+| GET | `/rdf/export` | ready (fase 4) |
+| GET | `/quality/reports` | ready (fase 4) |
+
+---
+
+## Testing
+
+La pirámide de pruebas, los comandos por capa y los criterios de aceptación del MVP se recogen en [`docs/testing.md`](docs/testing.md). Resumen rápido:
+
+```bash
+# Backend
+pytest apps/api/tests                    # Unitarias + integración
+ruff check apps/api/src apps/api/tests   # Lint
+mypy apps/api/src                        # Tipos
+
+# Frontend
+pnpm -C apps/web test                    # Vitest (jsdom)
+pnpm -C apps/web lint                    # ESLint
+pnpm -C apps/web typecheck               # tsc --noEmit
+pnpm -C apps/web format:check            # Prettier
+
+# E2E
+pnpm -C apps/web e2e                     # Playwright (Chromium)
+
+# RDF
+python -c "from rdflib import Graph; Graph().parse('ontology/atlashabita.ttl', format='turtle')"
+```
+
+Los criterios de salida del MVP se definen en [`docs/18_PLAN_DE_PRUEBAS_VALIDACION_Y_CALIDAD.md`](docs/18_PLAN_DE_PRUEBAS_VALIDACION_Y_CALIDAD.md).
+
+---
+
+## Roadmap por fases e issues
+
+El roadmap detallado con milestones, estado y issues asociadas está en [`docs/roadmap.md`](docs/roadmap.md). Resumen por hitos:
+
+| Milestone | Alcance | Estado | Issues destacadas |
+|---|---|---|---|
+| **M0 · Fundamentos** | ADRs, CODEOWNERS, templates, CI base. | completado | #01, #02, #03 |
+| **M1 · Infraestructura y scaffolding** | Monorepo, workflows, Docker, Makefile. | completado | #04, #05, #06, #07 |
+| **M2 · Pipeline de datos y RDF** | Dataset demo, ontología, shapes, lector seed. | completado | #08, #09, #10, #11, #12 |
+| **M3 · Diseño del sistema de datos** | Validaciones, named graphs, reportes de calidad. | en curso | #13, #14, #15, #16, #17 |
+| **M4 · Backend FastAPI** | Endpoints de dominio, scoring, SPARQL, RDF export. | ready | #18, #19, #20 |
+| **M5 · Frontend pixel a pixel** | Dashboard, mapa, ranking, ficha, comparador. | ready | #21, #22, #23, #24, #25, #26, #27 |
+| **M6 · Tests, CI, seguridad, performance** | Cobertura, OWASP, pip-audit, Playwright completo. | ready | #28, #29, #30, #31, #32, #33 |
+| **M7 · Documentación y release** | README, guías E2E, documentos técnicos, release develop→main. | en curso | #34 |
+
+---
+
+## Flujo GitHub
+
+El flujo operativo completo está en [`docs/github-workflow.md`](docs/github-workflow.md) y en [`CONTRIBUTING.md`](CONTRIBUTING.md). Resumen:
+
+1. `main` es estable y protegida; `develop` es la rama de integración.
+2. Cada tarea parte de una rama hija con prefijo semántico:
+   `feat/issue-<n>-<slug>`, `fix/issue-<n>-<slug>`, `refactor/issue-<n>-<slug>`, `docs/issue-<n>-<slug>`, `test/issue-<n>-<slug>`, `ci/issue-<n>-<slug>`, `chore/issue-<n>-<slug>`.
+3. Los commits siguen [Conventional Commits](https://www.conventionalcommits.org/) y son atómicos, sin coautores automáticos.
+4. Todas las PR se dirigen a `develop` excepto la release final. Se exige CI en verde y revisión antes del merge.
+5. Las ramas **no se borran** al fusionar: sirven de registro histórico.
+
+---
+
+## Documentación complementaria
+
+| Documento | Propósito |
+|---|---|
+| [`docs/architecture.md`](docs/architecture.md) | Arquitectura screaming, capas y decisiones clave. |
+| [`docs/data-pipeline.md`](docs/data-pipeline.md) | Pipeline de datos ingest → RDF. |
+| [`docs/rdf-model.md`](docs/rdf-model.md) | Resumen ejecutivo del modelo RDF y SPARQL. |
+| [`docs/api.md`](docs/api.md) | Catálogo de endpoints con contratos y errores. |
+| [`docs/testing.md`](docs/testing.md) | Pirámide de pruebas y criterios de aceptación. |
+| [`docs/roadmap.md`](docs/roadmap.md) | Milestones M0–M7 con estado e issues. |
+| [`docs/github-workflow.md`](docs/github-workflow.md) | Reglas operativas del repositorio. |
+| [`docs/03_PRD_PRODUCT_REQUIREMENTS_DOCUMENT.md`](docs/03_PRD_PRODUCT_REQUIREMENTS_DOCUMENT.md) | PRD granular del producto. |
+| [`docs/04_SRS_SOFTWARE_REQUIREMENTS_SPECIFICATION.md`](docs/04_SRS_SOFTWARE_REQUIREMENTS_SPECIFICATION.md) | SRS del sistema. |
+| [`docs/adr/`](docs/adr/) | Architecture Decision Records. |
+
+---
+
+## Créditos y licencia
+
+**Autor:** Gonzalo García Lama · Complementos de Bases de Datos · Universidad de Sevilla.
+
+El proyecto se distribuye bajo **licencia MIT** (ver `pyproject.toml` y cabeceras). Los datasets demo respetan las licencias de las fuentes originales (INE, MIVAU/SERPAVI, MITECO, SETELECO, AEMET); su atribución se conserva en [`data/seed/README.md`](data/seed/README.md).
+
+AtlasHabita es un proyecto académico. No sustituye a un portal oficial ni constituye asesoramiento profesional; ofrece orientación explicable sobre datos públicos.

--- a/apps/web/tests/e2e/fixtures/screenshots.md
+++ b/apps/web/tests/e2e/fixtures/screenshots.md
@@ -1,0 +1,84 @@
+# Capturas esperadas para E2E
+
+Este documento describe las capturas de pantalla de referencia usadas en las pruebas Playwright. No contiene imágenes binarias para evitar deriva con el sistema de diseño; sirve como especificación ejecutable para el equipo.
+
+Todas las capturas se toman en viewport `Desktop Chrome` (1280×720) según `apps/web/playwright.config.ts`. Los nombres de fichero siguen el patrón `<spec>-<step>.png` y se generan en `apps/web/test-results/` únicamente cuando el test falla (ver `screenshot: 'only-on-failure'`).
+
+---
+
+## Captura A · Dashboard principal (home.spec.ts)
+
+**Objetivo:** demostrar que la ruta `/` renderiza la estructura base del producto.
+
+| Zona                | Qué debe aparecer                                                                              |
+| ------------------- | ---------------------------------------------------------------------------------------------- |
+| Sidebar izquierda   | Logo "AtlasHabita", navegación con `Mapa`, `Ranking`, `Ficha`, `Comparador`, `Fuentes`.        |
+| Topbar              | Breadcrumb del análisis activo, selector de perfil y botón primario `Nuevo análisis`.          |
+| Mapa                | `canvas` MapLibre o `region` con `aria-label=Mapa` mostrando al menos un polígono coroplético. |
+| Panel de tendencias | Mínimo una tarjeta con título, indicador y delta visible.                                      |
+| Estado              | Sin mensajes de error; si no hay backend, leyenda `Modo demo`.                                 |
+
+Criterios de aceptación automáticos implementados en `home.spec.ts`:
+
+1. El título principal (`h1`) es visible.
+2. La marca `AtlasHabita` aparece en la cabecera.
+3. Cada enlace/zona de navegación está presente.
+4. El botón `Nuevo análisis` está visible y habilitado.
+5. Existe un mapa renderizado (role `region` con nombre, label o `canvas`).
+6. Existe al menos una tarjeta de tendencias (`region` con nombre, texto `tendencias` o un `article`).
+
+---
+
+## Captura B · Cambio de perfil (profile-flow.spec.ts)
+
+**Objetivo:** confirmar que los controles visibles permiten cambiar el perfil activo y que la _ranking card_ se actualiza.
+
+| Paso          | Qué se espera                                                                                                                                           |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Carga inicial | Se muestra el perfil por defecto y la ranking card con resultados ordenados.                                                                            |
+| Interacción   | Cambio de perfil mediante `combobox`, `radiogroup` o `button` con el nombre del perfil destino (`Familia`, `Estudiante`, `Emprendedor`, `Teletrabajo`). |
+| Resultado     | El contenido textual de la ranking card cambia respecto al estado inicial.                                                                              |
+
+Criterios:
+
+- El test **no** valida valores concretos de ranking (eso corresponde a los tests de dominio).
+- El test sí valida que el DOM de la tarjeta se actualice dentro de 8 s tras el cambio.
+- Si el flujo necesita backend real, se activa con `E2E_BACKEND=1` o `E2E_PROFILE_FLOW=1`.
+
+---
+
+## Captura C · Ficha territorial (fase 6)
+
+**Objetivo:** documentar que al seleccionar un territorio en el ranking o el mapa, la ficha muestra indicadores, explicación y fuentes.
+
+| Zona        | Qué debe aparecer                                                                                |
+| ----------- | ------------------------------------------------------------------------------------------------ |
+| Cabecera    | Nombre del territorio, tipo (`Municipio`), provincia y CCAA.                                     |
+| Indicadores | Lista con etiqueta, valor, unidad, periodo y badge de calidad.                                   |
+| Explicación | Resumen en lenguaje natural con al menos tres factores positivos y las penalizaciones aplicadas. |
+| Fuentes     | Cada indicador enlaza con su `DataSource`, periodo y licencia.                                   |
+
+Pendiente de especificación detallada hasta que exista la UI (milestone M5–M6).
+
+---
+
+## Captura D · Inspector de fuentes (fase 6)
+
+**Objetivo:** confirmar que el inspector muestra título, licencia, periodo, fecha de ingesta y estado de calidad.
+
+---
+
+## Convenciones
+
+- **Idioma:** todas las etiquetas visibles están en español.
+- **Accesibilidad:** contraste mínimo AA y elementos interactivos operables con teclado.
+- **Datos sensibles:** ninguna captura contiene PII; si un test usa datos reales, se anonimizan previamente.
+- **Limpieza:** los artefactos de `test-results/` y `playwright-report/` no se commitean (`.gitignore`).
+
+---
+
+## Referencias
+
+- [`apps/web/playwright.config.ts`](../../../playwright.config.ts)
+- [`docs/testing.md`](../../../../docs/testing.md)
+- [`docs/16_FRONTEND_UX_UI_Y_FLUJOS.md`](../../../../docs/16_FRONTEND_UX_UI_Y_FLUJOS.md)

--- a/apps/web/tests/e2e/home.spec.ts
+++ b/apps/web/tests/e2e/home.spec.ts
@@ -1,0 +1,87 @@
+import { expect, test } from '@playwright/test';
+
+/**
+ * E2E-001 · Dashboard principal.
+ *
+ * Verifica que al visitar `/` el usuario encuentra la estructura base del producto:
+ *  - Sidebar con navegación principal.
+ *  - Topbar con el botón "Nuevo análisis".
+ *  - Mapa renderizado.
+ *  - Al menos una tarjeta del panel de tendencias.
+ *
+ * Los selectores son accesibles (`getByRole`, `getByText`) y no dependen de clases o ids internos.
+ * Esta suite corre sobre datos mock incluidos en el bundle del frontend; cuando se apoye en el
+ * backend real, exportar `E2E_BACKEND=1`.
+ */
+
+const NAV_LABELS = ['Mapa', 'Ranking', 'Ficha', 'Comparador', 'Fuentes'] as const;
+
+test.describe('Dashboard principal', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+  });
+
+  test('muestra el titular y la marca del producto', async ({ page }) => {
+    await expect(page.getByRole('heading', { level: 1 })).toBeVisible();
+    await expect(page.getByText('AtlasHabita', { exact: false })).toBeVisible();
+  });
+
+  test('renderiza la sidebar con los enlaces de navegación', async ({ page }) => {
+    const sidebar = page.getByRole('navigation', { name: /principal|lateral|main/i });
+
+    // Cuando el componente aún no expone aria-label, evitamos romper la suite.
+    if (await sidebar.count()) {
+      await expect(sidebar).toBeVisible();
+    }
+
+    for (const label of NAV_LABELS) {
+      const entry = page.getByRole('link', { name: new RegExp(label, 'i') });
+      if (await entry.count()) {
+        await expect(entry.first()).toBeVisible();
+      } else {
+        await expect(page.getByText(new RegExp(label, 'i')).first()).toBeVisible();
+      }
+    }
+  });
+
+  test('renderiza la topbar con el botón "Nuevo análisis"', async ({ page }) => {
+    const newAnalysisButton = page.getByRole('button', { name: /nuevo análisis/i });
+    await expect(newAnalysisButton).toBeVisible();
+    await expect(newAnalysisButton).toBeEnabled();
+  });
+
+  test('renderiza un mapa visible', async ({ page }) => {
+    const byRole = page.getByRole('region', { name: /mapa/i });
+    const byLabel = page.getByLabel(/mapa/i);
+    const mapCandidates = [byRole, byLabel, page.locator('canvas').first()];
+
+    let mapVisible = false;
+    for (const candidate of mapCandidates) {
+      if (await candidate.count()) {
+        await expect(candidate.first()).toBeVisible();
+        mapVisible = true;
+        break;
+      }
+    }
+    expect(mapVisible).toBe(true);
+  });
+
+  test('muestra al menos una tarjeta de tendencias', async ({ page }) => {
+    const regionByRole = page.getByRole('region', { name: /tendencias|panel de tendencias/i });
+    const candidates = [
+      regionByRole,
+      page.getByText(/tendencias/i).first(),
+      page.getByRole('article').first(),
+    ];
+
+    let trendsFound = false;
+    for (const candidate of candidates) {
+      if (await candidate.count()) {
+        await expect(candidate.first()).toBeVisible();
+        trendsFound = true;
+        break;
+      }
+    }
+    expect(trendsFound).toBe(true);
+  });
+});

--- a/apps/web/tests/e2e/profile-flow.spec.ts
+++ b/apps/web/tests/e2e/profile-flow.spec.ts
@@ -1,0 +1,102 @@
+import { expect, test, type Locator, type Page } from '@playwright/test';
+
+/**
+ * E2E-002 · Cambio de perfil.
+ *
+ * Verifica que al cambiar el perfil activo mediante los controles visibles, el contenido del
+ * ranking (ranking card) se actualiza. No asume un selector concreto: prueba en orden un
+ * combobox accesible, un grupo de botones de rol `radio` y un botón etiquetado con el nombre del
+ * perfil. Si el flujo requiere backend real, marcar `E2E_BACKEND=1`.
+ */
+
+test.describe.configure({ mode: 'serial' });
+
+test.describe('Flujo de perfil y ranking', () => {
+  test('el cambio de perfil refleja un cambio en la ranking card', async ({ page }) => {
+    test.skip(
+      process.env.E2E_BACKEND !== '1' && process.env.E2E_PROFILE_FLOW !== '1',
+      'Requiere backend disponible o datos mock del flujo de perfil. Exportar E2E_BACKEND=1.'
+    );
+
+    await page.goto('/');
+
+    const ranking = await resolveRankingRegion(page);
+    await expect(ranking).toBeVisible();
+
+    const initialContent = (await ranking.innerText()).trim();
+    expect(initialContent.length).toBeGreaterThan(0);
+
+    const changed = await switchProfile(page);
+    expect(changed, 'No se encontró un control visible para cambiar el perfil').toBe(true);
+
+    await expect
+      .poll(
+        async () => {
+          const current = (await ranking.innerText()).trim();
+          return current !== initialContent && current.length > 0;
+        },
+        { timeout: 8_000 }
+      )
+      .toBe(true);
+  });
+});
+
+async function resolveRankingRegion(page: Page): Promise<Locator> {
+  const candidates: Locator[] = [
+    page.getByRole('region', { name: /ranking/i }),
+    page.getByRole('list', { name: /ranking|territorios/i }),
+    page.getByTestId('ranking-card'),
+    page.locator('[data-testid="ranking"]').first(),
+  ];
+
+  for (const candidate of candidates) {
+    if (await candidate.count()) {
+      return candidate.first();
+    }
+  }
+
+  // Fallback: buscar un encabezado "Ranking" y devolver su contenedor próximo.
+  const heading = page.getByRole('heading', { name: /ranking/i }).first();
+  await expect(heading).toBeVisible();
+  return heading.locator('xpath=ancestor::*[self::section or self::aside or self::main][1]');
+}
+
+async function switchProfile(page: Page): Promise<boolean> {
+  const newProfiles = ['Familia', 'Estudiante', 'Emprendedor', 'Teletrabajo'];
+
+  // 1) Combobox accesible.
+  const combo = page.getByRole('combobox', { name: /perfil/i }).first();
+  if (await combo.count()) {
+    for (const target of newProfiles) {
+      try {
+        await combo.selectOption({ label: target });
+        return true;
+      } catch {
+        // Si el combobox no tiene esa opción, probamos la siguiente.
+      }
+    }
+  }
+
+  // 2) Grupo de radios.
+  const radioGroup = page.getByRole('radiogroup', { name: /perfil/i }).first();
+  if (await radioGroup.count()) {
+    for (const target of newProfiles) {
+      const radio = radioGroup.getByRole('radio', { name: new RegExp(target, 'i') }).first();
+      if (await radio.count()) {
+        await radio.check({ force: true });
+        return true;
+      }
+    }
+  }
+
+  // 3) Botones etiquetados con el perfil.
+  for (const target of newProfiles) {
+    const button = page.getByRole('button', { name: new RegExp(target, 'i') }).first();
+    if (await button.count()) {
+      await button.click();
+      return true;
+    }
+  }
+
+  return false;
+}

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,343 @@
+# API REST de AtlasHabita
+
+Catálogo operativo de endpoints expuestos por `apps/api` (FastAPI). Alinea el contrato del servidor con los consumidores del frontend (`apps/web`) y documenta los códigos de error normalizados. Para la discusión extendida consulta [`15_BACKEND_API_CONTRATOS_Y_SERVICIOS.md`](15_BACKEND_API_CONTRATOS_Y_SERVICIOS.md).
+
+---
+
+## 1. Convenciones
+
+- **Base URL**: `http://127.0.0.1:8000` en local.
+- **Formato**: `application/json` (UTF-8); `application/geo+json` en capas de mapa.
+- **Autenticación**: no requerida en MVP (modo lectura pública). El panel técnico queda detrás de un flag `ATLASHABITA_ADMIN=1`.
+- **Paginación**: parámetros `limit` (≤ 200) y `offset` (≥ 0).
+- **Idempotencia**: todos los endpoints `GET` son idempotentes y cacheables por `ETag` cuando aplique.
+- **Versionado de datos**: cada respuesta principal incluye `scoring_version` y/o `data_version`.
+- **Documentación interactiva**: `/docs` (Swagger UI) y `/redoc`.
+
+---
+
+## 2. Catálogo
+
+| Método | Ruta | Estado | Descripción |
+|---|---|---|---|
+| GET | `/health` | **completado** | Estado básico del backend. |
+| GET | `/profiles` | ready | Lista de perfiles de decisión disponibles. |
+| GET | `/profiles/{profile_id}` | ready | Metadatos y pesos por defecto de un perfil. |
+| GET | `/territories/search?q=` | ready | Búsqueda textual tolerante a tildes y mayúsculas. |
+| GET | `/territories/{id}` | ready | Ficha territorial completa. |
+| GET | `/territories/{id}/indicators` | ready | Listado de indicadores del territorio. |
+| GET | `/rankings` | ready | Ranking parametrizado por perfil y ámbito. |
+| POST | `/rankings/custom` | ready | Ranking con pesos y filtros personalizados. |
+| GET | `/map/layers` | ready | Catálogo de capas disponibles. |
+| GET | `/map/layers/{layer_id}` | ready | GeoJSON simplificado de una capa. |
+| GET | `/sources` | ready | Catálogo de fuentes y estado. |
+| GET | `/sources/{id}` | ready | Detalle de una fuente (licencia, periodicidad, cobertura). |
+| GET | `/rdf/export` | ready | Exportación RDF limitada (Turtle/TriG/JSON-LD). |
+| GET | `/quality/reports` | ready | Reportes de calidad por fuente y ejecución. |
+
+Los estados siguen el roadmap: **completado** = implementado en `develop`; **ready** = especificado y pendiente de implementación en la fase 4 ([`roadmap.md`](roadmap.md)).
+
+---
+
+## 3. Contratos
+
+### 3.1 `GET /health`
+
+**Response 200**
+
+```json
+{
+  "status": "ok",
+  "name": "AtlasHabita",
+  "version": "0.1.0",
+  "environment": "local",
+  "timestamp": "2026-04-24T10:15:00+00:00"
+}
+```
+
+Implementado en [`apps/api/src/atlashabita/interfaces/api/routers/health.py`](../apps/api/src/atlashabita/interfaces/api/routers/health.py).
+
+---
+
+### 3.2 `GET /profiles`
+
+**Response 200**
+
+```json
+{
+  "items": [
+    {
+      "id": "remote_work",
+      "label": "Teletrabajador",
+      "description": "Prioriza conectividad, servicios y coste de vida.",
+      "default_weights": {
+        "connectivity": 0.30,
+        "rent_median": 0.25,
+        "services": 0.20,
+        "environment": 0.15,
+        "mobility": 0.10
+      }
+    }
+  ]
+}
+```
+
+---
+
+### 3.3 `GET /territories/search?q=`
+
+| Parámetro | Tipo | Obligatorio | Descripción |
+|---|---|---|---|
+| `q` | string | sí | Texto de búsqueda (min. 2 caracteres). |
+| `scope` | string | no | `country` (por defecto), `ccaa:<id>`, `province:<id>`. |
+| `limit` | int | no | 1–50 (por defecto 20). |
+
+**Response 200**
+
+```json
+{
+  "query": "sevilla",
+  "results": [
+    {
+      "id": "municipality:41091",
+      "name": "Sevilla",
+      "province": "Sevilla",
+      "autonomous_community": "Andalucía",
+      "type": "municipality"
+    }
+  ]
+}
+```
+
+---
+
+### 3.4 `GET /territories/{id}`
+
+**Path params:** `id` con el patrón `<type>:<codigo>` (`municipality:41091`, `province:41`, `autonomous_community:01`).
+
+**Response 200**
+
+```json
+{
+  "id": "municipality:41091",
+  "name": "Sevilla",
+  "type": "municipality",
+  "hierarchy": {
+    "province": "Sevilla",
+    "autonomous_community": "Andalucía"
+  },
+  "geometry_centroid": [-5.9823, 37.3886],
+  "indicators": [
+    {
+      "id": "rent_median",
+      "label": "Alquiler mediano",
+      "value": 10.8,
+      "unit": "EUR/m2/mes",
+      "period": "2025",
+      "source_id": "mivau_serpavi",
+      "quality": "ok"
+    }
+  ],
+  "scores": [
+    {
+      "profile": "remote_work",
+      "score": 84.2,
+      "confidence": 0.92,
+      "scoring_version": "2026.04.1"
+    }
+  ]
+}
+```
+
+---
+
+### 3.5 `GET /rankings`
+
+| Parámetro | Tipo | Obligatorio | Descripción |
+|---|---|---|---|
+| `profile` | string | sí | `remote_work`, `student`, `family`, etc. |
+| `scope` | string | no | `country` (por defecto), `ccaa:<id>`, `province:<id>`. |
+| `limit` | int | no | 1–200 (por defecto 20). |
+| `offset` | int | no | ≥ 0 (por defecto 0). |
+
+**Response 200**
+
+```json
+{
+  "profile": "remote_work",
+  "scope": "province:41",
+  "scoring_version": "2026.04.1",
+  "data_version": "2026.04.24",
+  "pagination": { "limit": 20, "offset": 0, "total": 85 },
+  "results": [
+    {
+      "rank": 1,
+      "territory_id": "municipality:41091",
+      "name": "Sevilla",
+      "province": "Sevilla",
+      "score": 84.2,
+      "confidence": 0.92,
+      "highlights": ["Conectividad alta", "Servicios abundantes"],
+      "warnings": ["Alquiler elevado"],
+      "top_contributions": [
+        { "factor": "connectivity", "weight": 0.30, "impact": 24.1 },
+        { "factor": "services",     "weight": 0.20, "impact": 18.3 }
+      ]
+    }
+  ]
+}
+```
+
+---
+
+### 3.6 `POST /rankings/custom`
+
+**Request body**
+
+```json
+{
+  "profile": "remote_work",
+  "scope": "country",
+  "weights_override": {
+    "connectivity": 0.40,
+    "rent_median": 0.30,
+    "services": 0.15,
+    "environment": 0.10,
+    "mobility": 0.05
+  },
+  "hard_filters": {
+    "max_rent_median": 12.0,
+    "min_connectivity": 0.70
+  },
+  "limit": 50
+}
+```
+
+**Response 200**: mismo contrato que `GET /rankings` con el bloque `applied_weights` y `applied_filters` añadido.
+
+Validaciones:
+
+- Suma de pesos = 1.0 ± 1e-6.
+- Pesos ∈ [0, 1].
+- Filtros duros referencian indicadores existentes.
+
+---
+
+### 3.7 `GET /map/layers` y `GET /map/layers/{layer_id}`
+
+`GET /map/layers` devuelve el catálogo:
+
+```json
+{
+  "items": [
+    { "id": "score_remote_work", "label": "Score teletrabajo", "type": "choropleth" },
+    { "id": "rent_median",       "label": "Alquiler mediano",  "type": "choropleth" },
+    { "id": "hospitals",         "label": "Hospitales",        "type": "poi" }
+  ]
+}
+```
+
+`GET /map/layers/{layer_id}` devuelve un `FeatureCollection` GeoJSON simplificado compatible con MapLibre.
+
+---
+
+### 3.8 `GET /sources` y `GET /sources/{id}`
+
+**Response 200 (detalle)**
+
+```json
+{
+  "id": "mivau_serpavi",
+  "title": "Sistema Estatal de Referencia del Precio del Alquiler",
+  "license": "CC BY 4.0",
+  "periodicity": "anual",
+  "last_ingestion": "2026-04-20T09:30:00Z",
+  "coverage": {
+    "municipal": 0.96,
+    "indicators": ["rent_median"]
+  },
+  "status": "ok"
+}
+```
+
+---
+
+### 3.9 `GET /rdf/export`
+
+| Parámetro | Tipo | Obligatorio | Descripción |
+|---|---|---|---|
+| `graph` | string | no | Named graph (`territories`, `housing`, `scores`, ...). |
+| `format` | enum | no | `turtle` (por defecto), `trig`, `json-ld`, `nt`. |
+| `limit` | int | no | Máximo de triples (≤ 50000). |
+
+La respuesta adjunta `Content-Type` apropiado (`text/turtle`, `application/trig`, `application/ld+json`).
+
+---
+
+### 3.10 `GET /quality/reports`
+
+Devuelve una lista paginada de reportes con `source_id`, `timestamp`, `status`, `coverage`, `critical_errors`, `warnings`.
+
+---
+
+## 4. Códigos de error normalizados
+
+Todas las respuestas de error siguen el esquema:
+
+```json
+{
+  "error": "INVALID_PROFILE",
+  "message": "El perfil 'xyz' no existe.",
+  "details": { "allowed": ["remote_work", "student", "family"] }
+}
+```
+
+| Código interno | HTTP | Significado |
+|---|---|---|
+| `INVALID_PROFILE` | 400 | Perfil inexistente o mal formado. |
+| `INVALID_SCOPE` | 400 | Ámbito territorial inválido. |
+| `INVALID_WEIGHTS` | 422 | Pesos fuera de rango o no suman 1. |
+| `INVALID_FILTER` | 422 | Filtro duro referencia indicador inexistente. |
+| `TERRITORY_NOT_FOUND` | 404 | Territorio solicitado no existe. |
+| `LAYER_NOT_FOUND` | 404 | Capa de mapa no disponible. |
+| `SOURCE_NOT_FOUND` | 404 | Fuente no encontrada. |
+| `INSUFFICIENT_DATA` | 409 | Datos insuficientes para calcular el score. |
+| `SOURCE_UNAVAILABLE` | 503 | Fuente no disponible en la versión actual. |
+| `QUALITY_BLOCKED` | 409 | Resultado bloqueado por validación de calidad. |
+| `RATE_LIMITED` | 429 | Exceso de peticiones. |
+| `INTERNAL_ERROR` | 500 | Error inesperado (registrado con `request_id`). |
+
+El mapeo se implementa vía `DomainError` en [`apps/api/src/atlashabita/observability/errors.py`](../apps/api/src/atlashabita/observability/errors.py) y el manejador global en [`apps/api/src/atlashabita/interfaces/api/app.py`](../apps/api/src/atlashabita/interfaces/api/app.py).
+
+---
+
+## 5. Cabeceras y seguridad
+
+| Cabecera | Uso |
+|---|---|
+| `X-Request-Id` | Generada o propagada para correlación de logs. |
+| `Cache-Control` | `public, max-age=60` en lecturas cacheables. |
+| `ETag` / `If-None-Match` | Sólo en recursos estables (`/map/layers/{id}`, `/rdf/export`). |
+
+Medidas de seguridad aplicadas ([`17_SEGURIDAD_PRIVACIDAD_Y_CUMPLIMIENTO.md`](17_SEGURIDAD_PRIVACIDAD_Y_CUMPLIMIENTO.md)):
+
+- Validación estricta con Pydantic v2.
+- Paginación obligatoria en listados.
+- Sin ejecución de SPARQL arbitrario en modo público.
+- CORS restringido a orígenes configurados.
+- Logs sin filtrado de secretos.
+
+---
+
+## 6. Criterio de aceptación
+
+La API se considera aceptable si el frontend puede construir mapa, ranking, ficha, comparador e inspector de fuentes sin leer ficheros internos ni conocer detalles del pipeline ([`15_BACKEND_API_CONTRATOS_Y_SERVICIOS.md §8`](15_BACKEND_API_CONTRATOS_Y_SERVICIOS.md)).
+
+---
+
+## 7. Referencias
+
+- [15 · Backend, API, contratos y servicios](15_BACKEND_API_CONTRATOS_Y_SERVICIOS.md)
+- [architecture.md §7 · Observabilidad y seguridad](architecture.md)
+- [testing.md · Pruebas de API](testing.md)
+- [`apps/api/src/atlashabita/interfaces/api/`](../apps/api/src/atlashabita/interfaces/api/)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,190 @@
+# Arquitectura de AtlasHabita
+
+Este documento consolida las decisiones de arquitectura adoptadas, cómo se traducen a carpetas y módulos y qué flujos existen entre capas. Es el punto de entrada operativo: para la visión académica extendida consulta [`10_ARQUITECTURA_DE_SOFTWARE.md`](10_ARQUITECTURA_DE_SOFTWARE.md); para el contexto de producto, el [PRD](03_PRD_PRODUCT_REQUIREMENTS_DOCUMENT.md).
+
+---
+
+## 1. Principios rectores
+
+1. **Arquitectura screaming**: el árbol de carpetas refleja el dominio del problema (territorios, indicadores, grafo, scoring, fuentes) y no los frameworks. Consolidado en [ADR 0002](adr/0002-arquitectura-screaming.md).
+2. **Dominio limpio**: entidades puras y políticas sin dependencias de FastAPI, RDFLib ni infraestructura. Los casos de uso orquestan; los adaptadores implementan.
+3. **Frontera estable backend↔frontend**: el frontend nunca lee ficheros RDF ni Parquet. Consume endpoints versionados ([`api.md`](api.md)).
+4. **Validación antes de publicación**: un dataset, grafo o score solo se promociona si supera quality gates (tabulares, geoespaciales y SHACL).
+5. **Explicabilidad antes que magia**: el scoring es una suma ponderada normalizada con contribuciones visibles, no una caja negra.
+6. **Observabilidad desde el día uno**: logging estructurado (structlog), correlación por request-id y errores de dominio con código estable.
+
+---
+
+## 2. Vista de alto nivel
+
+```mermaid
+flowchart TB
+    subgraph Fuentes externas
+      A1[Geoespacial · CNIG/IGN]
+      A2[Estadística · INE]
+      A3[Vivienda · SERPAVI/MIVAU]
+      A4[Servicios · MITECO/SETELECO]
+      A5[Transporte · NAP/Renfe]
+      A6[POIs · OSM]
+      A7[Semánticas · datos.gob.es, Wikidata]
+    end
+
+    subgraph Datos (zonas)
+      B1[data/raw/]
+      B2[data/normalized/]
+      B3[data/analytics/]
+      B4[data/rdf/]
+      B5[data/reports/]
+    end
+
+    subgraph Backend (apps/api)
+      C1[domain/]
+      C2[application/]
+      C3[infrastructure/]
+      C4[interfaces/api/]
+    end
+
+    subgraph Frontend (apps/web)
+      D1[features/dashboard]
+      D2[features/map]
+      D3[features/ranking]
+      D4[features/profile]
+      D5[features/sources]
+    end
+
+    A1 & A2 & A3 & A4 & A5 & A6 & A7 --> B1
+    B1 --> B2 --> B3 --> B4
+    B2 & B3 & B4 --> C3
+    C3 --> C2 --> C1
+    C2 --> C4
+    C4 --> D1 & D2 & D3 & D4 & D5
+    B1 & B2 & B4 --> B5
+```
+
+---
+
+## 3. Capas del backend (`apps/api/src/atlashabita/`)
+
+| Capa | Responsabilidad | Depende de | No depende de |
+|---|---|---|---|
+| `domain/` | Entidades (`Territory`, `Indicator`, `DecisionProfile`), value objects y políticas (`scoring`). | Nada salvo tipado estándar. | FastAPI, RDFLib, filesystem. |
+| `application/` | Casos de uso: `GetRanking`, `GetTerritoryProfile`, `BuildKnowledgeGraph`. | `domain/` y puertos abstractos. | Adaptadores concretos. |
+| `infrastructure/` | Implementaciones: lectores CSV/Parquet, RDFLib, pySHACL, caché, HTTP. | `domain/`. | `interfaces/`. |
+| `interfaces/api/` | Routers FastAPI, serialización Pydantic, manejo de `DomainError`. | `application/` e `infrastructure/`. | Lógica de dominio dentro de rutas. |
+| `config/` | `Settings` con `pydantic-settings` y carga de variables `ATLASHABITA_*`. | — | — |
+| `observability/` | `configure_logging`, `get_logger`, jerarquía de errores. | structlog. | dominio. |
+
+### Flujo de una petición `/rankings`
+
+```mermaid
+sequenceDiagram
+    participant UI as Frontend (TanStack Query)
+    participant API as interfaces/api/routers/rankings.py
+    participant UC as application/GetRanking
+    participant DOM as domain/scoring.py
+    participant INF as infrastructure/repositories/*
+    UI->>API: GET /rankings?profile=remote_work&scope=province:41
+    API->>UC: GetRanking(profile, scope, limit)
+    UC->>INF: load_indicators(scope), load_profile(profile_id)
+    INF-->>UC: List[IndicatorObservation], DecisionProfile
+    UC->>DOM: score(profile, observations)
+    DOM-->>UC: Ranking con contribuciones
+    UC-->>API: RankingResponse (Pydantic)
+    API-->>UI: 200 application/json
+```
+
+---
+
+## 4. Capas del frontend (`apps/web/src/`)
+
+| Carpeta | Propósito |
+|---|---|
+| `features/dashboard/` | Layout principal con sidebar, topbar y slots para mapa, ranking y ficha. |
+| `features/map/` | Renderizado MapLibre, capas coropléticas, leyenda y tooltips. |
+| `features/ranking/` | Lista ordenable con score, factores y sincronización con el mapa. |
+| `features/profile/` | Selección de perfil, sliders de pesos y filtros duros. |
+| `features/sources/` | Inspector de procedencia y calidad. |
+| `components/` | Primitivas UI (Button, Card, Badge, Tooltip). |
+| `services/` | Cliente tipado frente a la API. |
+| `state/` | Stores Zustand (perfil activo, pesos, ámbito). |
+| `hooks/` | Hooks transversales (`useRanking`, `useTerritory`, `useSources`). |
+| `styles/` | Tokens y utilidades Tailwind v4. |
+
+El estado de servidor vive en TanStack Query (cache, refetch declarativo); el estado efímero de UI en Zustand; la navegación en React Router v7.
+
+---
+
+## 5. Zonas de datos (`data/`)
+
+| Zona | Contenido | Formatos | Permanencia |
+|---|---|---|---|
+| `raw/` | Descargas originales tal cual llegan. | ZIP, CSV, JSON, SHP, PBF | Corto/medio plazo con hash SHA-256. |
+| `normalized/` | Datos limpios con esquema estable. | Parquet, GeoPackage | Versionable. |
+| `analytics/` | Indicadores agregados listos para scoring. | Parquet | Versionable. |
+| `rdf/` | Grafo RDF serializado por named graph. | Turtle, TriG, JSON-LD | Versionable. |
+| `seed/` | Dataset demo versionado en git. | CSV | Versionado. |
+| `reports/` | Reportes de calidad por ejecución. | JSON, Markdown, HTML | Auditables. |
+
+---
+
+## 6. Decisiones clave
+
+| ID | Decisión | Estado | Referencia |
+|---|---|---|---|
+| ADR-0001 | Auditoría inicial del repositorio heredado y desbloqueo del flujo. | Aceptado | [adr/0001](adr/0001-auditoria-inicial.md) |
+| ADR-0002 | Arquitectura screaming por dominios en apps/api y apps/web. | Aceptado | [adr/0002](adr/0002-arquitectura-screaming.md) |
+| ADR-0003 | Stack tecnológico: FastAPI, RDFLib, pySHACL, React 19, Tailwind v4, Vite 6, MapLibre. | Aceptado | [adr/0003](adr/0003-stack-tecnologico.md) |
+| DA-001 | Separar datos brutos de RDF; el grafo contiene entidades, relaciones, procedencia, indicadores agregados y scores. | Aceptado | [10_ARQUITECTURA_DE_SOFTWARE.md §5](10_ARQUITECTURA_DE_SOFTWARE.md) |
+| DA-002 | Scoring explicable (suma ponderada normalizada) antes que modelo opaco. | Aceptado | [14_MOTOR_DE_RECOMENDACION_Y_DATA_MINING.md](14_MOTOR_DE_RECOMENDACION_Y_DATA_MINING.md) |
+| DA-003 | API como única frontera visible; sin lectura directa de RDF/Parquet desde el frontend. | Aceptado | [15_BACKEND_API_CONTRATOS_Y_SERVICIOS.md](15_BACKEND_API_CONTRATOS_Y_SERVICIOS.md) |
+| DA-004 | Validación antes de publicación (quality gates + SHACL). | Aceptado | [12_INGESTA_ETL_ELT_Y_CALIDAD_DE_DATOS.md](12_INGESTA_ETL_ELT_Y_CALIDAD_DE_DATOS.md) |
+
+---
+
+## 7. Flujos transversales
+
+### 7.1 Observabilidad
+
+- `observability/logging.py` configura structlog con formato JSON en `prod` y rich en `local`.
+- Cada request recibe `request_id` correlacionado en logs y respuestas de error.
+- Los errores de dominio heredan de `DomainError` y se convierten en respuestas `JSONResponse` con `code`, `message`, `details` ([`apps/api/src/atlashabita/interfaces/api/app.py`](../apps/api/src/atlashabita/interfaces/api/app.py)).
+
+### 7.2 Configuración
+
+- `config/settings.py` expone `Settings` (pydantic-settings) leyendo `ATLASHABITA_*` del entorno y `.env`.
+- El frontend lee `VITE_API_BASE_URL` y otras variables `VITE_*` en build time.
+
+### 7.3 Seguridad
+
+- CORS restrictivo por defecto (`ATLASHABITA_CORS_ALLOW_ORIGINS`).
+- Paginación y límites obligatorios en endpoints de listado (`limit`, `offset`).
+- Sin exposición de rutas de ficheros internos.
+- Sin SPARQL arbitrario en modo público; consultas predefinidas o sandbox ([`17_SEGURIDAD_PRIVACIDAD_Y_CUMPLIMIENTO.md`](17_SEGURIDAD_PRIVACIDAD_Y_CUMPLIMIENTO.md)).
+
+---
+
+## 8. Riesgos arquitectónicos y mitigaciones
+
+| Riesgo | Impacto | Mitigación |
+|---|---|---|
+| Geometrías municipales pesadas en el mapa. | Alto | Simplificación previa + teselas por zoom. |
+| RDF excesivamente grande. | Medio | Named graphs, solo entidades y agregados semánticos en el grafo. |
+| Fuentes externas inestables. | Alto | Cache `data/raw/` + dataset demo `data/seed/` para modo offline. |
+| Acoplamiento ingesta↔UI. | Alto | Contratos tipados en `application/` y endpoints estables. |
+| Scoring opaco. | Alto | Contribuciones por factor, pesos visibles y tests de regresión sobre dataset demo. |
+
+---
+
+## 9. Referencias
+
+- [ADR 0001 · Auditoría inicial](adr/0001-auditoria-inicial.md)
+- [ADR 0002 · Arquitectura screaming](adr/0002-arquitectura-screaming.md)
+- [ADR 0003 · Stack tecnológico](adr/0003-stack-tecnologico.md)
+- [10 · Arquitectura de software (extendido)](10_ARQUITECTURA_DE_SOFTWARE.md)
+- [15 · Backend, API, contratos y servicios](15_BACKEND_API_CONTRATOS_Y_SERVICIOS.md)
+- [16 · Frontend, UX/UI y flujos](16_FRONTEND_UX_UI_Y_FLUJOS.md)
+- [api.md · Catálogo de endpoints](api.md)
+- [data-pipeline.md · Pipeline de datos](data-pipeline.md)
+- [rdf-model.md · Modelo RDF resumido](rdf-model.md)
+- [testing.md · Pirámide de pruebas](testing.md)
+- [roadmap.md · Milestones M0–M7](roadmap.md)

--- a/docs/data-pipeline.md
+++ b/docs/data-pipeline.md
@@ -1,0 +1,189 @@
+# Pipeline de datos de AtlasHabita
+
+Este documento describe el flujo operativo que convierte fuentes heterogéneas en datasets normalizados, indicadores agregados y grafo RDF listo para SPARQL. Para el tratamiento académico completo consulta [`12_INGESTA_ETL_ELT_Y_CALIDAD_DE_DATOS.md`](12_INGESTA_ETL_ELT_Y_CALIDAD_DE_DATOS.md); para el modelo semántico resultante, [`rdf-model.md`](rdf-model.md).
+
+---
+
+## 1. Flujo general
+
+```mermaid
+flowchart LR
+    A[Descubrimiento] --> B[Ingesta]
+    B --> C[data/raw/]
+    C --> D[Validación inicial]
+    D --> E[Normalización]
+    E --> F[data/normalized/]
+    F --> G[Validación de contrato]
+    G --> H[Agregación territorial]
+    H --> I[data/analytics/]
+    I --> J[Construcción RDF]
+    J --> K[Validación SHACL]
+    K --> L[data/rdf/*.ttl]
+    L --> M[API / SPARQL]
+    D --> R[data/reports/]
+    G --> R
+    K --> R
+```
+
+Cada flecha del diagrama corresponde a un caso de uso en `apps/api/src/atlashabita/application/`; los adaptadores concretos viven en `apps/api/src/atlashabita/infrastructure/ingestion/` y `infrastructure/knowledge_graph/`.
+
+---
+
+## 2. Etapas del pipeline
+
+### 2.1 Ingesta
+
+- Entrada: contrato de fuente con `id`, URL o fichero, tipo, licencia y periodicidad ([`12_INGESTA_ETL_ELT_Y_CALIDAD_DE_DATOS.md §5`](12_INGESTA_ETL_ELT_Y_CALIDAD_DE_DATOS.md)).
+- Salida: fichero en `data/raw/<id>/<yyyy-mm-dd>/` con hash SHA-256 y metadatos JSON.
+- Reintentos idempotentes con `httpx + tenacity`.
+- Para desarrollo offline se usa el dataset demo de `data/seed/` leído por [`apps/api/src/atlashabita/infrastructure/ingestion/seed_loader.py`](../apps/api/src/atlashabita/infrastructure/ingestion/seed_loader.py).
+
+### 2.2 Validación inicial
+
+- Comprueba tamaño, hash, formato y codificación.
+- Detecta cambios de esquema contra el contrato esperado.
+- Resultado: `data/reports/<id>/ingestion_<timestamp>.json` con estado `OK | WARNING | ERROR`.
+
+### 2.3 Normalización
+
+- Armoniza códigos territoriales (INE) y nombres (`python-slugify`).
+- Normaliza CRS a EPSG:4326 y simplifica geometrías.
+- Emite Parquet/GeoPackage en `data/normalized/<dominio>.parquet`.
+
+Validaciones tabulares aplicadas (resumen):
+
+| Validación | Ejemplo |
+|---|---|
+| Columnas obligatorias | `codigo_ine`, `valor`, `periodo`, `fuente`. |
+| Tipos | numérico, fecha, código como string. |
+| Rangos | score ∈ [0, 100]; porcentaje ∈ [0, 1] o [0, 100]. |
+| Unicidad | no duplicar `(indicador, territorio, periodo, fuente)`. |
+| Nulos | prohibidos en claves y fuente. |
+| Cobertura | % de municipios con dato por indicador crítico. |
+| Integridad territorial | el código debe existir en la dimensión territorios. |
+
+Validaciones geoespaciales:
+
+- CRS conocido y transformado si hace falta.
+- Geometrías no vacías y con área positiva para polígonos.
+- Correspondencia `codigo_territorial ↔ geometria`.
+- Simplificación compatible con el nivel de zoom objetivo del mapa.
+
+### 2.4 Agregación territorial
+
+- Combina fuentes para obtener indicadores por territorio y periodo.
+- Resultado: `data/analytics/indicators_by_territory.parquet` con columnas `(indicator_id, territory_id, period, value, unit, quality_flag, source_id)`.
+- Estas tablas alimentan el scoring y los endpoints `/territories/{id}/indicators` y `/rankings`.
+
+### 2.5 Construcción RDF
+
+- Adaptador `rdflib.Graph` por named graph (ver sección 4).
+- Política de URIs estable:
+
+```text
+https://data.atlashabita.example/resource/territory/municipality/{codigo_ine}
+https://data.atlashabita.example/resource/territory/province/{codigo_provincia}
+https://data.atlashabita.example/resource/indicator/{codigo_indicador}
+https://data.atlashabita.example/resource/source/{id_fuente}
+https://data.atlashabita.example/resource/profile/{id_perfil}
+https://data.atlashabita.example/resource/score/{version}/{perfil}/{territorio}
+```
+
+- Serialización por named graph a `data/rdf/<graph>.ttl`.
+
+### 2.6 Validación SHACL
+
+- `pyshacl.validate(data_graph, shacl_graph, inference='rdfs')` frente a [`ontology/shapes.ttl`](../ontology/shapes.ttl).
+- Un incumplimiento de severidad `Violation` bloquea la publicación (`data/reports/shacl_<timestamp>.json`).
+- Los `Warning` se conservan en el reporte pero no bloquean.
+
+### 2.7 Publicación
+
+- El grafo se publica si y solo si:
+  1. Validaciones tabulares críticas pasan.
+  2. Validaciones geoespaciales críticas pasan.
+  3. SHACL sin violaciones críticas.
+- Si falla, se mantiene la versión previa cacheada marcada como *antigua* y la UI muestra aviso.
+
+---
+
+## 3. Zonas de datos y retención
+
+| Zona | Ruta | Contenido | Retención |
+|---|---|---|---|
+| Raw | `data/raw/` | Descargas originales | Hasta la siguiente ingesta exitosa + 1. |
+| Normalizado | `data/normalized/` | Parquet/GeoPackage limpios | Versiones semánticas por dataset. |
+| Analítico | `data/analytics/` | Indicadores por territorio | Última versión + histórico trimestral. |
+| RDF | `data/rdf/` | Turtle por named graph | Última versión publicada + previa. |
+| Reportes | `data/reports/` | Calidad y SHACL | 12 meses. |
+| Seed | `data/seed/` | Dataset demo versionado | Siempre presente para desarrollo/tests. |
+
+---
+
+## 4. Named graphs
+
+Se separan por dominio para auditar, actualizar y consultar independientemente ([`11_MODELO_DE_DATOS_RDF_Y_ONTOLOGIA.md §10`](11_MODELO_DE_DATOS_RDF_Y_ONTOLOGIA.md)):
+
+| Named graph | Contenido |
+|---|---|
+| `ahg:territories` | Jerarquía administrativa y geometrías resumidas. |
+| `ahg:socioeconomic` | Renta, desempleo, educación. |
+| `ahg:housing` | Alquiler, vivienda, accesibilidad residencial. |
+| `ahg:mobility` | Transporte, estaciones, cobertura. |
+| `ahg:services` | Sanidad, educación, servicios básicos. |
+| `ahg:sources` | Metadatos y procedencia. |
+| `ahg:scores` | Scores calculados por perfil y versión. |
+
+---
+
+## 5. Dataset demo (`data/seed/`)
+
+Contiene lo imprescindible para que el pipeline funcione sin conexión y los tests sean deterministas:
+
+| Archivo | Contenido | Filas |
+|---|---|---|
+| `territories.csv` | CCAA, provincias y municipios con centroides y población. | 15 |
+| `sources.csv` | SERPAVI, INE, MITECO, SETELECO, AEMET. | 5 |
+| `indicators.csv` | Definiciones semánticas con unidad y direccionalidad. | 5 |
+| `observations.csv` | Valores por `(indicador, territorio, periodo)`. | 50 |
+| `profiles.csv` | Perfiles de decisión con pesos. | 3 |
+
+El lector está en [`seed_loader.py`](../apps/api/src/atlashabita/infrastructure/ingestion/seed_loader.py).
+
+---
+
+## 6. Reportes de calidad
+
+Formato canónico (YAML/JSON) generado en cada ejecución:
+
+```yaml
+fuente: ine_atlas_renta
+fecha_ejecucion: 2026-04-24T08:15:00Z
+estado: OK
+filas_raw: 123456
+filas_normalizadas: 123100
+cobertura_municipal: 0.98
+errores_criticos: 0
+advertencias: 12
+artefactos_generados:
+  - data/normalized/income.parquet
+  - data/reports/ine_atlas_renta_quality.json
+```
+
+---
+
+## 7. Reproducibilidad
+
+- Cada ejecución registra versión de scoring, hash de entrada y hash de salida.
+- `scripts/` contiene utilidades deterministas (sin dependencias vivas).
+- El workflow `ci-rdf.yml` reconstruye el grafo en CI usando `data/seed/` y valida SHACL.
+
+---
+
+## 8. Referencias
+
+- [12 · Ingesta ETL/ELT y calidad de datos](12_INGESTA_ETL_ELT_Y_CALIDAD_DE_DATOS.md)
+- [11 · Modelo RDF y ontología](11_MODELO_DE_DATOS_RDF_Y_ONTOLOGIA.md)
+- [rdf-model.md · Modelo RDF resumido](rdf-model.md)
+- [api.md · Endpoints que consumen el pipeline](api.md)
+- [testing.md · Validaciones y quality gates en la pirámide de pruebas](testing.md)

--- a/docs/rdf-model.md
+++ b/docs/rdf-model.md
@@ -1,0 +1,286 @@
+# Modelo RDF de AtlasHabita
+
+Resumen ejecutivo del Knowledge Graph construido en [`ontology/atlashabita.ttl`](../ontology/atlashabita.ttl) y validado por [`ontology/shapes.ttl`](../ontology/shapes.ttl). Para la discusión académica completa consulta [`11_MODELO_DE_DATOS_RDF_Y_ONTOLOGIA.md`](11_MODELO_DE_DATOS_RDF_Y_ONTOLOGIA.md) y [`data-pipeline.md`](data-pipeline.md).
+
+---
+
+## 1. Objetivos del modelo
+
+1. Representar el **dominio territorial** español (CCAA, provincias, municipios) con URIs estables.
+2. Modelar **indicadores y observaciones** con unidad, periodo y procedencia.
+3. Permitir **recomendación explicable**: perfiles, scores y contribuciones al score.
+4. Ser **consultable con SPARQL** y **validable con SHACL**.
+5. Mantener trazabilidad mediante `prov:Agent` y `prov:wasAttributedTo`.
+
+---
+
+## 2. Espacios de nombres
+
+| Prefijo | URI | Uso |
+|---|---|---|
+| `ah:` | `https://data.atlashabita.example/ontology/` | Ontología propia. |
+| `ahr:` | `https://data.atlashabita.example/resource/` | Recursos. |
+| `rdf:` | `http://www.w3.org/1999/02/22-rdf-syntax-ns#` | Base RDF. |
+| `rdfs:` | `http://www.w3.org/2000/01/rdf-schema#` | Etiquetas y clases. |
+| `owl:` | `http://www.w3.org/2002/07/owl#` | Clases y propiedades OWL. |
+| `xsd:` | `http://www.w3.org/2001/XMLSchema#` | Tipos literales. |
+| `dct:` | `http://purl.org/dc/terms/` | Metadatos Dublin Core. |
+| `skos:` | `http://www.w3.org/2004/02/skos/core#` | Taxonomías. |
+| `geo:` | `http://www.w3.org/2003/01/geo/wgs84_pos#` | Coordenadas. |
+| `prov:` | `http://www.w3.org/ns/prov#` | Procedencia. |
+| `sh:` | `http://www.w3.org/ns/shacl#` | Shapes SHACL. |
+
+---
+
+## 3. Clases principales
+
+Extraídas directamente de `ontology/atlashabita.ttl`:
+
+```turtle
+ah:Territory              a owl:Class .
+ah:AutonomousCommunity    rdfs:subClassOf ah:Territory .
+ah:Province               rdfs:subClassOf ah:Territory .
+ah:Municipality           rdfs:subClassOf ah:Territory .
+
+ah:Indicator              a owl:Class .
+ah:IndicatorObservation   a owl:Class .
+ah:DataSource             rdfs:subClassOf prov:Agent .
+
+ah:DecisionProfile        a owl:Class .
+ah:Score                  a owl:Class .
+ah:ScoreContribution      a owl:Class .
+```
+
+---
+
+## 4. Propiedades principales
+
+| Propiedad | Dominio | Rango | Uso |
+|---|---|---|---|
+| `ah:belongsTo` | `ah:Territory` | `ah:Territory` | Jerarquía administrativa. |
+| `ah:population` | `ah:Territory` | `xsd:integer` | Población registrada. |
+| `ah:area` | `ah:Territory` | `xsd:decimal` | Área en km². |
+| `ah:hasIndicatorObservation` | `ah:Territory` | `ah:IndicatorObservation` | Valores observados. |
+| `ah:indicator` | `ah:IndicatorObservation` | `ah:Indicator` | Tipo de indicador. |
+| `ah:value` | `ah:IndicatorObservation` | `xsd:decimal` | Valor numérico. |
+| `ah:unit` | `ah:IndicatorObservation` | `xsd:string` | Unidad canónica. |
+| `ah:period` | `ah:IndicatorObservation` | `xsd:string` | Periodo (`2025`, `2025Q2`). |
+| `ah:providedBy` | `ah:IndicatorObservation` | `ah:DataSource` | Procedencia (sub-propiedad de `prov:wasAttributedTo`). |
+| `ah:direction` | `ah:Indicator` | `xsd:string` | `higher_is_better` o `lower_is_better`. |
+| `ah:qualityFlag` | `ah:IndicatorObservation` | `xsd:string` | `ok`, `warning`, `imputed`. |
+| `ah:license` | `ah:DataSource` | `xsd:string` | Licencia de uso. |
+| `ah:periodicity` | `ah:DataSource` | `xsd:string` | Frecuencia de actualización. |
+| `ah:hasScore` | `ah:Territory` | `ah:Score` | Resultado por perfil. |
+| `ah:forProfile` | `ah:Score` | `ah:DecisionProfile` | Perfil aplicado. |
+| `ah:hasContribution` | `ah:Score` | `ah:ScoreContribution` | Explicación parcial. |
+| `ah:weight` | `ah:ScoreContribution` | `xsd:decimal` | Peso aplicado. |
+| `ah:normalizedValue` | `ah:ScoreContribution` | `xsd:decimal` | Valor tras normalizar. |
+| `ah:impact` | `ah:ScoreContribution` | `xsd:decimal` | Aporte final al score. |
+| `ah:scoreValue` | `ah:Score` | `xsd:decimal` | Score total (0–100). |
+| `ah:scoringVersion` | `ah:Score` | `xsd:string` | Versión reproducible. |
+| `ah:confidence` | `ah:Score` | `xsd:decimal` | Confianza (0–1). |
+
+---
+
+## 5. Política de URIs
+
+```text
+https://data.atlashabita.example/resource/territory/autonomous_community/{id_ccaa}
+https://data.atlashabita.example/resource/territory/province/{codigo_provincia}
+https://data.atlashabita.example/resource/territory/municipality/{codigo_ine}
+https://data.atlashabita.example/resource/indicator/{codigo_indicador}
+https://data.atlashabita.example/resource/source/{id_fuente}
+https://data.atlashabita.example/resource/profile/{id_perfil}
+https://data.atlashabita.example/resource/observation/{indicador}/{territorio}/{periodo}
+https://data.atlashabita.example/resource/score/{scoring_version}/{perfil}/{territorio}
+```
+
+---
+
+## 6. Ejemplo Turtle
+
+```turtle
+@prefix ah:   <https://data.atlashabita.example/ontology/> .
+@prefix ahr:  <https://data.atlashabita.example/resource/> .
+@prefix dct:  <http://purl.org/dc/terms/> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
+@prefix geo:  <http://www.w3.org/2003/01/geo/wgs84_pos#> .
+
+ahr:territory/municipality/41091
+    a ah:Municipality ;
+    dct:identifier "41091" ;
+    rdfs:label "Sevilla"@es ;
+    geo:lat "37.3886"^^xsd:decimal ;
+    geo:long "-5.9823"^^xsd:decimal ;
+    ah:population 684025 ;
+    ah:belongsTo ahr:territory/province/41 ;
+    ah:hasIndicatorObservation ahr:observation/rent_median/41091/2025 .
+
+ahr:observation/rent_median/41091/2025
+    a ah:IndicatorObservation ;
+    ah:indicator ahr:indicator/rent_median ;
+    ah:value "10.8"^^xsd:decimal ;
+    ah:unit "EUR_M2_MONTH" ;
+    ah:period "2025" ;
+    ah:qualityFlag "ok" ;
+    ah:providedBy ahr:source/mivau_serpavi .
+
+ahr:source/mivau_serpavi
+    a ah:DataSource ;
+    dct:title "Sistema Estatal de Referencia del Precio del Alquiler de Vivienda"@es ;
+    ah:license "CC BY 4.0" ;
+    ah:periodicity "anual" .
+```
+
+---
+
+## 7. Restricciones SHACL destacadas
+
+De [`ontology/shapes.ttl`](../ontology/shapes.ttl):
+
+```turtle
+ah:TerritoryShape
+    a sh:NodeShape ;
+    sh:targetClass ah:Territory ;
+    sh:property [ sh:path dct:identifier ; sh:minCount 1 ; sh:datatype xsd:string ] ;
+    sh:property [ sh:path rdfs:label ; sh:minCount 1 ] ;
+    sh:property [
+        sh:path geo:lat ;
+        sh:maxCount 1 ;
+        sh:datatype xsd:decimal ;
+        sh:minInclusive -90 ;
+        sh:maxInclusive 90 ;
+    ] .
+
+ah:IndicatorObservationShape
+    a sh:NodeShape ;
+    sh:targetClass ah:IndicatorObservation ;
+    sh:property [ sh:path ah:indicator ; sh:minCount 1 ; sh:class ah:Indicator ] ;
+    sh:property [ sh:path ah:value ; sh:minCount 1 ; sh:datatype xsd:decimal ] ;
+    sh:property [ sh:path ah:period ; sh:minCount 1 ; sh:datatype xsd:string ] ;
+    sh:property [ sh:path ah:providedBy ; sh:minCount 1 ; sh:class ah:DataSource ] .
+
+ah:ScoreShape
+    a sh:NodeShape ;
+    sh:targetClass ah:Score ;
+    sh:property [ sh:path ah:forProfile ; sh:minCount 1 ; sh:class ah:DecisionProfile ] ;
+    sh:property [
+        sh:path ah:scoreValue ;
+        sh:minCount 1 ;
+        sh:datatype xsd:decimal ;
+        sh:minInclusive 0 ;
+        sh:maxInclusive 100 ;
+    ] ;
+    sh:property [ sh:path ah:scoringVersion ; sh:minCount 1 ; sh:datatype xsd:string ] .
+```
+
+Un `sh:Violation` sobre cualquiera de estas shapes bloquea la publicación del grafo ([`data-pipeline.md §2.6`](data-pipeline.md)).
+
+---
+
+## 8. Consultas SPARQL de ejemplo
+
+### 8.1 Municipios con score alto para teletrabajo
+
+```sparql
+PREFIX ah:   <https://data.atlashabita.example/ontology/>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+SELECT ?municipio ?nombre ?score
+WHERE {
+  ?municipio a ah:Municipality ;
+             rdfs:label ?nombre ;
+             ah:hasScore ?s .
+  ?s ah:forProfile <https://data.atlashabita.example/resource/profile/remote_work> ;
+     ah:scoreValue ?score .
+  FILTER (?score >= 80)
+}
+ORDER BY DESC(?score)
+LIMIT 20
+```
+
+### 8.2 Fuentes usadas por un territorio
+
+```sparql
+PREFIX ah:  <https://data.atlashabita.example/ontology/>
+PREFIX dct: <http://purl.org/dc/terms/>
+
+SELECT DISTINCT ?fuente ?titulo
+WHERE {
+  <https://data.atlashabita.example/resource/territory/municipality/41091>
+      ah:hasIndicatorObservation ?obs .
+  ?obs ah:providedBy ?fuente .
+  ?fuente dct:title ?titulo .
+}
+```
+
+### 8.3 Contribuciones de un score concreto
+
+```sparql
+PREFIX ah: <https://data.atlashabita.example/ontology/>
+
+SELECT ?factor ?peso ?valorNormalizado ?impacto
+WHERE {
+  <https://data.atlashabita.example/resource/score/2026.04.1/remote_work/41091>
+      ah:hasContribution ?c .
+  ?c ah:indicator ?factor ;
+     ah:weight ?peso ;
+     ah:normalizedValue ?valorNormalizado ;
+     ah:impact ?impacto .
+}
+ORDER BY DESC(?impacto)
+```
+
+### 8.4 Jerarquía administrativa
+
+```sparql
+PREFIX ah:   <https://data.atlashabita.example/ontology/>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+SELECT ?municipio ?nombreMun ?provincia ?nombreProv ?ccaa ?nombreCcaa
+WHERE {
+  ?municipio a ah:Municipality ;
+             rdfs:label ?nombreMun ;
+             ah:belongsTo ?provincia .
+  ?provincia rdfs:label ?nombreProv ;
+             ah:belongsTo ?ccaa .
+  ?ccaa rdfs:label ?nombreCcaa .
+}
+```
+
+---
+
+## 9. Named graphs utilizados
+
+| Named graph | URI | Contenido |
+|---|---|---|
+| Territorios | `https://data.atlashabita.example/graph/territories` | Jerarquía y geometrías resumidas. |
+| Socioeconomía | `https://data.atlashabita.example/graph/socioeconomic` | Renta, desempleo, educación. |
+| Vivienda | `https://data.atlashabita.example/graph/housing` | Alquiler y vivienda. |
+| Movilidad | `https://data.atlashabita.example/graph/mobility` | Transporte y cobertura. |
+| Servicios | `https://data.atlashabita.example/graph/services` | Sanidad y educación. |
+| Fuentes | `https://data.atlashabita.example/graph/sources` | Metadatos de procedencia. |
+| Scores | `https://data.atlashabita.example/graph/scores` | Resultados calculados. |
+
+---
+
+## 10. Criterio de aceptación del modelo
+
+El modelo RDF se considera aceptable si:
+
+1. El grafo cargado en RDFLib parsea sin errores.
+2. `pyshacl.validate(...)` no reporta violaciones críticas.
+3. Las consultas SPARQL 8.1–8.4 devuelven resultados no vacíos sobre el dataset demo.
+4. Toda observación tiene `indicator`, `value`, `period` y `providedBy` (enforced por SHACL).
+5. Todo score tiene `forProfile`, `scoreValue ∈ [0, 100]` y `scoringVersion`.
+
+---
+
+## 11. Referencias
+
+- [`ontology/atlashabita.ttl`](../ontology/atlashabita.ttl) · Ontología.
+- [`ontology/shapes.ttl`](../ontology/shapes.ttl) · Shapes SHACL.
+- [11 · Modelo RDF y ontología](11_MODELO_DE_DATOS_RDF_Y_ONTOLOGIA.md).
+- [data-pipeline.md](data-pipeline.md) · Pipeline que produce el grafo.
+- [api.md](api.md) · Endpoints que exponen datos derivados del grafo.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,221 @@
+# Roadmap de AtlasHabita
+
+Plan de entrega por milestones, con estado y trazabilidad a issues. El flujo operativo que rige la creación de ramas y PRs se describe en [`github-workflow.md`](github-workflow.md) y [`CONTRIBUTING.md`](../CONTRIBUTING.md).
+
+Leyenda de estado:
+
+| Símbolo | Significado |
+|---|---|
+| `completado` | Fusionado en `develop` y verificado en CI. |
+| `en curso` | Hay ramas activas trabajando sobre la milestone. |
+| `ready` | Especificado, con issues abiertas y pendiente de implementación. |
+| `futuro` | Fuera del alcance del MVP; propuesta post-defensa. |
+
+---
+
+## Visión general
+
+```mermaid
+flowchart LR
+    M0[M0 · Fundamentos] --> M1[M1 · Infraestructura]
+    M1 --> M2[M2 · Pipeline y RDF]
+    M2 --> M3[M3 · Calidad de datos]
+    M3 --> M4[M4 · Backend FastAPI]
+    M4 --> M5[M5 · Frontend pixel-a-pixel]
+    M5 --> M6[M6 · Tests, CI, seguridad]
+    M6 --> M7[M7 · Documentación y release]
+```
+
+---
+
+## M0 · Fundamentos
+
+**Estado:** `completado`
+
+- ADRs iniciales, CODEOWNERS, plantillas de issue/PR, `CONTRIBUTING.md`.
+- Workflows base de CI (quality, security, docs).
+
+Issues asociadas:
+
+| Issue | Título | Estado |
+|---|---|---|
+| #1 | Auditoría inicial y plan de ejecución. | completado |
+| #2 | Crear `develop`, labels y milestones. | completado |
+| #3 | Plantillas de issue, PR y CODEOWNERS. | completado |
+
+Entregables:
+
+- [`docs/adr/0001-auditoria-inicial.md`](adr/0001-auditoria-inicial.md)
+- [`docs/adr/0002-arquitectura-screaming.md`](adr/0002-arquitectura-screaming.md)
+- [`docs/adr/0003-stack-tecnologico.md`](adr/0003-stack-tecnologico.md)
+- [`docs/github-workflow.md`](github-workflow.md)
+
+---
+
+## M1 · Infraestructura y scaffolding
+
+**Estado:** `completado`
+
+- Monorepo `apps/api` + `apps/web`.
+- Backend FastAPI con dominio limpio, `/health` y observabilidad.
+- Frontend Vite + React 19 + Tailwind v4 + Vitest.
+- Docker Compose, Makefile, `.env.example`.
+- CI completa por áreas (`ci-backend`, `ci-frontend`, `ci-build`, `ci-rdf`, `ci-e2e`, `ci-docs`).
+
+Issues asociadas:
+
+| Issue | Título | Estado |
+|---|---|---|
+| #4 | Scaffolding del monorepo y CI completa. | completado |
+| #5 | Backend inicial con dominio limpio y `/health`. | completado |
+| #6 | Frontend inicial con Vite + Tailwind v4. | completado |
+| #7 | Infra: Makefile, Compose, `.env.example`. | completado |
+
+---
+
+## M2 · Pipeline de datos y RDF base
+
+**Estado:** `completado`
+
+- Dataset demo versionado (`data/seed/`).
+- Ontología `ontology/atlashabita.ttl` y shapes `ontology/shapes.ttl`.
+- Lector seed (`seed_loader.py`).
+
+Issues asociadas:
+
+| Issue | Título | Estado |
+|---|---|---|
+| #8 | Dataset demo, ontología y lector seed. | completado |
+| #9 | Shapes SHACL mínimas. | completado |
+| #10 | Política de URIs y named graphs documentada. | completado |
+| #11 | Validación RDF en CI. | completado |
+| #12 | Infraestructura RDF (rdflib + pyshacl). | completado |
+
+---
+
+## M3 · Diseño del sistema de datos (calidad avanzada)
+
+**Estado:** `en curso`
+
+- Validaciones tabulares y geoespaciales con reportes persistentes.
+- Named graphs operativos con particiones por dominio.
+- Reporte consolidado de calidad.
+
+Issues asociadas:
+
+| Issue | Título | Estado |
+|---|---|---|
+| #13 | Validaciones tabulares con reporte YAML/JSON. | en curso |
+| #14 | Validaciones geoespaciales (CRS, topología, simplificación). | ready |
+| #15 | Particionado por named graphs y exportación TriG. | ready |
+| #16 | Reporte consolidado de calidad. | ready |
+| #17 | Quality gates en CI (`ci-rdf` ampliado). | ready |
+
+---
+
+## M4 · Backend FastAPI con dominio limpio
+
+**Estado:** `ready`
+
+- Endpoints de dominio: perfiles, territorios, rankings, capas, fuentes, RDF.
+- Scoring explicable con contribuciones.
+- SPARQL endpoints internos predefinidos.
+
+Issues asociadas:
+
+| Issue | Título | Estado |
+|---|---|---|
+| #18 | `GET /profiles` y `GET /territories`. | ready |
+| #19 | `GET /rankings` y `POST /rankings/custom`. | ready |
+| #20 | `GET /map/layers` y `GET /sources`. | ready |
+
+Referencias: [`api.md`](api.md), [`15_BACKEND_API_CONTRATOS_Y_SERVICIOS.md`](15_BACKEND_API_CONTRATOS_Y_SERVICIOS.md).
+
+---
+
+## M5 · Frontend pixel a pixel
+
+**Estado:** `ready`
+
+- Sistema de diseño derivado de la captura de referencia.
+- Sidebar, topbar con "Nuevo análisis", mapa, ranking y panel de tendencias.
+- Estados: cargando, vacío, error, datos incompletos, modo demo.
+
+Issues asociadas:
+
+| Issue | Título | Estado |
+|---|---|---|
+| #21 | Sistema de diseño y tokens Tailwind v4. | ready |
+| #22 | Design system shell (sidebar + topbar). | ready |
+| #23 | Mapa MapLibre y capas coropléticas. | ready |
+| #24 | Ranking lateral sincronizado con el mapa. | ready |
+| #25 | Ficha territorial con indicadores y explicación. | ready |
+| #26 | Inspector de fuentes. | ready |
+| #27 | Integración frontend con API. | ready |
+
+Referencias: [`16_FRONTEND_UX_UI_Y_FLUJOS.md`](16_FRONTEND_UX_UI_Y_FLUJOS.md).
+
+---
+
+## M6 · Tests, CI, seguridad y performance
+
+**Estado:** `ready`
+
+- Cobertura de tests unitarios y de integración por encima del 70 %.
+- OWASP Top 10 revisado para la API.
+- Playwright con cobertura del flujo principal.
+- Benchmark ligero con datos demo.
+
+Issues asociadas:
+
+| Issue | Título | Estado |
+|---|---|---|
+| #28 | Cobertura backend ≥ 70 %. | ready |
+| #29 | Cobertura frontend ≥ 60 %. | ready |
+| #30 | `bandit`, `pip-audit`, `npm audit` estrictos. | ready |
+| #31 | Playwright para E2E-001..E2E-005. | ready |
+| #32 | Lighthouse/k6 smoke. | ready |
+| #33 | Revisión OWASP Top 10. | ready |
+
+Referencias: [`testing.md`](testing.md), [`18_PLAN_DE_PRUEBAS_VALIDACION_Y_CALIDAD.md`](18_PLAN_DE_PRUEBAS_VALIDACION_Y_CALIDAD.md).
+
+---
+
+## M7 · Documentación final y release
+
+**Estado:** `en curso`
+
+- README exhaustivo.
+- Guías `architecture.md`, `data-pipeline.md`, `rdf-model.md`, `api.md`, `testing.md`, `roadmap.md`.
+- Playwright E2E `home.spec.ts` y `profile-flow.spec.ts`.
+- Release final: PR `develop → main` con tag SemVer y release notes.
+
+Issues asociadas:
+
+| Issue | Título | Estado |
+|---|---|---|
+| #34 | Documentación final y guía E2E. | en curso |
+
+---
+
+## Futuro (fuera del MVP)
+
+| Tema | Descripción |
+|---|---|
+| Modo técnico avanzado | SPARQL console con sandbox. |
+| Multi-tenant | Perfiles guardados por usuario. |
+| Cobertura internacional | Extender más allá de España. |
+| Machine learning complementario | Clustering de territorios similares. |
+| Accesibilidad AAA | Auditoría WCAG 2.2 completa. |
+
+---
+
+## Referencias cruzadas
+
+- [`architecture.md`](architecture.md)
+- [`data-pipeline.md`](data-pipeline.md)
+- [`rdf-model.md`](rdf-model.md)
+- [`api.md`](api.md)
+- [`testing.md`](testing.md)
+- [`github-workflow.md`](github-workflow.md)
+- [`CONTRIBUTING.md`](../CONTRIBUTING.md)

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,190 @@
+# Estrategia de pruebas de AtlasHabita
+
+Este documento consolida la pirámide de pruebas, cómo se ejecutan por capa y los criterios de aceptación del MVP. Complementa el documento académico [`18_PLAN_DE_PRUEBAS_VALIDACION_Y_CALIDAD.md`](18_PLAN_DE_PRUEBAS_VALIDACION_Y_CALIDAD.md).
+
+---
+
+## 1. Pirámide de pruebas
+
+```mermaid
+flowchart TD
+    A[E2E - Playwright]          --> B[API - pytest + httpx]
+    B --> C[Integración de datos - pytest + rdflib + pyshacl]
+    C --> D[Unitarias - pytest / vitest]
+    C --> E[Validación SHACL - pyshacl]
+    C --> F[Quality gates tabulares]
+```
+
+Regla de pulgar: muchas unitarias, algunas de integración, pocas de E2E. Los tiempos de CI deben mantener cada workflow por debajo de 5 minutos.
+
+---
+
+## 2. Capas y cómo se ejecutan
+
+### 2.1 Unitarias · Backend
+
+- Herramienta: `pytest`, `pytest-cov`.
+- Alcance: entidades de dominio, reglas de scoring, URI builder, normalización.
+- Ejecución:
+
+```bash
+pytest apps/api/tests
+ruff check apps/api/src apps/api/tests
+mypy apps/api/src
+```
+
+- Cobertura mínima exigida (`pyproject.toml`): **70 % de líneas** en `atlashabita/`.
+
+### 2.2 Unitarias · Frontend
+
+- Herramienta: `vitest` + `@testing-library/react` + `jsdom`.
+- Alcance: componentes de UI, hooks puros, store Zustand, servicios con `MSW` (cuando aplique).
+- Ejecución:
+
+```bash
+pnpm -C apps/web test
+pnpm -C apps/web test:coverage
+pnpm -C apps/web lint
+pnpm -C apps/web typecheck
+pnpm -C apps/web format:check
+```
+
+### 2.3 Integración · Datos
+
+- Herramienta: `pytest` con fixtures que cargan `data/seed/`.
+- Alcance: pipeline ingest→normalize→analytics→RDF sobre dataset demo.
+- Verifica: contratos tabulares, construcción del grafo y serialización.
+
+### 2.4 Validación SHACL
+
+- Herramienta: `pyshacl`.
+- Alcance: `ontology/shapes.ttl` sobre el grafo generado.
+- CI: workflow `ci-rdf.yml`.
+
+### 2.5 API
+
+- Herramienta: `pytest` + `httpx.AsyncClient`.
+- Alcance: contratos request/response, códigos de error, paginación.
+- Se levanta la app en memoria (`create_app`) sin red.
+
+### 2.6 E2E
+
+- Herramienta: `@playwright/test` (Chromium).
+- Alcance: flujo principal de `apps/web`.
+- Ejecución:
+
+```bash
+pnpm -C apps/web exec playwright install chromium   # una vez
+pnpm -C apps/web e2e
+```
+
+- Configuración en [`apps/web/playwright.config.ts`](../apps/web/playwright.config.ts): `webServer` levanta Vite en `127.0.0.1:5173` y reutiliza servidor si ya está vivo.
+- Los specs actuales viven en [`apps/web/tests/e2e/`](../apps/web/tests/e2e/).
+
+### 2.7 Rendimiento (espejo académico)
+
+- Perfilado ligero con Lighthouse CI o `k6` sobre `/rankings` (fase 6).
+- Métricas objetivo: `p95 < 500 ms` para ranking con dataset demo; LCP frontend `< 2.5 s`.
+
+---
+
+## 3. Pruebas unitarias críticas (extracto)
+
+| ID | Prueba | Resultado esperado |
+|---|---|---|
+| TU-001 | Normalizar código INE de longitud variable. | Código estable con padding correcto. |
+| TU-002 | Construir URI de municipio. | URI válida y determinista. |
+| TU-003 | Normalizar indicador `higher_is_better`. | Valor ∈ [0, 1]. |
+| TU-004 | Normalizar indicador `lower_is_better`. | Valor invertido correctamente. |
+| TU-005 | Calcular score ponderado. | Suma coherente de contribuciones. |
+| TU-006 | Reescalar pesos ante indicador faltante. | Pesos finales suman 1. |
+| TU-007 | Detectar fuente incompleta. | `DomainError(INVALID_SOURCE)`. |
+
+---
+
+## 4. Pruebas de datos
+
+| ID | Validación | Severidad |
+|---|---|---|
+| TD-001 | Todos los municipios tienen código y nombre. | Crítica |
+| TD-002 | No hay indicadores sin fuente. | Crítica |
+| TD-003 | Valores dentro de rango. | Alta |
+| TD-004 | Cobertura municipal mínima por indicador crítico. | Alta |
+| TD-005 | Geometrías no vacías. | Crítica |
+| TD-006 | Sin duplicados por `(indicador, territorio, periodo, fuente)`. | Alta |
+
+---
+
+## 5. Pruebas RDF y SPARQL
+
+| ID | Prueba | Resultado esperado |
+|---|---|---|
+| TRDF-001 | Shapes cargan sin errores. | Grafo shapes válido. |
+| TRDF-002 | `MunicipalityShape` sin violaciones. | Sin `sh:Violation`. |
+| TRDF-003 | SPARQL jerarquía (sección 8.4 de [`rdf-model.md`](rdf-model.md)). | Municipios → provincia → CCAA. |
+| TRDF-004 | SPARQL score por perfil. | Devuelve `scoreValue` y contribuciones. |
+| TRDF-005 | Serializar y volver a parsear. | No pierde triples críticos. |
+
+---
+
+## 6. Pruebas E2E (MVP)
+
+| ID | Flujo | Resultado esperado |
+|---|---|---|
+| E2E-001 | Visitar `/`, ver sidebar, topbar con "Nuevo análisis", mapa renderizado y al menos una tarjeta de tendencias. | Elementos visibles. Implementado en `home.spec.ts`. |
+| E2E-002 | Cambiar perfil con controles visibles y verificar cambio en la ranking card. | Cambio observable. Implementado en `profile-flow.spec.ts`. |
+| E2E-003 | Abrir ficha territorial desde el ranking. | Aparecen indicadores, explicación y fuentes. (fase 6) |
+| E2E-004 | Inspeccionar fuente de un indicador. | Panel con título, periodo y fecha. (fase 6) |
+| E2E-005 | Aplicar filtro imposible. | Estado «sin resultados». (fase 6) |
+
+Los specs de E2E-001 y E2E-002 están en [`apps/web/tests/e2e/home.spec.ts`](../apps/web/tests/e2e/home.spec.ts) y [`apps/web/tests/e2e/profile-flow.spec.ts`](../apps/web/tests/e2e/profile-flow.spec.ts). Siguen las prácticas:
+
+- Selectores visibles (`getByRole`, `getByText`) sin depender de implementación interna.
+- `test.skip(process.env.E2E_BACKEND !== '1', ...)` para flujos que requieran API levantada.
+- Mocks de mapa y dashboard considerados por defecto.
+
+---
+
+## 7. Dataset de pruebas
+
+El dataset demo de `data/seed/` alimenta todas las capas de la pirámide. Ver [`data-pipeline.md §5`](data-pipeline.md).
+
+---
+
+## 8. Criterios de aceptación del MVP
+
+El MVP se considera entregable cuando:
+
+1. Pasan todas las **pruebas unitarias críticas** (TU-001..TU-007).
+2. Pasan las **validaciones de datos críticas** (TD-001, TD-002, TD-005).
+3. El grafo cumple **SHACL mínimo** (shapes de `Territory`, `IndicatorObservation`, `Score`).
+4. Los endpoints principales (`/health`, `/profiles`, `/territories/{id}`, `/rankings`) devuelven contratos válidos ([`api.md`](api.md)).
+5. Las pruebas E2E del flujo principal (E2E-001 y E2E-002) pasan en CI.
+6. CI completa (`ci-quality`, `ci-backend`, `ci-frontend`, `ci-build`, `ci-security`, `ci-rdf`, `ci-e2e`, `ci-docs`) en verde sobre `develop`.
+7. Los errores conocidos están documentados en la release note.
+
+---
+
+## 9. Automatización en CI
+
+| Workflow | Qué ejecuta |
+|---|---|
+| `ci-quality.yml` | Conventional Commits, tamaño de diff y linters genéricos. |
+| `ci-backend.yml` | `ruff`, `mypy`, `pytest` con cobertura. |
+| `ci-frontend.yml` | `eslint`, `tsc`, `vitest`, `prettier --check`. |
+| `ci-build.yml` | Build de producción (`vite build`, `pip install -e`). |
+| `ci-security.yml` | `bandit`, `pip-audit`, `npm audit`, secret scan. |
+| `ci-rdf.yml` | Parseo RDF y validación SHACL. |
+| `ci-e2e.yml` | `playwright test` en Chromium con Vite levantado. |
+| `ci-docs.yml` | Markdown lint y enlaces rotos en `docs/`. |
+
+---
+
+## 10. Referencias
+
+- [18 · Plan de pruebas, validación y calidad](18_PLAN_DE_PRUEBAS_VALIDACION_Y_CALIDAD.md)
+- [data-pipeline.md](data-pipeline.md)
+- [rdf-model.md](rdf-model.md)
+- [api.md](api.md)
+- [`apps/web/playwright.config.ts`](../apps/web/playwright.config.ts)
+- [`apps/api/pyproject.toml`](../apps/api/pyproject.toml)


### PR DESCRIPTION
## Resumen

Documentación completa del proyecto (README reescrito, docs/architecture.md, data-pipeline.md, rdf-model.md, api.md, testing.md, roadmap.md) y specs Playwright del flujo principal (home y cambio de perfil) con selectores accesibles.

## Issues

Closes #31
Closes #34

## Verificación

- `pnpm format:check`, `pnpm exec playwright install chromium` y `pnpm exec playwright test --list` (6 tests detectados) en verde.
- 2 044 líneas nuevas de docs.

## Notas

- Los documentos reutilizan Turtle/SPARQL reales del repo para evitar deriva.
- `profile-flow.spec.ts` requiere `E2E_BACKEND=1` o `E2E_PROFILE_FLOW=1` para no romper pipelines sin backend.