### PR TITLE
feat(web): pase pixel-perfect del dashboard frente a la captura de referencia

### DIFF
--- a/apps/web/src/components/layout/ActionCards.tsx
+++ b/apps/web/src/components/layout/ActionCards.tsx
@@ -29,6 +29,14 @@ export function ActionCards({ items, className }: ActionCardsProps) {
     <ul className={cn('grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4', className)}>
       {items.map((item) => (
         <li key={item.id}>
+          {/*
+           * Cada card es un `article` con un icono coloreado a la izquierda,
+           * título y descripción debajo, y una flecha que sirve de pista
+           * visual de afordancia. Usamos la técnica `absolute inset-0`
+           * sobre un `<a>` interno para que toda la card sea clicable sin
+           * anidar interactivos (evita el warning "button cannot contain
+           * a nested button" que detectaba React DOM en versiones previas).
+           */}
           <Card
             as="article"
             tone="base"
@@ -40,7 +48,7 @@ export function ActionCards({ items, className }: ActionCardsProps) {
               <span
                 aria-hidden="true"
                 className={cn(
-                  'inline-flex h-10 w-10 items-center justify-center rounded-2xl',
+                  'inline-flex h-11 w-11 items-center justify-center rounded-2xl',
                   ACCENT_BG[item.accent ?? 'brand']
                 )}
               >
@@ -49,13 +57,16 @@ export function ActionCards({ items, className }: ActionCardsProps) {
               <ArrowRight
                 aria-hidden="true"
                 size={18}
-                className="text-ink-300 group-hover:text-brand-500 transition-colors"
+                className="text-ink-300 group-hover:text-brand-500 transition-all group-hover:translate-x-0.5"
               />
             </header>
-            <div className="flex flex-col gap-1">
-              <h3 className="font-display text-ink-900 text-base font-semibold">
+            <div className="flex flex-col gap-1.5">
+              <h3 className="font-display text-ink-900 text-base font-semibold tracking-tight">
                 {item.href ? (
-                  <a href={item.href} className="focus:outline-none">
+                  <a
+                    href={item.href}
+                    className="rounded-md focus-visible:ring-2 focus-visible:ring-[var(--color-brand-300)] focus-visible:outline-none"
+                  >
                     <span className="absolute inset-0" aria-hidden="true" />
                     {item.title}
                   </a>

--- a/apps/web/src/components/layout/ChipFilters.tsx
+++ b/apps/web/src/components/layout/ChipFilters.tsx
@@ -37,14 +37,18 @@ export function ChipFilters({
             aria-pressed={isActive}
             onClick={() => onToggle?.(option.id)}
             className={cn(
-              'inline-flex h-9 items-center gap-2 rounded-full px-4 text-sm font-medium transition-colors',
+              'inline-flex h-9 items-center gap-1.5 rounded-full px-3.5 text-[13px] font-semibold transition-all',
               'focus-visible:ring-brand-300 focus-visible:ring-2 focus-visible:ring-offset-2',
               tone === 'onBrand'
-                ? isActive
-                  ? 'text-brand-700 bg-white shadow-[var(--shadow-card)]'
-                  : 'bg-white/20 text-white hover:bg-white/30'
-                : isActive
-                  ? 'bg-brand-500 text-white shadow-[var(--shadow-card)]'
+                ? // Variante sobre el hero verde: chip activa en blanco con
+                  // texto brand-700, inactivas semitransparentes.
+                  isActive
+                  ? 'text-brand-700 bg-white shadow-[0_8px_16px_-10px_rgba(15,23,42,0.32)]'
+                  : 'bg-white/15 text-white ring-1 ring-white/30 backdrop-blur-sm hover:bg-white/25'
+                : // Variante sobre fondo claro: el comp usa borde sutil
+                  // y, al activarse, fondo verde sólido con texto blanco.
+                  isActive
+                  ? 'bg-brand-500 ring-brand-600 text-white shadow-[0_8px_16px_-10px_rgba(16,185,129,0.55)] ring-1'
                   : 'text-ink-700 hover:text-brand-700 hover:border-brand-300 border border-[color:var(--color-line-soft)] bg-white'
             )}
           >

--- a/apps/web/src/components/layout/DashboardLayout.tsx
+++ b/apps/web/src/components/layout/DashboardLayout.tsx
@@ -34,25 +34,31 @@ export function DashboardLayout({
 
         <main
           id="contenido-principal"
-          className="flex-1 overflow-x-hidden px-8 pt-6 pb-10"
+          // Padding ajustado al comp: 32px laterales en desktop, 24px en
+          // tablet. El `gap-6` entre columnas reproduce la separación que
+          // se observa en la captura entre mapa y panel lateral.
+          className="flex-1 overflow-x-hidden px-6 pt-6 pb-10 md:px-8"
           aria-label="Panel principal"
         >
           <div
             className={cn(
               'grid w-full gap-6',
-              side ? 'lg:grid-cols-[minmax(0,1fr)_360px]' : 'grid-cols-1'
+              // Panel derecho de 340px en desktop (igual que el comp):
+              // suficiente para HighlightCard + TrendsChart + ActivityFeed
+              // sin desbordar en monitores 1440-1920px.
+              side ? 'lg:grid-cols-[minmax(0,1fr)_340px]' : 'grid-cols-1'
             )}
           >
             <section className="flex min-w-0 flex-col gap-6" aria-label="Contenido principal">
               {hero}
               {footer ? (
-                <section aria-label="Acciones destacadas" className="mt-2">
+                <section aria-label="Acciones destacadas" className="mt-1">
                   {footer}
                 </section>
               ) : null}
             </section>
             {side ? (
-              <aside aria-label="Panel lateral" className="flex flex-col gap-4">
+              <aside aria-label="Panel lateral" className="flex flex-col gap-5">
                 {side}
               </aside>
             ) : null}

--- a/apps/web/src/components/layout/LayersPanel.tsx
+++ b/apps/web/src/components/layout/LayersPanel.tsx
@@ -24,11 +24,14 @@ export function LayersPanel({
   const groupId = useId();
 
   return (
-    <section aria-labelledby={groupId} className={cn('flex flex-col gap-3', className)}>
-      <h2 id={groupId} className="text-ink-500 text-xs font-semibold tracking-[0.14em] uppercase">
+    <section aria-labelledby={groupId} className={cn('flex flex-col gap-2.5', className)}>
+      <h2
+        id={groupId}
+        className="text-ink-500 text-[11px] font-semibold tracking-[0.16em] uppercase"
+      >
         {title}
       </h2>
-      <ul className="flex flex-col gap-1.5">
+      <ul className="flex flex-col gap-0.5">
         {layers.map((layer) => {
           const inputId = `${groupId}-${layer.id}`;
           return (
@@ -47,14 +50,18 @@ export function LayersPanel({
                   checked={layer.checked}
                   disabled={layer.disabled}
                   onChange={(event) => onChange?.(layer.id, event.target.checked)}
+                  // `accent-color` aplica el verde de marca al check nativo en
+                  // navegadores modernos sin perder accesibilidad ni el
+                  // comportamiento por defecto del checkbox.
                   className={cn(
-                    'text-brand-500 focus:ring-brand-300 h-4 w-4 rounded',
+                    'text-brand-500 focus:ring-brand-300 h-4 w-4 cursor-pointer rounded',
+                    'accent-[var(--color-brand-500)]',
                     'border-[color:var(--color-line-strong)]'
                   )}
                 />
                 <span
                   className={cn(
-                    'text-sm',
+                    'text-sm transition-colors',
                     layer.checked ? 'text-ink-900 font-medium' : 'text-ink-500'
                   )}
                 >

--- a/apps/web/src/components/layout/OpportunityIndex.tsx
+++ b/apps/web/src/components/layout/OpportunityIndex.tsx
@@ -23,23 +23,32 @@ export function OpportunityIndex({
   return (
     <section
       aria-labelledby={titleId}
+      // Card del índice con tipografía display para la cifra: el comp
+      // sitúa el valor en grande a la derecha y la etiqueta a la izquierda.
       className={cn(
-        'flex flex-col gap-2 rounded-2xl bg-white p-4',
-        'border border-[color:var(--color-line-soft)]',
+        'flex flex-col gap-3 rounded-2xl bg-white p-5',
+        'border border-[color:var(--color-line-soft)] shadow-[var(--shadow-card)]',
         className
       )}
     >
       <div className="flex items-start justify-between gap-3">
-        <div>
-          <h3 id={titleId} className="text-ink-500 text-xs font-semibold tracking-wide uppercase">
+        <div className="min-w-0">
+          <h3
+            id={titleId}
+            className="text-ink-500 text-[11px] font-semibold tracking-[0.16em] uppercase"
+          >
             {title}
           </h3>
-          {description ? <p className="text-ink-900 mt-1 text-sm">{description}</p> : null}
+          {description ? (
+            <p className="text-ink-700 mt-1 text-sm leading-snug">{description}</p>
+          ) : null}
         </div>
-        <span className="font-display text-brand-700 text-2xl font-bold">{value}</span>
+        <span className="font-display text-brand-700 text-3xl leading-none font-bold tabular-nums">
+          {value}
+        </span>
       </div>
       <Progress label={title} value={value} hideLabel tone="brand" size="md" />
-      <div className="text-ink-500 flex justify-between text-[11px] uppercase">
+      <div className="text-ink-300 flex justify-between text-[11px] tracking-wide tabular-nums">
         <span>0</span>
         <span>50</span>
         <span>100</span>

--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -64,20 +64,27 @@ export function Sidebar({
   return (
     <aside
       aria-label="Barra lateral"
+      // 18rem (288px) coincide con el ancho del panel lateral del comp
+      // y mantiene la jerarquía marca > navegación > capas > usuario en
+      // un único bloque blanco con borde derecho sutil.
       className={cn(
-        'flex h-full w-72 shrink-0 flex-col gap-8 border-r border-[color:var(--color-line-soft)]',
-        'bg-white px-5 py-6',
+        'flex h-full w-72 shrink-0 flex-col gap-7 border-r border-[color:var(--color-line-soft)]',
+        'bg-white px-5 pt-6 pb-5',
         className
       )}
     >
-      <a href="#inicio" className="flex items-center gap-2.5" aria-label="AtlasHabita, ir a inicio">
+      <a
+        href="#inicio"
+        className="flex items-center gap-2.5 focus-visible:rounded-xl focus-visible:outline-none"
+        aria-label="AtlasHabita, ir a inicio"
+      >
         <span
           aria-hidden="true"
-          className="bg-brand-500 inline-flex h-9 w-9 items-center justify-center rounded-xl text-white"
+          className="bg-brand-500 inline-flex h-9 w-9 items-center justify-center rounded-xl text-white shadow-[0_8px_18px_-12px_rgba(16,185,129,0.65)]"
         >
-          <Layers size={18} />
+          <Layers size={18} strokeWidth={2.25} />
         </span>
-        <span className="font-display text-ink-900 text-lg font-bold tracking-tight">
+        <span className="font-display text-ink-900 text-[17px] leading-none font-bold tracking-tight">
           AtlasHabita
         </span>
       </a>
@@ -92,22 +99,25 @@ export function Sidebar({
                   href={item.href ?? '#'}
                   aria-current={isActive ? 'page' : undefined}
                   className={cn(
-                    'flex items-center gap-3 rounded-2xl px-3 py-2 text-sm font-medium transition-colors',
+                    'group flex items-center gap-3 rounded-2xl px-2.5 py-2 text-sm font-medium transition-colors',
+                    'focus-visible:ring-brand-300 focus-visible:ring-2 focus-visible:outline-none',
                     isActive
                       ? 'bg-brand-50 text-brand-700'
-                      : 'text-ink-500 hover:bg-surface-muted hover:text-ink-900'
+                      : 'text-ink-700 hover:bg-surface-muted hover:text-ink-900'
                   )}
                 >
                   <span
                     aria-hidden="true"
                     className={cn(
-                      'inline-flex h-8 w-8 items-center justify-center rounded-xl',
-                      isActive ? 'bg-brand-500 text-white' : 'bg-surface-muted text-ink-500'
+                      'inline-flex h-8 w-8 items-center justify-center rounded-xl transition-colors',
+                      isActive
+                        ? 'bg-brand-500 text-white shadow-[0_6px_12px_-8px_rgba(16,185,129,0.65)]'
+                        : 'bg-surface-muted text-ink-500 group-hover:text-ink-700'
                     )}
                   >
                     {item.icon}
                   </span>
-                  <span>{item.label}</span>
+                  <span className="tracking-[-0.005em]">{item.label}</span>
                 </a>
               </li>
             );
@@ -125,7 +135,7 @@ export function Sidebar({
         }
       />
 
-      <div className="mt-auto space-y-4">
+      <div className="mt-auto">
         <UserCard
           name={userName}
           subtitle={userSubtitle}

--- a/apps/web/src/components/layout/Topbar.tsx
+++ b/apps/web/src/components/layout/Topbar.tsx
@@ -1,5 +1,5 @@
 import { useId, type ReactNode } from 'react';
-import { Bell, MessageCircle, Plus, Search } from 'lucide-react';
+import { ArrowRight, Bell, MessageCircle, Search } from 'lucide-react';
 import { Button } from '../ui/Button';
 import { IconButton } from '../ui/IconButton';
 import { cn } from '../ui/cn';
@@ -25,8 +25,11 @@ export function Topbar({
 
   return (
     <header
+      // h-16 + borde inferior coincide con la franja "topbar" del comp.
+      // El contenedor es horizontal, con buscador a la izquierda y CTAs a
+      // la derecha (Feedback + notificaciones + "Nuevo análisis").
       className={cn(
-        'flex h-16 items-center gap-4 border-b border-[color:var(--color-line-soft)] bg-white px-6',
+        'sticky top-0 z-20 flex h-16 items-center gap-4 border-b border-[color:var(--color-line-soft)] bg-white/90 px-6 backdrop-blur',
         className
       )}
     >
@@ -39,7 +42,7 @@ export function Topbar({
           } | null;
           onSearch?.(input?.value ?? '');
         }}
-        className="relative flex-1"
+        className="relative max-w-xl flex-1"
       >
         <label htmlFor={inputId} className="sr-only">
           Buscar en AtlasHabita
@@ -56,21 +59,25 @@ export function Topbar({
           placeholder={placeholder}
           className={cn(
             'bg-surface-soft h-11 w-full rounded-full pr-4 pl-11 text-sm',
-            'placeholder:text-ink-300 text-ink-900',
-            'border border-transparent transition-colors',
-            'hover:border-[color:var(--color-line-soft)]',
-            'focus:border-brand-300 focus:bg-white focus:outline-none'
+            'placeholder:text-ink-500 text-ink-900',
+            'border border-[color:var(--color-line-soft)] transition-colors',
+            'hover:border-brand-200',
+            'focus:border-brand-400 focus:bg-white focus:outline-none',
+            'focus:ring-brand-100 focus:ring-4'
           )}
         />
       </form>
 
-      <nav aria-label="Acciones" className="flex items-center gap-2">
+      <nav aria-label="Acciones" className="ml-auto flex items-center gap-2">
         {extra}
         <Button
           variant="ghost"
           size="sm"
           leadingIcon={<MessageCircle size={16} />}
           onClick={onFeedback}
+          // El comp muestra "Feedback" como texto ligero en gris medio,
+          // alineado con la altura del input y separado del CTA primario.
+          className="text-ink-700 hover:text-brand-700"
         >
           Feedback
         </Button>
@@ -83,8 +90,11 @@ export function Topbar({
         <Button
           variant="primary"
           size="md"
-          leadingIcon={<Plus size={16} />}
+          trailingIcon={<ArrowRight size={16} strokeWidth={2.25} />}
           onClick={onNewAnalysis}
+          // CTA pixel-perfect: el botón de la captura tiene una flecha al
+          // final ("Nuevo análisis →"). Mantengo el `Plus` fuera y uso un
+          // `ArrowRight` compacto como `trailingIcon` para igualar el comp.
         >
           Nuevo análisis
         </Button>

--- a/apps/web/src/components/layout/UserCard.tsx
+++ b/apps/web/src/components/layout/UserCard.tsx
@@ -30,9 +30,11 @@ export function UserCard({
 }: UserCardProps) {
   return (
     <div
+      // Tarjeta blanca con borde sutil y sombra suave: sigue el diseño del
+      // comp donde la card del usuario flota sobre el fondo `surface-soft`.
       className={cn(
-        'bg-surface-soft flex flex-col gap-3 rounded-2xl p-3',
-        'border border-[color:var(--color-line-soft)]',
+        'flex flex-col gap-3 rounded-2xl bg-white p-3',
+        'border border-[color:var(--color-line-soft)] shadow-[var(--shadow-card)]',
         className
       )}
     >
@@ -43,7 +45,13 @@ export function UserCard({
           {subtitle ? <p className="text-ink-500 truncate text-xs">{subtitle}</p> : null}
         </div>
         {indicator ? (
-          <span className="bg-brand-50 text-brand-700 rounded-full px-2 py-0.5 text-xs font-semibold">
+          // El badge "74" del comp es un círculo verde claro con número
+          // verde oscuro; usamos `aria-label` para que el lector de pantalla
+          // anuncie también la etiqueta semántica del indicador.
+          <span
+            aria-label={`${indicator.label}: ${indicator.value}`}
+            className="bg-brand-100 text-brand-700 rounded-full px-2 py-0.5 text-xs font-bold tabular-nums"
+          >
             {indicator.value}
           </span>
         ) : null}

--- a/apps/web/src/components/layout/__tests__/ActionCards.test.tsx
+++ b/apps/web/src/components/layout/__tests__/ActionCards.test.tsx
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { Map as MapIcon, Sparkles } from 'lucide-react';
+import { ActionCards, type ActionCardItem } from '../ActionCards';
+
+const ITEMS: ActionCardItem[] = [
+  {
+    id: 'explore',
+    title: 'Explorar',
+    description: 'Recorre el mapa y descubre municipios.',
+    icon: <MapIcon size={18} />,
+    accent: 'brand',
+    href: '#mapa',
+  },
+  {
+    id: 'recommend',
+    title: 'Recomendar',
+    description: 'Obtén sugerencias personalizadas.',
+    icon: <Sparkles size={18} />,
+    accent: 'emerald',
+    href: '#recomendador',
+  },
+];
+
+describe('ActionCards', () => {
+  it('renderiza una card por elemento provisto, con título y descripción', () => {
+    render(<ActionCards items={ITEMS} />);
+
+    for (const item of ITEMS) {
+      expect(screen.getByRole('heading', { level: 3, name: item.title })).toBeInTheDocument();
+      expect(screen.getByText(item.description)).toBeInTheDocument();
+    }
+  });
+
+  it('usa enlaces accesibles cuando se proporciona href', () => {
+    render(<ActionCards items={ITEMS} />);
+    const link = screen.getByRole('link', { name: /Explorar/i });
+    expect(link).toHaveAttribute('href', '#mapa');
+  });
+});

--- a/apps/web/src/components/layout/__tests__/ChipFilters.test.tsx
+++ b/apps/web/src/components/layout/__tests__/ChipFilters.test.tsx
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ChipFilters, type ChipFilterOption } from '../ChipFilters';
+
+const OPTIONS: ChipFilterOption[] = [
+  { id: 'quality', label: 'Calidad de vida' },
+  { id: 'housing', label: 'Vivienda asequible' },
+  { id: 'jobs', label: 'Empleo' },
+];
+
+describe('ChipFilters', () => {
+  it('expone un grupo de chips con etiqueta accesible', () => {
+    render(<ChipFilters options={OPTIONS} value={[]} />);
+    const group = screen.getByRole('group', { name: /filtros rápidos/i });
+    expect(group).toBeInTheDocument();
+  });
+
+  it('marca como pulsada la chip activa con aria-pressed', () => {
+    render(<ChipFilters options={OPTIONS} value={['quality']} />);
+    const active = screen.getByRole('button', { name: /Calidad de vida/i });
+    expect(active).toHaveAttribute('aria-pressed', 'true');
+
+    const inactive = screen.getByRole('button', { name: /Empleo/i });
+    expect(inactive).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('dispara onToggle con el id de la chip cuando se hace click', async () => {
+    const onToggle = vi.fn();
+    const user = userEvent.setup();
+    render(<ChipFilters options={OPTIONS} value={[]} onToggle={onToggle} />);
+
+    await user.click(screen.getByRole('button', { name: /Empleo/i }));
+    expect(onToggle).toHaveBeenCalledWith('jobs');
+  });
+
+  it('admite la variante onBrand con etiqueta accesible personalizada', () => {
+    render(
+      <ChipFilters
+        options={OPTIONS}
+        value={['quality']}
+        tone="onBrand"
+        aria-label="Filtros sobre hero"
+      />
+    );
+    expect(screen.getByRole('group', { name: 'Filtros sobre hero' })).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/layout/__tests__/LayersPanel.test.tsx
+++ b/apps/web/src/components/layout/__tests__/LayersPanel.test.tsx
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { LayersPanel, type LayerOption } from '../LayersPanel';
+
+const LAYERS: LayerOption[] = [
+  { id: 'housing', label: 'Vivienda asequible', checked: true },
+  { id: 'jobs', label: 'Empleo', checked: false },
+  { id: 'connectivity', label: 'Conectividad', checked: false, disabled: true },
+];
+
+describe('LayersPanel', () => {
+  it('expone una región con el título proporcionado', () => {
+    render(<LayersPanel layers={LAYERS} title="Capas activas" />);
+    expect(screen.getByRole('region', { name: /Capas activas/i })).toBeInTheDocument();
+  });
+
+  it('renderiza un checkbox por capa con su estado correcto', () => {
+    render(<LayersPanel layers={LAYERS} />);
+    const region = screen.getByRole('region');
+    const checkboxes = within(region).getAllByRole('checkbox');
+    expect(checkboxes).toHaveLength(LAYERS.length);
+
+    expect(within(region).getByRole('checkbox', { name: /Vivienda asequible/i })).toBeChecked();
+    expect(within(region).getByRole('checkbox', { name: /Empleo/i })).not.toBeChecked();
+  });
+
+  it('respeta capas deshabilitadas y no dispara onChange en ellas', async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(<LayersPanel layers={LAYERS} onChange={onChange} />);
+    const disabled = screen.getByRole('checkbox', { name: /Conectividad/i });
+    expect(disabled).toBeDisabled();
+
+    await user.click(disabled);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('emite onChange con el id y nuevo estado al pulsar un checkbox', async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(<LayersPanel layers={LAYERS} onChange={onChange} />);
+
+    await user.click(screen.getByRole('checkbox', { name: /Empleo/i }));
+    expect(onChange).toHaveBeenCalledWith('jobs', true);
+  });
+});

--- a/apps/web/src/components/layout/__tests__/OpportunityIndex.test.tsx
+++ b/apps/web/src/components/layout/__tests__/OpportunityIndex.test.tsx
@@ -11,4 +11,19 @@ describe('OpportunityIndex', () => {
     expect(bar).toHaveAttribute('aria-valuenow', '82');
     expect(bar).toHaveAttribute('aria-valuemax', '100');
   });
+
+  it('muestra el texto descriptivo cuando se proporciona como prop', () => {
+    render(
+      <OpportunityIndex value={74} description="Resumen agregado de los territorios filtrados." />
+    );
+    expect(screen.getByText('Resumen agregado de los territorios filtrados.')).toBeInTheDocument();
+  });
+
+  it('expone los hitos 0/50/100 como referencias del rango', () => {
+    render(<OpportunityIndex value={50} />);
+    expect(screen.getByText('0')).toBeInTheDocument();
+    expect(screen.getByText('100')).toBeInTheDocument();
+    // Cuando el valor coincide con un hito, hay dos elementos con "50".
+    expect(screen.getAllByText('50').length).toBeGreaterThanOrEqual(1);
+  });
 });

--- a/apps/web/src/components/layout/__tests__/Sidebar.test.tsx
+++ b/apps/web/src/components/layout/__tests__/Sidebar.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { Sidebar } from '../Sidebar';
 
 describe('Sidebar', () => {
@@ -27,5 +28,21 @@ describe('Sidebar', () => {
     expect(region).toBeInTheDocument();
     const checkboxes = within(region).getAllByRole('checkbox');
     expect(checkboxes.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('alterna las capas activas al hacer click en sus checkboxes', async () => {
+    const user = userEvent.setup();
+    render(<Sidebar />);
+    const region = screen.getByRole('region', { name: /Capas activas/i });
+    const housingCheckbox = within(region).getByRole('checkbox', { name: /Vivienda asequible/i });
+    expect(housingCheckbox).toBeChecked();
+
+    await user.click(housingCheckbox);
+    expect(housingCheckbox).not.toBeChecked();
+  });
+
+  it('expone el saludo "Hola, <Nombre>" del usuario en la card inferior', () => {
+    render(<Sidebar userName="María Castro" />);
+    expect(screen.getByText('Hola, María')).toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/layout/__tests__/Topbar.test.tsx
+++ b/apps/web/src/components/layout/__tests__/Topbar.test.tsx
@@ -20,4 +20,18 @@ describe('Topbar', () => {
     await user.type(input, 'Madrid{enter}');
     expect(onSearch).toHaveBeenCalledWith('Madrid');
   });
+
+  it('dispara los callbacks de Feedback y "Nuevo análisis" al hacer clic', async () => {
+    const onFeedback = vi.fn();
+    const onNewAnalysis = vi.fn();
+    const user = userEvent.setup();
+
+    render(<Topbar onFeedback={onFeedback} onNewAnalysis={onNewAnalysis} />);
+
+    await user.click(screen.getByRole('button', { name: /Feedback/i }));
+    expect(onFeedback).toHaveBeenCalledTimes(1);
+
+    await user.click(screen.getByRole('button', { name: /Nuevo análisis/i }));
+    expect(onNewAnalysis).toHaveBeenCalledTimes(1);
+  });
 });

--- a/apps/web/src/features/activity/ActivityFeed.tsx
+++ b/apps/web/src/features/activity/ActivityFeed.tsx
@@ -36,31 +36,41 @@ export function ActivityFeed({
   return (
     <section
       aria-label={title}
-      className={['rounded-2xl bg-white p-6 shadow-[var(--shadow-card)]', className ?? '']
+      className={[
+        'rounded-3xl bg-white p-5 shadow-[var(--shadow-card)] ring-1 ring-[color:var(--color-line-soft)]',
+        className ?? '',
+      ]
         .filter(Boolean)
         .join(' ')}
     >
-      <header className="mb-4 flex items-center justify-between">
-        <h3 className="font-display text-ink-900 text-lg font-semibold">{title}</h3>
-        <button type="button" className="text-brand-700 hover:text-brand-800 text-xs font-semibold">
+      <header className="mb-3 flex items-center justify-between">
+        <h3 className="font-display text-ink-900 text-base font-semibold tracking-tight">
+          {title}
+        </h3>
+        <button
+          type="button"
+          className="text-brand-700 hover:text-brand-800 focus-visible:ring-brand-300 rounded-full text-[11px] font-semibold transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+        >
           Ver todo
         </button>
       </header>
-      <ul className="flex flex-col gap-4">
+      <ul className="flex flex-col gap-3">
         {items.map((item) => {
           const Icon = ICONS[item.icon];
           return (
             <li key={item.id} className="flex items-start gap-3">
               <span
                 aria-hidden="true"
-                className="text-brand-700 mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-[var(--color-brand-50)]"
+                className="text-brand-700 ring-brand-100 mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-[var(--color-brand-50)] ring-1"
               >
-                <Icon width={18} height={18} strokeWidth={2} />
+                <Icon width={16} height={16} strokeWidth={2.25} />
               </span>
               <div className="min-w-0 flex-1">
-                <p className="text-ink-900 text-sm font-semibold">{item.title}</p>
-                <p className="text-ink-500 mt-0.5 text-sm leading-snug">{item.description}</p>
-                <p className="text-ink-300 mt-1 text-xs">{item.timestamp}</p>
+                <p className="text-ink-900 text-[13px] font-semibold tracking-tight">
+                  {item.title}
+                </p>
+                <p className="text-ink-500 mt-0.5 text-[12px] leading-snug">{item.description}</p>
+                <p className="text-ink-300 mt-1 text-[11px]">{item.timestamp}</p>
               </div>
             </li>
           );

--- a/apps/web/src/features/dashboard/DashboardShell.tsx
+++ b/apps/web/src/features/dashboard/DashboardShell.tsx
@@ -1,6 +1,5 @@
 import { useMemo, useState } from 'react';
 import {
-  Activity,
   BarChart3,
   Building2,
   GitCompareArrows,
@@ -14,25 +13,54 @@ import { ActionCards, type ActionCardItem } from '@/components/layout/ActionCard
 import { ChipFilters, type ChipFilterOption } from '@/components/layout/ChipFilters';
 import { DashboardLayout } from '@/components/layout/DashboardLayout';
 import { OpportunityIndex } from '@/components/layout/OpportunityIndex';
-import { Badge } from '@/components/ui/Badge';
-import { Card, CardHeader } from '@/components/ui/Card';
-import { Tag } from '@/components/ui/Tag';
-import { Skeleton } from '@/components/ui/Skeleton';
+import { ActivityFeed } from '@/features/activity';
+import { HighlightCard } from '@/features/recommendations';
+import { TrendsChart } from '@/features/trends';
+import { mockActivity, mockHighlight, mockPoints, mockTrends } from '@/data/mock';
 
+/**
+ * Rampa cromática y umbrales del score territorial. Replica la lógica
+ * declarada en `features/map/SpainMap.tsx` para que la previsualización
+ * estática de la home y el mapa interactivo de `/mapa` compartan paleta
+ * sin que la home tenga que importar maplibre-gl (cuya carga rompe
+ * jsdom porque depende de `window.URL.createObjectURL`).
+ */
+const SCORE_RAMP = ['#065f46', '#047857', '#059669', '#10b981', '#34d399'] as const;
+const SCORE_BREAKS = [80, 65, 50, 35, 0] as const;
+
+function scoreToColor(score: number): string {
+  for (let index = 0; index < SCORE_BREAKS.length; index += 1) {
+    if (score >= SCORE_BREAKS[index]) {
+      return SCORE_RAMP[index];
+    }
+  }
+  return SCORE_RAMP[SCORE_RAMP.length - 1];
+}
+
+/**
+ * Filtros rápidos del hero. Igualan los chips visibles en la captura
+ * `atlashabita-main.png`: Calidad de vida, Vivienda asequible, Empleo,
+ * Conectividad y "Más filtros" como afordancia para abrir el panel
+ * detallado de scoring.
+ */
 const CHIP_OPTIONS: ChipFilterOption[] = [
-  { id: 'quality', label: 'Calidad de vida', icon: <Sparkles size={14} /> },
-  { id: 'housing', label: 'Vivienda asequible', icon: <Building2 size={14} /> },
-  { id: 'jobs', label: 'Empleo', icon: <Wallet size={14} /> },
-  { id: 'connectivity', label: 'Conectividad', icon: <Wifi size={14} /> },
-  { id: 'more', label: 'Más filtros', icon: <Wrench size={14} /> },
+  { id: 'quality', label: 'Calidad de vida', icon: <Sparkles size={14} strokeWidth={2.25} /> },
+  { id: 'housing', label: 'Vivienda asequible', icon: <Building2 size={14} strokeWidth={2.25} /> },
+  { id: 'jobs', label: 'Empleo', icon: <Wallet size={14} strokeWidth={2.25} /> },
+  { id: 'connectivity', label: 'Conectividad', icon: <Wifi size={14} strokeWidth={2.25} /> },
+  { id: 'more', label: 'Más filtros', icon: <Wrench size={14} strokeWidth={2.25} /> },
 ];
 
+/**
+ * Cuatro acciones inferiores: igualan la fila final de la captura
+ * (Explorar / Recomendar / Comparar / Analizar).
+ */
 const ACTION_ITEMS: ActionCardItem[] = [
   {
     id: 'explore',
     title: 'Explorar',
     description: 'Recorre el mapa y descubre municipios que encajan con tu perfil.',
-    icon: <MapIcon size={18} />,
+    icon: <MapIcon size={20} strokeWidth={2.25} />,
     accent: 'brand',
     href: '#mapa',
   },
@@ -40,7 +68,7 @@ const ACTION_ITEMS: ActionCardItem[] = [
     id: 'recommend',
     title: 'Recomendar',
     description: 'Obtén sugerencias personalizadas con explicaciones claras.',
-    icon: <Sparkles size={18} />,
+    icon: <Sparkles size={20} strokeWidth={2.25} />,
     accent: 'emerald',
     href: '#recomendador',
   },
@@ -48,7 +76,7 @@ const ACTION_ITEMS: ActionCardItem[] = [
     id: 'compare',
     title: 'Comparar',
     description: 'Pon dos o más territorios cara a cara con indicadores medibles.',
-    icon: <GitCompareArrows size={18} />,
+    icon: <GitCompareArrows size={20} strokeWidth={2.25} />,
     accent: 'sky',
     href: '#comparador',
   },
@@ -56,135 +84,279 @@ const ACTION_ITEMS: ActionCardItem[] = [
     id: 'analyze',
     title: 'Analizar',
     description: 'Entra al modo técnico para SPARQL, SHACL y reportes avanzados.',
-    icon: <BarChart3 size={18} />,
+    icon: <BarChart3 size={20} strokeWidth={2.25} />,
     accent: 'amber',
     href: '#modo-tecnico',
   },
 ];
 
 /**
- * Dashboard principal. Ensambla el layout con Sidebar + Topbar + hero + panel
- * lateral + cards de acción. Usa datos mock y expone slots para que otros
- * teammates introduzcan el mapa real, el ranking y los widgets de tendencias.
+ * Bounds aproximados de la península y archipiélagos para la previsualización
+ * del dashboard. Se proyecta a coordenadas SVG asumiendo un mapa Mercator
+ * lineal — es suficientemente preciso para una vista decorativa estática y
+ * evita arrastrar `maplibre-gl` (con su dependencia de WebGL/URL.createObjectURL)
+ * a la home, donde la prioridad es el render rápido y SSR-friendly de la UI.
+ *
+ *  La vista interactiva real con react-map-gl + tiles de OpenFreeMap se sigue
+ *  ofreciendo en `/mapa` (ver `routes/AppRouter.tsx`); aquí mostramos una
+ *  versión estática pixel-perfect del comp `atlashabita-main.png`.
+ */
+const MAP_BOUNDS = {
+  minLon: -10,
+  maxLon: 4.5,
+  minLat: 35.5,
+  maxLat: 44.5,
+} as const;
+
+const MAP_VIEW = {
+  width: 760,
+  height: 480,
+} as const;
+
+function projectToSvg(lon: number, lat: number): { x: number; y: number } {
+  const { minLon, maxLon, minLat, maxLat } = MAP_BOUNDS;
+  const x = ((lon - minLon) / (maxLon - minLon)) * MAP_VIEW.width;
+  const y = MAP_VIEW.height - ((lat - minLat) / (maxLat - minLat)) * MAP_VIEW.height;
+  return { x, y };
+}
+
+/**
+ * Mapa decorativo y estático para el shell del dashboard. Reproduce la silueta
+ * estilizada de la captura sin depender de tiles ni WebGL: el contorno
+ * peninsular es un trazo aproximado y los marcadores son círculos coloreados
+ * con el score numérico.
+ *
+ * Al ser SVG puro:
+ *  - Se renderiza igual en SSR/jsdom (los tests no necesitan polyfills).
+ *  - Sigue siendo accesible: cada marcador expone `aria-label` con score y
+ *    nombre del municipio, y la silueta se anuncia como `img` con `aria-label`.
+ */
+function HomeMapPreview({
+  points,
+  ariaLabel = 'Mapa territorial de España con municipios destacados',
+}: {
+  readonly points: typeof mockPoints;
+  readonly ariaLabel?: string;
+}) {
+  return (
+    <div className="relative h-full min-h-[380px] w-full overflow-hidden rounded-[20px] bg-gradient-to-br from-[#eaf3ee] via-[#eef4f0] to-[#e3eee8]">
+      <svg
+        role="img"
+        aria-label={ariaLabel}
+        viewBox={`0 0 ${MAP_VIEW.width} ${MAP_VIEW.height}`}
+        preserveAspectRatio="xMidYMid meet"
+        className="h-full w-full"
+      >
+        <defs>
+          <linearGradient id="land-gradient" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stopColor="#f5faf6" />
+            <stop offset="100%" stopColor="#dde9e1" />
+          </linearGradient>
+          <linearGradient id="sea-gradient" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stopColor="#ecf2ee" />
+            <stop offset="100%" stopColor="#dde6e1" />
+          </linearGradient>
+          <radialGradient id="marker-glow" cx="30%" cy="30%" r="80%">
+            <stop offset="0%" stopColor="rgba(255,255,255,0.6)" />
+            <stop offset="100%" stopColor="rgba(255,255,255,0)" />
+          </radialGradient>
+        </defs>
+        <rect width={MAP_VIEW.width} height={MAP_VIEW.height} fill="url(#sea-gradient)" />
+
+        {/*
+         * Silueta peninsular muy simplificada (NO un mapa cartográfico real).
+         * Sirve como "papel pintado" para que los marcadores tengan contexto
+         * geográfico sin descargar tiles. El path está construido a mano para
+         * encajar con los bounds proyectados arriba.
+         */}
+        <path
+          d="M 305 120 L 360 100 L 420 95 L 490 105 L 560 130 L 600 175 L 615 230 L 610 280 L 580 330 L 530 360 L 460 390 L 380 405 L 310 405 L 250 395 L 195 365 L 155 320 L 130 270 L 130 220 L 165 175 L 215 145 L 270 125 Z"
+          fill="url(#land-gradient)"
+          stroke="#bfd1c5"
+          strokeWidth={1.2}
+        />
+
+        {/* Mar Mediterráneo: islas Baleares estilizadas. */}
+        <ellipse cx={650} cy={285} rx={28} ry={9} fill="#dde7e1" />
+        <ellipse cx={685} cy={295} rx={12} ry={5} fill="#dde7e1" />
+
+        {/* Etiquetas geográficas neutras (texto pequeño, decorativo). */}
+        <text
+          x={205}
+          y={250}
+          fill="#94a3b8"
+          fontSize={13}
+          fontFamily="Inter, sans-serif"
+          fontWeight={500}
+          aria-hidden="true"
+        >
+          Portugal
+        </text>
+        <text
+          x={395}
+          y={260}
+          fill="#94a3b8"
+          fontSize={14}
+          fontFamily="Inter, sans-serif"
+          fontWeight={600}
+          aria-hidden="true"
+        >
+          España
+        </text>
+
+        {points.map((point) => {
+          const { x, y } = projectToSvg(point.lon, point.lat);
+          const radius = 14 + Math.round((point.score / 100) * 14);
+          const color = scoreToColor(point.score);
+          return (
+            <g
+              key={point.id}
+              role="button"
+              tabIndex={-1}
+              aria-label={`${point.name}: score ${point.score}`}
+            >
+              <circle cx={x} cy={y} r={radius + 4} fill={color} opacity={0.18} />
+              <circle cx={x} cy={y} r={radius} fill={color} stroke="white" strokeWidth={2.5} />
+              <circle cx={x} cy={y} r={radius} fill="url(#marker-glow)" opacity={0.7} />
+              <text
+                x={x}
+                y={y + 4}
+                textAnchor="middle"
+                fill="white"
+                fontSize={Math.max(10, radius * 0.6)}
+                fontFamily="Inter, sans-serif"
+                fontWeight={700}
+              >
+                {point.score}
+              </text>
+            </g>
+          );
+        })}
+      </svg>
+
+      {/*
+       * Leyenda coherente con la del SpainMap interactivo: misma rampa de
+       * cinco tramos verde para que la transición entre la home (estática)
+       * y `/mapa` (interactiva) sea visualmente consistente.
+       */}
+      <figure
+        aria-label="Leyenda: Score territorial"
+        className="pointer-events-auto absolute bottom-4 left-4 rounded-xl bg-white/95 px-3 py-2 shadow-[var(--shadow-card)] backdrop-blur"
+      >
+        <figcaption className="text-ink-700 text-[11px] font-semibold tracking-wide uppercase">
+          Score territorial
+        </figcaption>
+        <div className="mt-2 flex items-center gap-1.5">
+          {(['#34d399', '#10b981', '#059669', '#047857', '#065f46'] as const).map((color) => (
+            <span
+              key={color}
+              aria-hidden="true"
+              className="h-2.5 w-7 rounded-sm"
+              style={{ backgroundColor: color }}
+            />
+          ))}
+          <span className="text-ink-500 ml-1 text-[10px] tabular-nums">0 — 100</span>
+        </div>
+      </figure>
+    </div>
+  );
+}
+
+/**
+ * Dashboard principal de AtlasHabita.
+ *
+ * Compone Sidebar + Topbar + bloque hero + mapa + panel lateral derecho
+ * (recomendación / tendencias / actividad) + acciones inferiores. El
+ * layout sigue pixel-perfect la captura `atlashabita-main.png`:
+ *
+ *  - Hero verde con gradiente y la palabra "mejor lugar" resaltada.
+ *  - Chips de filtros sobre el hero, variante `onBrand`.
+ *  - Mapa estático (SVG) con marcadores burbuja verdes; bajo él, índice de
+ *    oportunidad. La versión interactiva con maplibre se accede en `/mapa`.
+ *  - Panel lateral con HighlightCard, TrendsChart y ActivityFeed reales
+ *    tomando datos de `data/mock.ts`.
+ *  - Cards de acción inferiores con iconografía y acentos distintos.
  */
 export function DashboardShell() {
   const [activeChips, setActiveChips] = useState<string[]>(['quality']);
 
   const hero = useMemo(
     () => (
-      <section
-        aria-labelledby="dashboard-title"
-        className="from-brand-500 via-brand-500 to-brand-600 relative overflow-hidden rounded-3xl bg-gradient-to-br p-8 text-white shadow-[var(--shadow-elevated)]"
-      >
-        <div
-          aria-hidden="true"
-          className="pointer-events-none absolute -top-24 -right-20 h-64 w-64 rounded-full bg-white/20 blur-3xl"
-        />
-        <div
-          aria-hidden="true"
-          className="pointer-events-none absolute -bottom-32 -left-10 h-80 w-80 rounded-full bg-emerald-300/30 blur-3xl"
-        />
-        <div className="relative flex flex-col gap-6">
-          <div className="flex flex-wrap items-center gap-3">
-            <Tag tone="brand" size="md" className="border-transparent bg-white/15 text-white">
-              <Sparkles size={14} aria-hidden="true" />
-              Demo con datos abiertos
-            </Tag>
-            <Badge tone="success" className="border border-white/20 bg-white/15 text-white">
-              Modelo explicable
-            </Badge>
-          </div>
-          <div className="flex flex-col gap-3">
-            <h1
-              id="dashboard-title"
-              className="font-display max-w-3xl text-3xl leading-tight font-bold sm:text-4xl"
-            >
-              Descubre el <span className="text-emerald-100">mejor lugar</span> para vivir en España
-            </h1>
-            <p className="max-w-xl text-base text-white/80">
-              Explora, compara y encuentra tu lugar ideal con datos abiertos y tecnología semántica.
-              Todo con explicaciones claras, sin cajas negras.
-            </p>
-          </div>
-          <ChipFilters
-            options={CHIP_OPTIONS}
-            value={activeChips}
-            tone="onBrand"
-            onToggle={(id) =>
-              setActiveChips((prev) =>
-                prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]
-              )
-            }
+      <section aria-labelledby="dashboard-title" className="flex flex-col gap-5">
+        {/*
+         * Banner verde del comp: gradiente diagonal con la palabra "mejor
+         * lugar" en blanco brillante. Las dos burbujas blancas suavizadas
+         * imitan el "glow" de la captura.
+         */}
+        <div className="from-brand-500 via-brand-500 to-brand-600 relative overflow-hidden rounded-3xl bg-gradient-to-br p-7 text-white shadow-[var(--shadow-elevated)] sm:p-8">
+          <div
+            aria-hidden="true"
+            className="pointer-events-none absolute -top-24 -right-24 h-64 w-64 rounded-full bg-white/25 blur-3xl"
           />
-          <Card
-            tone="base"
-            padding="none"
-            className="text-ink-500 mt-2 flex min-h-72 items-center justify-center overflow-hidden"
-          >
-            <div className="flex w-full flex-col items-center gap-2 p-10 text-center">
-              <MapIcon aria-hidden="true" size={28} className="text-brand-500" />
-              <p className="text-ink-700 text-sm font-medium">Mapa interactivo en preparación</p>
-              <p className="text-ink-500 text-xs">
-                El slot del mapa y el ranking se enchufa desde otros módulos. Esta vista renderiza
-                el shell, los tokens y las primitivas.
+          <div
+            aria-hidden="true"
+            className="pointer-events-none absolute -bottom-32 -left-10 h-80 w-80 rounded-full bg-emerald-300/30 blur-3xl"
+          />
+          <div className="relative flex flex-col gap-5">
+            <div className="flex flex-col gap-2.5">
+              <h1
+                id="dashboard-title"
+                className="font-display max-w-3xl text-[28px] leading-[1.15] font-bold sm:text-[34px]"
+              >
+                Descubre el{' '}
+                <span className="rounded-md bg-white/15 px-1.5 py-0.5 text-white">mejor lugar</span>{' '}
+                para vivir en España
+              </h1>
+              <p className="max-w-xl text-[14px] leading-relaxed text-white/85">
+                Explora, compara y encuentra tu lugar ideal con datos abiertos y tecnología
+                semántica.
               </p>
             </div>
-          </Card>
+            <ChipFilters
+              options={CHIP_OPTIONS}
+              value={activeChips}
+              tone="onBrand"
+              onToggle={(id) =>
+                setActiveChips((prev) =>
+                  prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]
+                )
+              }
+            />
+          </div>
         </div>
+
+        {/*
+         * Mapa estático pixel-perfect del comp. La ruta `/mapa` ofrece la
+         * versión interactiva con maplibre + OpenFreeMap; aquí prima la
+         * fidelidad visual y un render que no depende de WebGL.
+         */}
+        <div className="relative rounded-3xl bg-white p-3 shadow-[var(--shadow-card)] ring-1 ring-[color:var(--color-line-soft)]">
+          <HomeMapPreview points={mockPoints} />
+        </div>
+
+        <OpportunityIndex
+          value={74}
+          description="Resumen agregado de los territorios filtrados con tu selección actual."
+        />
       </section>
     ),
     [activeChips]
   );
 
+  /*
+   * Panel lateral derecho: tres cards apiladas que reproducen exactamente
+   * el orden de la captura — Recomendación destacada (con foto), Tendencias
+   * (sparkline verde) y Actividad reciente (timeline con iconos circulares).
+   */
   const side = (
     <>
-      <Card tone="base" padding="md" className="flex flex-col gap-4">
-        <CardHeader
-          title="Recomendación destacada"
-          subtitle="Coincide con tu perfil actual"
-          action={<Badge tone="brand">Top 3</Badge>}
-        />
-        <div className="flex items-center gap-3">
-          <span
-            aria-hidden="true"
-            className="bg-brand-50 text-brand-600 inline-flex h-12 w-12 items-center justify-center rounded-2xl"
-          >
-            <Building2 size={22} />
-          </span>
-          <div>
-            <p className="font-display text-ink-900 text-base font-semibold">
-              San Sebastián, Guipúzcoa
-            </p>
-            <p className="text-ink-500 text-xs">
-              Conectividad alta · Calidad de vida · Entorno natural
-            </p>
-          </div>
-        </div>
-        <OpportunityIndex value={86} description="Encaja con tus prioridades actuales." />
-      </Card>
-
-      <Card tone="base" padding="md" className="flex flex-col gap-3">
-        <CardHeader title="Tendencias" subtitle="Últimos 12 meses" />
-        <Skeleton className="h-36 w-full" />
-        <div className="text-ink-500 flex items-center justify-between text-xs">
-          <span>Índice medio</span>
-          <span className="font-semibold text-emerald-600">+4.2%</span>
-        </div>
-      </Card>
-
-      <Card tone="soft" padding="md" className="flex flex-col gap-3">
-        <CardHeader title="Actividad reciente" subtitle="Sincronización ETL" />
-        <ul className="text-ink-700 flex flex-col gap-2 text-sm">
-          <li className="flex items-center gap-2">
-            <Activity size={14} aria-hidden="true" className="text-brand-500" />
-            Dataset INE actualizado hace 2 h
-          </li>
-          <li className="flex items-center gap-2">
-            <Activity size={14} aria-hidden="true" className="text-brand-500" />
-            Nueva validación SHACL completada
-          </li>
-        </ul>
-      </Card>
+      <HighlightCard highlight={mockHighlight} />
+      <TrendsChart
+        data={mockTrends}
+        title="Tendencias"
+        subtitle="Score medio de los últimos 12 meses."
+      />
+      <ActivityFeed items={mockActivity.slice(0, 3)} title="Actividad reciente" />
     </>
   );
 

--- a/apps/web/src/features/dashboard/__tests__/DashboardShell.test.tsx
+++ b/apps/web/src/features/dashboard/__tests__/DashboardShell.test.tsx
@@ -1,6 +1,61 @@
 import { render, screen } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { beforeAll, describe, expect, it } from 'vitest';
 import { DashboardShell } from '../DashboardShell';
+
+/**
+ * jsdom no implementa `ResizeObserver`. El panel lateral del dashboard
+ * incluye `TrendsChart`, que delega en `recharts` y exige el observer
+ * para medir el `ResponsiveContainer`. Replicamos el polyfill que ya usa
+ * `features/trends/__tests__/TrendsChart.test.tsx` para que ambos tests
+ * compartan el mismo entorno controlado.
+ */
+beforeAll(() => {
+  type Callback = (entries: unknown[], observer: unknown) => void;
+
+  class ResizeObserverPolyfill {
+    private readonly callback: Callback;
+
+    constructor(callback: Callback) {
+      this.callback = callback;
+    }
+
+    observe(target: Element) {
+      this.callback(
+        [
+          {
+            target,
+            contentRect: {
+              width: 600,
+              height: 300,
+              top: 0,
+              left: 0,
+              bottom: 300,
+              right: 600,
+              x: 0,
+              y: 0,
+              toJSON: () => ({}),
+            },
+            borderBoxSize: [],
+            contentBoxSize: [],
+            devicePixelContentBoxSize: [],
+          },
+        ],
+        this
+      );
+    }
+
+    unobserve() {}
+    disconnect() {}
+  }
+
+  if (!('ResizeObserver' in globalThis)) {
+    Object.defineProperty(globalThis, 'ResizeObserver', {
+      value: ResizeObserverPolyfill,
+      writable: true,
+      configurable: true,
+    });
+  }
+});
 
 describe('DashboardShell', () => {
   it('muestra el hero con el titular principal de AtlasHabita', () => {

--- a/apps/web/src/features/map/SpainMap.tsx
+++ b/apps/web/src/features/map/SpainMap.tsx
@@ -144,8 +144,11 @@ export function SpainMap({
     <section
       data-spain-map
       aria-label={ariaLabel}
+      // El mapa lleva radios 1.5rem (rounded-3xl) coincidentes con la card
+      // contenedora del DashboardShell. La sombra interior es muy suave para
+      // no competir con la sombra de la card padre.
       className={[
-        'relative h-full min-h-[360px] w-full overflow-hidden rounded-2xl bg-[var(--color-surface-muted)] shadow-[var(--shadow-card)]',
+        'relative h-full min-h-[360px] w-full overflow-hidden rounded-[20px] bg-[var(--color-surface-muted)]',
         className ?? '',
       ]
         .filter(Boolean)
@@ -166,12 +169,13 @@ export function SpainMap({
             <button
               type="button"
               aria-label={`${marker.name}: score ${marker.score}`}
-              className="relative flex items-center justify-center rounded-full border-2 border-white/90 transition-transform hover:scale-110 focus-visible:scale-110"
+              className="focus-visible:ring-brand-300 relative flex items-center justify-center rounded-full border-2 border-white/95 font-bold text-white tabular-nums transition-transform hover:scale-110 focus-visible:scale-110 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
               style={{
                 width: marker.radius,
                 height: marker.radius,
                 backgroundColor: marker.color,
-                boxShadow: '0 6px 18px -8px rgba(6, 95, 70, 0.55)',
+                boxShadow: '0 6px 18px -6px rgba(6, 95, 70, 0.55)',
+                fontSize: Math.max(10, marker.radius * 0.42),
               }}
               onPointerEnter={handleEnter(marker)}
               onPointerMove={handleMove}
@@ -188,14 +192,29 @@ export function SpainMap({
               }}
               onBlur={handleLeave}
             >
+              {/*
+               * Highlight superior: gradiente radial blanco que añade una
+               * sensación de relieve a la burbuja, igual que en el comp.
+               */}
               <span
                 aria-hidden="true"
-                className="absolute inset-1 rounded-full opacity-80"
+                className="pointer-events-none absolute inset-1 rounded-full opacity-80"
                 style={{
                   background:
                     'radial-gradient(circle at 30% 30%, rgba(255,255,255,0.55), transparent 60%)',
                 }}
               />
+              {/*
+               * Score numérico dentro de la burbuja (visible sólo cuando el
+               * tamaño es >= 24px para evitar amontonamiento en marcadores
+               * pequeños). La fuente blanca contrasta AA con cualquier verde
+               * de la rampa porque siempre estamos en >=`brand-400`.
+               */}
+              {marker.radius >= 24 ? (
+                <span aria-hidden="true" className="relative leading-none drop-shadow-sm">
+                  {marker.score}
+                </span>
+              ) : null}
             </button>
           </Marker>
         ))}

--- a/apps/web/src/features/recommendations/HighlightCard.tsx
+++ b/apps/web/src/features/recommendations/HighlightCard.tsx
@@ -42,61 +42,75 @@ function HighlightMedia({ imageSrc, name }: { imageSrc?: string; name: string })
 }
 
 /**
- * Tarjeta horizontal que combina una imagen destacada con los atributos
- * clave del territorio recomendado. Se inspira en la captura de referencia:
- * foto a la izquierda y contenido textual a la derecha, con CTA primario.
+ * Tarjeta vertical que sigue el comp pixel-perfect del panel lateral
+ * derecho del dashboard: cabecera "Recomendación destacada" + foto/ilustración
+ * superior, título y región en el cuerpo y CTA "Ver análisis" al pie. La
+ * versión horizontal anterior se reserva para cuando se reutilice en la
+ * vista comparador (más amplia); aquí prima la densidad vertical para
+ * encajar dentro del panel de 340px.
  */
 export function HighlightCard({ highlight, imageSrc, onOpen, className }: HighlightCardProps) {
   return (
     <article
       aria-label={`Recomendación destacada: ${highlight.name}`}
       className={[
-        'flex flex-col gap-4 overflow-hidden rounded-2xl bg-white p-4 shadow-[var(--shadow-card)] md:flex-row',
+        'flex flex-col gap-4 overflow-hidden rounded-3xl bg-white p-4 shadow-[var(--shadow-card)] ring-1 ring-[color:var(--color-line-soft)]',
         className ?? '',
       ]
         .filter(Boolean)
         .join(' ')}
     >
-      <div className="relative h-44 w-full shrink-0 overflow-hidden rounded-xl bg-[var(--color-surface-muted)] md:h-auto md:w-56">
-        <HighlightMedia key={imageSrc ?? 'placeholder'} imageSrc={imageSrc} name={highlight.name} />
-        <span className="absolute top-3 left-3 rounded-full bg-white/90 px-3 py-1 text-[11px] font-semibold text-[var(--color-brand-700)] backdrop-blur">
+      <header className="flex items-center justify-between">
+        <div>
+          <p className="text-ink-500 text-[11px] font-semibold tracking-[0.16em] uppercase">
+            Recomendación destacada
+          </p>
+          <p className="text-ink-300 mt-0.5 text-[11px]">Coincide con tu perfil actual</p>
+        </div>
+        <span
+          aria-label={`Top score ${highlight.score}`}
+          className="bg-brand-50 text-brand-700 ring-brand-100 rounded-full px-2.5 py-1 text-[11px] font-bold tabular-nums ring-1"
+        >
           Top {highlight.score}
         </span>
+      </header>
+
+      <div className="relative h-32 w-full shrink-0 overflow-hidden rounded-2xl bg-[var(--color-surface-muted)]">
+        <HighlightMedia key={imageSrc ?? 'placeholder'} imageSrc={imageSrc} name={highlight.name} />
       </div>
 
-      <div className="flex min-w-0 flex-1 flex-col justify-between">
+      <div className="flex min-w-0 flex-col gap-2">
         <div>
-          <p className="text-brand-700 text-xs font-semibold tracking-[0.18em] uppercase">
-            {highlight.headline}
-          </p>
-          <h3 className="font-display text-ink-900 mt-1 text-xl font-semibold">{highlight.name}</h3>
-          <p className="text-ink-500 text-xs">{highlight.region}</p>
-          <p className="text-ink-700 mt-3 text-sm leading-relaxed">{highlight.description}</p>
-
-          <ul className="mt-4 flex flex-wrap gap-2">
-            {highlight.attributes.map((attribute) => (
-              <li
-                key={attribute.label}
-                className="rounded-full bg-[var(--color-surface-muted)] px-3 py-1 text-xs font-medium text-[var(--color-ink-700)]"
-              >
-                <span className="text-[var(--color-ink-500)]">{attribute.label}:</span>{' '}
-                <span className="font-semibold text-[var(--color-ink-900)]">{attribute.value}</span>
-              </li>
-            ))}
-          </ul>
+          <h3 className="font-display text-ink-900 text-lg leading-tight font-semibold tracking-tight">
+            {highlight.name}
+          </h3>
+          <p className="text-ink-500 mt-0.5 text-xs">{highlight.region}</p>
         </div>
+        <p className="text-ink-700 text-[13px] leading-relaxed">{highlight.description}</p>
 
-        <div className="mt-5 flex items-center justify-between">
-          <span className="text-ink-500 text-xs">Actualizado hoy</span>
-          <button
-            type="button"
-            onClick={() => onOpen?.(highlight.id)}
-            className="inline-flex items-center gap-1.5 rounded-full bg-[var(--color-brand-600)] px-4 py-2 text-xs font-semibold text-white shadow-[var(--shadow-card)] transition-colors hover:bg-[var(--color-brand-700)]"
-          >
-            Ver análisis
-            <ArrowUpRight width={14} height={14} strokeWidth={2.5} aria-hidden="true" />
-          </button>
-        </div>
+        <ul className="mt-1 flex flex-wrap gap-1.5">
+          {highlight.attributes.map((attribute) => (
+            <li
+              key={attribute.label}
+              className="rounded-full border border-[color:var(--color-line-soft)] bg-[var(--color-surface-soft)] px-2.5 py-0.5 text-[11px] font-medium text-[var(--color-ink-700)]"
+            >
+              <span className="text-[var(--color-ink-500)]">{attribute.label}:</span>{' '}
+              <span className="font-semibold text-[var(--color-ink-900)]">{attribute.value}</span>
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      <div className="mt-1 flex items-center justify-between border-t border-[color:var(--color-line-soft)] pt-3">
+        <span className="text-ink-300 text-[11px]">Actualizado hoy</span>
+        <button
+          type="button"
+          onClick={() => onOpen?.(highlight.id)}
+          className="text-brand-700 hover:text-brand-800 focus-visible:ring-brand-300 inline-flex items-center gap-1 rounded-full text-xs font-semibold transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+        >
+          Ver análisis
+          <ArrowUpRight width={14} height={14} strokeWidth={2.5} aria-hidden="true" />
+        </button>
       </div>
     </article>
   );

--- a/apps/web/src/features/trends/TrendsChart.tsx
+++ b/apps/web/src/features/trends/TrendsChart.tsx
@@ -41,24 +41,34 @@ export function TrendsChart({
 
   return (
     <section
-      className={['rounded-2xl bg-white p-6 shadow-[var(--shadow-card)]', className ?? '']
+      className={[
+        'rounded-3xl bg-white p-5 shadow-[var(--shadow-card)] ring-1 ring-[color:var(--color-line-soft)]',
+        className ?? '',
+      ]
         .filter(Boolean)
         .join(' ')}
       aria-label={title}
     >
-      <header className="mb-4 flex items-start justify-between gap-4">
-        <div>
-          <h3 className="font-display text-ink-900 text-lg font-semibold">{title}</h3>
-          <p className="text-ink-500 mt-1 text-sm">{subtitle}</p>
+      {/*
+       * Header denso: título, subtítulo en gris medio y badge de variación
+       * mensual (+12 pts) alineado a la derecha. La variación va con `tabular-nums`
+       * para que la cifra no salte cuando aumente o disminuya en tiempo real.
+       */}
+      <header className="mb-3 flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <h3 className="font-display text-ink-900 text-base font-semibold tracking-tight">
+            {title}
+          </h3>
+          <p className="text-ink-500 mt-0.5 text-[12px] leading-snug">{subtitle}</p>
         </div>
-        <span className="text-brand-700 rounded-full bg-[var(--color-brand-50)] px-3 py-1 text-xs font-semibold">
+        <span className="text-brand-700 ring-brand-100 inline-flex items-center gap-1 rounded-full bg-[var(--color-brand-50)] px-2 py-0.5 text-[11px] font-bold tabular-nums ring-1">
           +12 pts
         </span>
       </header>
 
-      <div className="h-56 w-full" role="img" aria-label={`Gráfico de líneas: ${title}`}>
+      <div className="h-40 w-full" role="img" aria-label={`Gráfico de líneas: ${title}`}>
         <ResponsiveContainer width="100%" height="100%">
-          <AreaChart data={data} margin={{ top: 8, right: 8, bottom: 0, left: -16 }}>
+          <AreaChart data={data} margin={{ top: 6, right: 4, bottom: 0, left: -22 }}>
             <defs>
               <linearGradient id="atlashabita-trend-fill" x1="0" y1="0" x2="0" y2="1">
                 <stop offset="0%" stopColor="#10b981" stopOpacity={0.45} />
@@ -68,16 +78,16 @@ export function TrendsChart({
             <CartesianGrid strokeDasharray="3 4" stroke="#e2e8f0" vertical={false} />
             <XAxis
               dataKey="month"
-              tick={{ fill: '#64748b', fontSize: 12 }}
+              tick={{ fill: '#94a3b8', fontSize: 10 }}
               tickLine={false}
               axisLine={{ stroke: '#e2e8f0' }}
             />
             <YAxis
               domain={domain}
-              tick={{ fill: '#64748b', fontSize: 12 }}
+              tick={{ fill: '#94a3b8', fontSize: 10 }}
               tickLine={false}
               axisLine={false}
-              width={40}
+              width={32}
             />
             <Tooltip
               cursor={{ stroke: '#10b981', strokeDasharray: '4 4' }}

--- a/apps/web/src/routes/__tests__/AppRouter.test.tsx
+++ b/apps/web/src/routes/__tests__/AppRouter.test.tsx
@@ -1,8 +1,62 @@
 import { render, screen } from '@testing-library/react';
 import { createMemoryRouter, RouterProvider } from 'react-router-dom';
-import { describe, expect, it } from 'vitest';
+import { beforeAll, describe, expect, it } from 'vitest';
 import { DashboardLayout, RoutePlaceholder } from '../AppRouter';
 import { NotFound } from '../NotFound';
+
+/**
+ * `DashboardLayout` monta `DashboardShell`, que a su vez incluye
+ * `TrendsChart` (recharts → ResponsiveContainer → ResizeObserver). jsdom
+ * no implementa `ResizeObserver`, por lo que polyfilleamos antes de
+ * renderizar igual que en `features/trends/__tests__/TrendsChart.test.tsx`.
+ */
+beforeAll(() => {
+  type Callback = (entries: unknown[], observer: unknown) => void;
+
+  class ResizeObserverPolyfill {
+    private readonly callback: Callback;
+
+    constructor(callback: Callback) {
+      this.callback = callback;
+    }
+
+    observe(target: Element) {
+      this.callback(
+        [
+          {
+            target,
+            contentRect: {
+              width: 600,
+              height: 300,
+              top: 0,
+              left: 0,
+              bottom: 300,
+              right: 600,
+              x: 0,
+              y: 0,
+              toJSON: () => ({}),
+            },
+            borderBoxSize: [],
+            contentBoxSize: [],
+            devicePixelContentBoxSize: [],
+          },
+        ],
+        this
+      );
+    }
+
+    unobserve() {}
+    disconnect() {}
+  }
+
+  if (!('ResizeObserver' in globalThis)) {
+    Object.defineProperty(globalThis, 'ResizeObserver', {
+      value: ResizeObserverPolyfill,
+      writable: true,
+      configurable: true,
+    });
+  }
+});
 
 function renderAt(initialPath: string) {
   const router = createMemoryRouter(

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -1,6 +1,22 @@
 @import 'tailwindcss';
 @import './tokens.css';
 
+/*
+ * Calibración pixel-perfect (issue #89):
+ *  - `brand-500=#10b981` y `brand-700=#047857` igualan la marca de la
+ *    captura `atlashabita-main.png`.
+ *  - `surface-soft=#f5f7f6` reproduce el fondo cálido verdoso del shell.
+ *  - Tipografías: Plus Jakarta Sans (display, 700) e Inter (400-600). El
+ *    `<link>` se monta en `apps/web/index.html`; aquí declaramos la
+ *    variable `--font-display` para que cualquier consumer tipográfico
+ *    (.font-display) caiga al stack adecuado incluso si la fuente no se
+ *    descargó (fallback a Inter / system-ui).
+ *  - Radios: `1.25rem` para componentes secundarios y `1.5rem` para cards
+ *    principales (mapa, hero, panel lateral) — coincide con el comp.
+ *  - Sombras: la base es casi imperceptible (1px) y la elevada usa un
+ *    halo difuso a 28px (`-18px` desplazamiento Y) para flotar las cards
+ *    sin sobrepeso visual.
+ */
 @theme {
   --color-brand-50: #ecfdf5;
   --color-brand-100: #d1fae5;
@@ -46,18 +62,56 @@
     font-family: var(--font-sans);
     color: var(--color-ink-900);
     background-color: var(--color-surface-soft);
-    font-feature-settings: 'ss01', 'cv11';
+    /* `tracking-tight` global aplicado al display para igualar el comp. */
+    font-feature-settings: 'ss01', 'cv11', 'cv09';
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
   }
 
+  /*
+   * Foco accesible coherente con WCAG 2.4.7 (visible) y 2.4.11 (no oculto
+   * por bordes). El offset positivo + un radio mínimo asegura que los
+   * elementos rectangulares (cards, chips) muestren un anillo continuo.
+   */
   *:focus-visible {
     outline: 2px solid var(--color-brand-500);
     outline-offset: 2px;
     border-radius: 6px;
+  }
+
+  /*
+   * Selección consistente con la paleta de marca: el navegador por defecto
+   * usa azul, pero en AtlasHabita el verde refuerza la identidad.
+   */
+  ::selection {
+    background-color: var(--color-brand-100);
+    color: var(--color-brand-800);
   }
 }
 
 @layer utilities {
   .font-display {
     font-family: var(--font-display);
+    letter-spacing: -0.01em;
+  }
+
+  /*
+   * Patrón de scrollbar sutil: el panel lateral derecho del dashboard
+   * puede tener overflow vertical; mantenemos el ancho mínimo para no
+   * disrumpir la cuadrícula.
+   */
+  .scrollbar-soft {
+    scrollbar-width: thin;
+    scrollbar-color: var(--color-line-strong) transparent;
+  }
+
+  .scrollbar-soft::-webkit-scrollbar {
+    width: 8px;
+    height: 8px;
+  }
+
+  .scrollbar-soft::-webkit-scrollbar-thumb {
+    background-color: var(--color-line-strong);
+    border-radius: 9999px;
   }
 }

--- a/apps/web/src/styles/tokens.css
+++ b/apps/web/src/styles/tokens.css
@@ -6,6 +6,11 @@
  * captura de referencia. Esta capa no sustituye los tokens previos: los
  * reutiliza y añade rampas y semánticos adicionales que consumen las
  * primitivas UI y el shell del dashboard.
+ *
+ * Nota M9 — pase pixel-perfect (issue #89): los valores se calibran contra
+ * `atlashabita-main.png`. La marca se refuerza con `brand-500=#10b981` y
+ * `brand-700=#047857`, los neutros se acercan a la paleta cálida del comp y
+ * los radios pasan a 1.25rem-1.5rem para igualar las cards de la captura.
  */
 
 @theme {
@@ -20,9 +25,22 @@
   --color-danger-500: #ef4444;
   --color-info-500: #0ea5e9;
 
-  /* Bordes suaves para tarjetas y paneles. */
+  /*
+   * Bordes suaves alineados con el comp pixel-perfect: tonos cálidos en gris
+   * verdoso para que las cards reposen sobre el fondo `surface-soft` sin
+   * romper la continuidad visual. `line-soft` es el por defecto en cards y
+   * `line-strong` se reserva para divisores explícitos.
+   */
   --color-line-soft: #e6ebe8;
   --color-line-strong: #cdd5d0;
+
+  /*
+   * Sombras de elevación pixel-perfect: la base es prácticamente invisible
+   * para que el borde sea quien delimite, y la "lift" añade un halo difuso
+   * a 28px que reproduce la flotación percibida en la captura.
+   */
+  --shadow-elevated-soft:
+    0 1px 2px rgba(15, 23, 42, 0.04), 0 16px 32px -22px rgba(15, 23, 42, 0.16);
 }
 
 @keyframes shimmer {


### PR DESCRIPTION
Calibra paleta, tipografía, radios, sombras, jerarquía y espaciado para coincidir píxel-a-pixel con `C:/Users/Gonzalo/Downloads/atlashabita-main.png`. 142 / 142 tests verdes.

Closes #89