### PR TITLE
ci(trivy): fijar trivy-action a @master (tag 0.28.0 inexistente)

### DIFF
--- a/.github/workflows/ci-trivy.yml
+++ b/.github/workflows/ci-trivy.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Ejecutar Trivy (tabla · reporte informativo)
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@master
         with:
           scan-type: fs
           scan-ref: .


### PR DESCRIPTION
El tag pinned `aquasecurity/trivy-action@0.28.0` no existe y hacía que GitHub marcara "Set up job" como fallido antes de ejecutar ningún paso. Pasamos a `@master`, que es la referencia estable recomendada por los mantenedores de la acción.