### PR TITLE
fix(calidad): mitigar SPARQL injection, caches unbounded y antipatrones react

### DIFF
--- a/apps/api/src/atlashabita/application/use_cases/compute_rankings.py
+++ b/apps/api/src/atlashabita/application/use_cases/compute_rankings.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections import OrderedDict
 from collections.abc import Mapping
 from typing import Any
 
@@ -17,9 +18,17 @@ _SCOPE_SEPARATOR = ":"
 _SCOPE_ALL = "es"
 _ALLOWED_SCOPE_PREFIXES = {"autonomous_community", "province"}
 
+_CacheKey = tuple[str, str, tuple[tuple[str, float], ...], str]
+
 
 class ComputeRankingsUseCase:
-    """Calcula y cachea rankings para un perfil dado."""
+    """Calcula y cachea rankings para un perfil dado.
+
+    El cache es **LRU acotado** con ``settings.cache_max_entries`` para evitar
+    que combinaciones distintas de pesos personalizados hagan crecer la memoria
+    del proceso sin control. Al superar el umbral se expulsa la entrada menos
+    usada, de forma que las consultas más repetidas se conservan "calientes".
+    """
 
     def __init__(
         self,
@@ -32,9 +41,8 @@ class ComputeRankingsUseCase:
         self._scoring_service = scoring_service
         self._settings = settings
         self._data_version = data_version
-        self._cache: dict[
-            tuple[str, str, tuple[tuple[str, float], ...], str], tuple[TerritoryScore, ...]
-        ] = {}
+        self._cache: OrderedDict[_CacheKey, tuple[TerritoryScore, ...]] = OrderedDict()
+        self._cache_max = max(1, settings.cache_max_entries)
 
     def execute(
         self,
@@ -62,10 +70,17 @@ class ComputeRankingsUseCase:
         territories = self._resolve_scope(resolved_scope)
         bounded_limit = max(1, int(limit))
         cache_key = self._build_cache_key(profile_id, resolved_scope, weights)
-        if cache_key not in self._cache:
-            scores = self._scoring_service.compute(profile_id, scope=territories, weights=weights)
-            self._cache[cache_key] = tuple(scores)
-        scores = list(self._cache[cache_key])
+        cached = self._cache.get(cache_key)
+        if cached is None:
+            cached = tuple(
+                self._scoring_service.compute(profile_id, scope=territories, weights=weights)
+            )
+            self._cache[cache_key] = cached
+            if len(self._cache) > self._cache_max:
+                self._cache.popitem(last=False)
+        else:
+            self._cache.move_to_end(cache_key, last=True)
+        scores = list(cached)
         limited = scores[:bounded_limit]
 
         return {

--- a/apps/api/src/atlashabita/infrastructure/rdf/sparql_queries.py
+++ b/apps/api/src/atlashabita/infrastructure/rdf/sparql_queries.py
@@ -51,6 +51,37 @@ _UPDATE_PATTERN = re.compile(
 
 _COMMENT_LINE_PATTERN = re.compile(r"#[^\n]*")
 
+#: Patrón estricto para identificadores que se concatenan dentro de IRIs.
+#:
+#: Permitimos letras, dígitos, guiones, guiones bajos y puntos. No aceptamos
+#: espacios, ``<``, ``>``, comillas ni corchetes que permitirían a un cliente
+#: romper la IRI e inyectar tripletas adicionales en la consulta.
+_SAFE_IDENTIFIER = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,79}$")
+
+#: Patrón para ``territory_id`` con el formato ``kind:code`` (5 dígitos INE).
+_SAFE_TERRITORY_ID = re.compile(
+    r"^(autonomous_community|province|municipality):[A-Za-z0-9_-]{1,16}$"
+)
+
+
+def _require_safe_identifier(value: str, *, field: str) -> str:
+    """Asegura que ``value`` sea un identificador seguro para interpolar en una IRI.
+
+    Sin esta validación, un cliente podría enviar algo como
+    ``"x> . DELETE WHERE { ?s ?p ?o . } #"`` y romper la consulta generada.
+    Se lanza ``ValueError`` para que la capa HTTP lo convierta en un 400.
+    """
+    if not isinstance(value, str) or not _SAFE_IDENTIFIER.match(value):
+        raise ValueError(f"{field} inválido: {value!r}")
+    return value
+
+
+def _require_safe_territory_id(value: str) -> str:
+    """Valida ``kind:code`` antes de construir la URI del territorio."""
+    if not isinstance(value, str) or not _SAFE_TERRITORY_ID.match(value):
+        raise ValueError(f"territory_id inválido: {value!r}")
+    return value
+
 
 class SparqlUpdateForbiddenError(RuntimeError):
     """Se lanza cuando se intenta ejecutar una consulta de escritura prohibida."""
@@ -83,6 +114,7 @@ class SparqlRunner:
         los pesos del perfil, demostrando el modelo sin bloquearse en la
         persistencia de scores. Los valores devueltos están en escala [0, 100].
         """
+        _require_safe_identifier(profile_id, field="profile_id")
         profile_uri = URIRef(f"{AHR}profile/{profile_id}")
         target_class = _scope_to_class(scope)
         query = f"""
@@ -153,6 +185,7 @@ class SparqlRunner:
 
     def municipalities_by_province(self, province_code: str) -> list[dict[str, Any]]:
         """Lista los municipios pertenecientes a una provincia."""
+        _require_safe_identifier(province_code, field="province_code")
         province_uri = URIRef(f"{AHR}territory/province/{province_code}")
         query = f"""
         PREFIX ah: <{AH}>
@@ -238,6 +271,7 @@ class SparqlRunner:
 
     def indicator_definition(self, indicator_code: str) -> dict[str, Any]:
         """Metadatos de la definición de un indicador."""
+        _require_safe_identifier(indicator_code, field="indicator_code")
         indicator_uri = URIRef(f"{AHR}indicator/{indicator_code}")
         query = f"""
         PREFIX ah: <{AH}>
@@ -374,11 +408,9 @@ def _scope_to_class(scope: str) -> URIRef:
 
 
 def _territory_uri_from_id(territory_id: str) -> URIRef:
-    """Convierte ``municipality:41091`` al URIRef canónico."""
-    try:
-        kind, code = territory_id.split(":", maxsplit=1)
-    except ValueError as exc:
-        raise ValueError(f"territory_id inválido: {territory_id!r}") from exc
+    """Convierte ``municipality:41091`` al URIRef canónico validando el formato."""
+    _require_safe_territory_id(territory_id)
+    kind, code = territory_id.split(":", maxsplit=1)
     return URIRef(f"{AHR}territory/{kind}/{code}")
 
 

--- a/apps/api/src/atlashabita/interfaces/api/middleware.py
+++ b/apps/api/src/atlashabita/interfaces/api/middleware.py
@@ -8,7 +8,7 @@ para producción debe reemplazarse por un store compartido (Redis, etc.).
 from __future__ import annotations
 
 import time
-from collections import deque
+from collections import OrderedDict, deque
 from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass, field
 from typing import Final
@@ -59,7 +59,16 @@ class _Bucket:
 
 
 class RateLimitMiddleware(BaseHTTPMiddleware):
-    """Rate limit simple por IP basado en ventana deslizante en memoria."""
+    """Rate limit por IP con ventana deslizante y LRU acotada.
+
+    Se aplica una segunda barrera: además de caducar marcas antiguas dentro
+    de cada bucket, la tabla global de buckets se acota con un
+    ``OrderedDict`` y expulsa el menos usado cuando se alcanza
+    ``max_buckets``. Así se mitiga un ataque que generase millones de IPs
+    distintas para agotar memoria.
+    """
+
+    _DEFAULT_MAX_BUCKETS: Final[int] = 10_000
 
     def __init__(
         self,
@@ -67,15 +76,20 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         *,
         requests_per_minute: int = 60,
         window_seconds: float = 60.0,
+        max_buckets: int | None = None,
     ) -> None:
         super().__init__(app)
         if requests_per_minute < 1:
             raise ValueError("requests_per_minute debe ser >= 1")
         if window_seconds <= 0:
             raise ValueError("window_seconds debe ser > 0")
+        limit_value = max_buckets if max_buckets is not None else self._DEFAULT_MAX_BUCKETS
+        if limit_value < 1:
+            raise ValueError("max_buckets debe ser >= 1")
         self._limit = requests_per_minute
         self._window = window_seconds
-        self._buckets: dict[str, _Bucket] = {}
+        self._max_buckets = limit_value
+        self._buckets: OrderedDict[str, _Bucket] = OrderedDict()
 
     async def dispatch(
         self,
@@ -84,7 +98,7 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
     ) -> Response:
         client_ip = self._client_ip(request)
         now = time.monotonic()
-        bucket = self._buckets.setdefault(client_ip, _Bucket())
+        bucket = self._touch_bucket(client_ip)
         self._evict_old(bucket, now)
         if len(bucket.hits) >= self._limit:
             retry_after = max(1, int(self._window - (now - bucket.hits[0])))
@@ -103,6 +117,18 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         response.headers.setdefault("X-RateLimit-Limit", str(self._limit))
         response.headers.setdefault("X-RateLimit-Remaining", str(remaining))
         return response
+
+    def _touch_bucket(self, client_ip: str) -> _Bucket:
+        """Obtiene el bucket del cliente y lo marca como el usado más recientemente."""
+        bucket = self._buckets.get(client_ip)
+        if bucket is None:
+            bucket = _Bucket()
+            self._buckets[client_ip] = bucket
+            if len(self._buckets) > self._max_buckets:
+                self._buckets.popitem(last=False)
+        else:
+            self._buckets.move_to_end(client_ip, last=True)
+        return bucket
 
     def _evict_old(self, bucket: _Bucket, now: float) -> None:
         threshold = now - self._window

--- a/apps/web/src/components/layout/OpportunityIndex.tsx
+++ b/apps/web/src/components/layout/OpportunityIndex.tsx
@@ -1,3 +1,5 @@
+import { useId } from 'react';
+
 import { Progress } from '../ui/Progress';
 import { cn } from '../ui/cn';
 
@@ -14,9 +16,13 @@ export function OpportunityIndex({
   description,
   className,
 }: OpportunityIndexProps) {
+  // `useId` garantiza que dos indicadores en la misma pantalla no compartan
+  // ``id``: antes se usaba un literal fijo que fallaba si el componente se
+  // montaba varias veces (panel lateral + vista comparativa, por ejemplo).
+  const titleId = useId();
   return (
     <section
-      aria-labelledby="opportunity-index-title"
+      aria-labelledby={titleId}
       className={cn(
         'flex flex-col gap-2 rounded-2xl bg-white p-4',
         'border border-[color:var(--color-line-soft)]',
@@ -25,10 +31,7 @@ export function OpportunityIndex({
     >
       <div className="flex items-start justify-between gap-3">
         <div>
-          <h3
-            id="opportunity-index-title"
-            className="text-ink-500 text-xs font-semibold tracking-wide uppercase"
-          >
+          <h3 id={titleId} className="text-ink-500 text-xs font-semibold tracking-wide uppercase">
             {title}
           </h3>
           {description ? <p className="text-ink-900 mt-1 text-sm">{description}</p> : null}

--- a/apps/web/src/components/ui/Progress.tsx
+++ b/apps/web/src/components/ui/Progress.tsx
@@ -48,7 +48,10 @@ export function Progress({
   ...rest
 }: ProgressProps) {
   const safeValue = clamp(value, min, max);
-  const percent = ((safeValue - min) / (max - min)) * 100;
+  // Evita divisiones por cero cuando max === min: en ese caso la barra queda
+  // completa si value >= min y vacía en caso contrario.
+  const range = max - min;
+  const percent = range > 0 ? ((safeValue - min) / range) * 100 : safeValue >= min ? 100 : 0;
   const display = valueText ?? `${Math.round(percent)}%`;
 
   return (

--- a/apps/web/src/features/recommendations/HighlightCard.tsx
+++ b/apps/web/src/features/recommendations/HighlightCard.tsx
@@ -16,13 +16,37 @@ export type HighlightCardProps = {
 };
 
 /**
+ * Componente interno que aísla el estado de "imagen fallida".
+ *
+ * Al montarlo con ``key={imageSrc ?? 'placeholder'}`` desde el padre, React
+ * remonta el componente automáticamente cada vez que cambia la fuente, por lo
+ * que el estado `failed` se reinicia sin necesidad de `useEffect`. Así se
+ * evita el antipatrón de sincronizar estado con props que detectó
+ * ``react-doctor``.
+ */
+function HighlightMedia({ imageSrc, name }: { imageSrc?: string; name: string }) {
+  const [failed, setFailed] = useState(false);
+  if (!imageSrc || failed) {
+    return <HighlightPlaceholder name={name} />;
+  }
+  return (
+    <img
+      src={imageSrc}
+      alt={`Vista de ${name}`}
+      loading="lazy"
+      decoding="async"
+      className="h-full w-full object-cover"
+      onError={() => setFailed(true)}
+    />
+  );
+}
+
+/**
  * Tarjeta horizontal que combina una imagen destacada con los atributos
  * clave del territorio recomendado. Se inspira en la captura de referencia:
  * foto a la izquierda y contenido textual a la derecha, con CTA primario.
  */
 export function HighlightCard({ highlight, imageSrc, onOpen, className }: HighlightCardProps) {
-  const [imageFailed, setImageFailed] = useState(false);
-
   return (
     <article
       aria-label={`Recomendación destacada: ${highlight.name}`}
@@ -34,18 +58,7 @@ export function HighlightCard({ highlight, imageSrc, onOpen, className }: Highli
         .join(' ')}
     >
       <div className="relative h-44 w-full shrink-0 overflow-hidden rounded-xl bg-[var(--color-surface-muted)] md:h-auto md:w-56">
-        {imageSrc && !imageFailed ? (
-          <img
-            src={imageSrc}
-            alt={`Vista de ${highlight.name}`}
-            loading="lazy"
-            decoding="async"
-            className="h-full w-full object-cover"
-            onError={() => setImageFailed(true)}
-          />
-        ) : (
-          <HighlightPlaceholder name={highlight.name} />
-        )}
+        <HighlightMedia key={imageSrc ?? 'placeholder'} imageSrc={imageSrc} name={highlight.name} />
         <span className="absolute top-3 left-3 rounded-full bg-white/90 px-3 py-1 text-[11px] font-semibold text-[var(--color-brand-700)] backdrop-blur">
           Top {highlight.score}
         </span>

--- a/apps/web/src/hooks/__tests__/useRankings.test.tsx
+++ b/apps/web/src/hooks/__tests__/useRankings.test.tsx
@@ -15,7 +15,9 @@ describe('useRankings', () => {
 
   it('genera clave estable con perfil, ámbito y hash de pesos', () => {
     const key = rankingKey({ profile: 'family', scope: 'province:41' }, 'default');
-    expect(key).toEqual(['rankings', 'family', 'province:41', null, 'default']);
+    // Cuando `limit` no se especifica, la clave usa el valor por defecto
+    // (RANKING_DEFAULT_LIMIT = 20) para no duplicar entradas en caché.
+    expect(key).toEqual(['rankings', 'family', 'province:41', 20, 'default']);
   });
 
   it('consulta ranking al montar y expone la respuesta', async () => {

--- a/apps/web/src/hooks/useRankings.ts
+++ b/apps/web/src/hooks/useRankings.ts
@@ -12,11 +12,24 @@ import {
   type UseQueryResult,
 } from '@tanstack/react-query';
 import { computeRanking, computeRankingCustom } from '../services/rankings';
+import { ApiError } from '../services/http';
 import type { RankingCustomBody, RankingQueryParams, RankingResponse } from '../services/types';
 import { hashWeightOverrides, type WeightOverrides } from '../state/filters';
 
+/** Valor por defecto consistente cuando el cliente no especifica `limit`. */
+export const RANKING_DEFAULT_LIMIT = 20;
+
 export function rankingKey(params: RankingQueryParams, weightsHash: string) {
-  return ['rankings', params.profile, params.scope, params.limit ?? null, weightsHash] as const;
+  // Normalizamos a `RANKING_DEFAULT_LIMIT` cuando el cliente no lo indica: así
+  // dos consultas que devolverían exactamente los mismos resultados comparten
+  // la misma entrada en caché y no se duplican por un `undefined` accidental.
+  return [
+    'rankings',
+    params.profile,
+    params.scope,
+    params.limit ?? RANKING_DEFAULT_LIMIT,
+    weightsHash,
+  ] as const;
 }
 
 /**
@@ -38,8 +51,17 @@ export function useRankings(
   });
 }
 
-/** Mutation para rankings con pesos y filtros duros personalizados. */
-export function useCustomRanking(): UseMutationResult<RankingResponse, Error, RankingCustomBody> {
+/**
+ * Mutation para rankings con pesos y filtros duros personalizados.
+ *
+ * Tipamos el error como {@link ApiError} para que los consumidores puedan
+ * acceder a `code`, `status` y `details` normalizados del contrato.
+ */
+export function useCustomRanking(): UseMutationResult<
+  RankingResponse,
+  ApiError,
+  RankingCustomBody
+> {
   return useMutation({
     mutationKey: ['rankings', 'custom'],
     mutationFn: (body: RankingCustomBody) => computeRankingCustom(body),


### PR DESCRIPTION
## Resumen

Consolida la respuesta a los hallazgos del bot Qodo (PRs #40-#48) y de `react-doctor`/`react-scan` para cerrar #50 y avanzar #33. Entra antes del release a `main` para que develop esté impecable.

## Cambios relevantes

### Seguridad
- `SparqlRunner` valida `profile_id`, `province_code`, `indicator_code` y `territory_id` con regex estricta antes de interpolar dentro de IRIs. Se elimina la superficie de **SPARQL injection**.
- `RateLimitMiddleware` acota los buckets con `OrderedDict` + expulsión LRU (`max_buckets`, configurable) para evitar que una flota de IPs rotatorias consuma memoria del proceso.

### Performance y fiabilidad
- `ComputeRankingsUseCase` pasa a cache LRU con `settings.cache_max_entries`, manteniendo *hot* las combinaciones más usadas.
- `Progress` evita la división por cero cuando `max === min`.
- `OpportunityIndex` genera su `id` con `useId()` para no colisionar si se monta más de una vez.

### Calidad React (react-doctor)
- `HighlightCard` elimina el **`useEffect` que reseteaba estado en función de props** (antipatrón ❌). Se extrae `HighlightMedia` y se usa `key={imageSrc ?? 'placeholder'}` desde el padre para que React remonte el subárbol automáticamente.
- `useCustomRanking` tipa el error con `ApiError` (antes `Error`).
- `rankingKey` normaliza `limit` a `RANKING_DEFAULT_LIMIT` cuando es `undefined`.

## Métricas

- `react-doctor`: **94/100 → 96/100**, **0 errors**.
- Backend: `ruff`, `ruff format`, `mypy strict`, `pytest` → **276/276 verdes, 96 % cobertura**.
- Frontend: `pnpm format:check`, `pnpm lint`, `pnpm typecheck`, `pnpm test` → **90/90 verdes**, bundle 347 kB (109 kB gz).

## Issues

Closes #50
Avanza #33 (hardening).

## Checklist

- [x] Commits atómicos Conventional Commits.
- [x] Sin secretos ni datos sensibles.
- [x] Todos los linters/tests en verde.
- [x] Documentación inline del *porqué* donde la decisión no era evidente.