### PR TITLE
docs: ultrareview post v0.1.1 con estado, hallazgos y roadmap

### DIFF
--- a/docs/reviews/v0.1.1-ultrareview.md
+++ b/docs/reviews/v0.1.1-ultrareview.md
@@ -1,0 +1,80 @@
+# Ultrareview · AtlasHabita v0.1.1
+
+- **Fecha:** 2026-04-24
+- **Ámbito:** monorepo completo tras el tag `v0.1.1`.
+- **Autor:** GONZALO GARCÍA LAMA
+
+Informe final de revisión cruzada pedido por el equipo al cierre de la fase 7. Contempla hallazgos del bot Qodo, `react-doctor`, ejecuciones completas de CI y auditoría manual línea a línea.
+
+## 1. Estado de la plataforma
+
+| Área | Indicador | Valor |
+|---|---|---|
+| Backend Python | `ruff` + `ruff format` | All checks passed |
+| Backend Python | `mypy --strict` | Success (60 archivos) |
+| Backend Python | `pytest` (suite completa) | 276 / 276 · 96 % cobertura |
+| Frontend React | `pnpm format:check` / `pnpm lint` / `pnpm typecheck` / `pnpm test` | En verde · 90 tests |
+| Frontend React | `pnpm build` | 347 kB (109 kB gzip) |
+| Calidad frontend | `react-doctor --lint --dead-code` | **96 / 100**, 0 errores |
+| CI GitHub | Workflows verdes | 10 / 10 |
+
+Cobertura por paquete crítico (backend):
+
+| Paquete | Cobertura |
+|---|---|
+| `atlashabita.infrastructure.rdf` | 91 % – 100 % |
+| `atlashabita.infrastructure.data` | 100 % |
+| `atlashabita.infrastructure.security` | 100 % |
+| `atlashabita.application` (scoring y use cases) | 87 % – 100 % |
+| `atlashabita.interfaces.api` (routers, schemas, cache, deps) | 88 % – 100 % |
+| `atlashabita.observability` (errors, logging, middleware, tracing) | 95 % – 100 % |
+
+## 2. Hallazgos abordados
+
+### Seguridad
+- **SPARQL injection** en `SparqlRunner`: se validan `profile_id`, `province_code`, `indicator_code` y `territory_id` con regex estricta antes de interpolar en IRIs (`_require_safe_identifier`, `_require_safe_territory_id`).
+- **Rate limiter unbounded**: `RateLimitMiddleware` acota con `OrderedDict` + `max_buckets` y expulsa el menos usado.
+- **Cabeceras HTTP**: CSP conservador, HSTS de dos años, `X-Frame-Options`, `X-Content-Type-Options`, `Permissions-Policy` y `Referrer-Policy` se inyectan en todas las respuestas.
+- **SECURITY.md** publica el contacto (`licitaciones@gpic.es`) y la política de vulnerabilidades.
+
+### Fiabilidad
+- **Cache de rankings** convertida a LRU con `cache_max_entries` configurable.
+- **Progress** evita división por cero cuando `max === min`.
+- **OpportunityIndex** usa `useId()` para no duplicar `id` cuando se monta varias veces.
+- **HighlightCard** elimina el antipatrón "state reset in useEffect" mediante componente hijo remontado con `key={imageSrc ?? 'placeholder'}`.
+- **`useCustomRanking`** tipa el error con `ApiError` para propagar `code`/`status`/`details`.
+
+### Calidad y performance
+- **`rankingKey`** normaliza `limit` al default cuando es `undefined`, evitando doble entrada en caché.
+- **Cacheo en infraestructura** (`@cached_property`, `OrderedDict`, `functools.lru_cache`).
+- **`SeedLoader`** cachea el dataset con `lru_cache` por configuración, abaratando hits repetidos desde los use cases.
+
+### CI/CD
+- 10 workflows independientes en verde: `ci-quality`, `ci-backend`, `ci-frontend`, `ci-build`, `ci-rdf`, `ci-e2e`, `ci-docs`, `ci-security`, `ci-codeql`, `ci-trivy`.
+- `Dependabot` monitoriza pip, npm, actions y docker; `SECURITY.md` documenta el canal.
+
+## 3. Hallazgos residuales (no bloqueantes)
+
+| Id | Severidad | Descripción | Plan |
+|---|---|---|---|
+| R1 | Baja | 69 warnings de `react-doctor` quedan, mayoría sobre *unused exports* en índices de barril expuestos para versiones futuras de la UI. | Revisar cuando se consuman; documentado como deuda aceptable. |
+| R2 | Media | `recharts` es una librería pesada; se identifica para *code splitting* en release posterior. | Crear ticket de seguimiento al migrar a `React.lazy` con el próximo flujo de comparador. |
+| R3 | Baja | `Sidebar` inicializa `layerState` desde la prop `layers` (patrón uncontrolled). | Comportamiento deliberado; añadida nota en el componente cuando se retome la conexión con el store global. |
+| R4 | Baja | `pip-audit` es informativo; la política de vulnerabilidades se traslada a Dependabot + SECURITY.md. | Revisar trimestralmente y actualizar SEMAnalizador como parte de M8. |
+| R5 | Baja | Playwright está como smoke no bloqueante; cuando la UI cierre todas las features, pasará a obligatorio. | Issue de seguimiento en roadmap (M8). |
+
+Ninguno bloquea el release.
+
+## 4. Recomendaciones para M8+
+
+1. Persistir scores en el grafo RDF para poder responder `top_scores_by_profile` con SPARQL puro sin recalcular.
+2. Lazy-load de `recharts` y `maplibre-gl` con `React.lazy` + `Suspense`.
+3. Añadir `pnpm audit --prod --audit-level=high` como obligatorio cuando se resuelvan los hallazgos transitivos.
+4. Subir el umbral de cobertura del frontend de 60 % a 80 % en `vitest.config.ts`.
+5. Añadir capa de telemetría OpenTelemetry para medición real de tiempos de scoring/SPARQL en producción.
+
+## 5. Cierre
+
+El proyecto AtlasHabita cumple los 17 requisitos críticos del SRS y los 35 tickets de la planificación inicial. La release `v0.1.1` queda estable, con CI verde, documentación actualizada y deuda técnica conocida y acotada.
+
+**Decisión:** seguir a M8 con las mejoras descritas, manteniendo `develop` como rama de integración y `main` estable.


### PR DESCRIPTION
## Resumen

Informe final de auditoría cruzada del monorepo tras el release `v0.1.1`. Documenta el estado actual, los hallazgos mitigados, los residuales aceptados como deuda y las recomendaciones para M8.

## Highlights

- Backend: 276/276 pytest, 96 % de cobertura, `mypy --strict` en verde.
- Frontend: 90/90 vitest, `react-doctor` 96/100 sin errores, bundle 347 kB (109 kB gzip).
- CI: 10 workflows en verde tras mitigar `ci-trivy`, `ci-quality`, `ci-security` y `ci-e2e`.
- Seguridad: SPARQL injection bloqueada, rate-limit LRU acotado, cabeceras CSP/HSTS activas, `SECURITY.md` publicado.

## Ficheros

- `docs/reviews/v0.1.1-ultrareview.md` (nuevo).

## Issues

Closes #59

## Checklist

- [x] Rama parte de `develop`.
- [x] Conventional Commit en el único commit.
- [x] Sólo documentación; no toca código productivo.