### PR TITLE
ci(trivy): reducir workflow a modo tabla sin SARIF

### DIFF
--- a/.github/workflows/ci-trivy.yml
+++ b/.github/workflows/ci-trivy.yml
@@ -11,7 +11,6 @@ on:
 
 permissions:
   contents: read
-  security-events: write
 
 concurrency:
   group: trivy-${{ github.ref }}
@@ -25,7 +24,7 @@ jobs:
       - name: Clonar repositorio
         uses: actions/checkout@v4
 
-      - name: Ejecutar Trivy (tabla · gating CRITICAL/HIGH)
+      - name: Ejecutar Trivy (tabla · reporte informativo)
         uses: aquasecurity/trivy-action@0.28.0
         with:
           scan-type: fs
@@ -34,24 +33,3 @@ jobs:
           ignore-unfixed: true
           severity: CRITICAL,HIGH
           exit-code: '0'
-
-      - name: Ejecutar Trivy (SARIF · para GitHub Security)
-        if: always()
-        continue-on-error: true
-        uses: aquasecurity/trivy-action@0.28.0
-        with:
-          scan-type: fs
-          scan-ref: .
-          format: sarif
-          output: trivy-results.sarif
-          ignore-unfixed: true
-          severity: CRITICAL,HIGH,MEDIUM
-          exit-code: '0'
-
-      - name: Publicar resultados SARIF (omitido si no hay GHAS)
-        if: hashFiles('trivy-results.sarif') != ''
-        continue-on-error: true
-        uses: github/codeql-action/upload-sarif@v3
-        with:
-          sarif_file: trivy-results.sarif
-          category: trivy-fs


### PR DESCRIPTION
## Resumen

`ci-trivy` fallaba en "Set up job" porque el runner rechazaba la declaración de `security-events: write` en configuraciones donde SARIF no está habilitado para el repositorio. Se deja el análisis filesystem en modo tabla informativa.

## Cambios
- Eliminada la solicitud de `security-events: write` y la subida SARIF.
- Trivy filesystem sigue escaneando y reportando CRITICAL/HIGH en los logs del job (exit-code 0 para no bloquear integraciones).

CodeQL mantiene su propio workflow con SARIF porque sí funciona en el repositorio.