### PR TITLE
feat(web): animaciones GSAP fluidas con respeto a prefers-reduced-motion

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -19,8 +19,10 @@
     "e2e": "playwright test"
   },
   "dependencies": {
+    "@gsap/react": "^2.1.2",
     "@tanstack/react-query": "^5.59.0",
     "clsx": "^2.1.1",
+    "gsap": "^3.13.0",
     "lucide-react": "^0.469.0",
     "maplibre-gl": "^4.7.1",
     "react": "^19.0.0",

--- a/apps/web/pnpm-lock.yaml
+++ b/apps/web/pnpm-lock.yaml
@@ -8,12 +8,18 @@ importers:
 
   .:
     dependencies:
+      '@gsap/react':
+        specifier: ^2.1.2
+        version: 2.1.2(gsap@3.15.0)(react@19.2.5)
       '@tanstack/react-query':
         specifier: ^5.59.0
         version: 5.100.1(react@19.2.5)
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      gsap:
+        specifier: ^3.13.0
+        version: 3.15.0
       lucide-react:
         specifier: ^0.469.0
         version: 0.469.0(react@19.2.5)
@@ -573,6 +579,12 @@ packages:
   '@eslint/plugin-kit@0.4.1':
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@gsap/react@2.1.2':
+    resolution: {integrity: sha512-JqliybO1837UcgH2hVOM4VO+38APk3ECNrsuSM4MuXp+rbf+/2IG2K1YJiqfTcXQHH7XlA0m3ykniFYstfq0Iw==}
+    peerDependencies:
+      gsap: ^3.12.5
+      react: '>=17'
 
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
@@ -1748,6 +1760,9 @@ packages:
 
   grid-index@1.1.0:
     resolution: {integrity: sha512-HZRwumpOGUrHyxO5bqKZL0B0GlUpwtCAzZ42sgxUPniu33R1LSFH5yrIcBCHjkctCAh3mtWKcKd9J4vDDdeVHA==}
+
+  gsap@3.15.0:
+    resolution: {integrity: sha512-dMW4CWBTUK1AEEDeZc1g4xpPGIrSf9fJF960qbTZmN/QwZIWY5wgliS6JWl9/25fpTGJrMRtSjGtOmPnfjZB+A==}
 
   has-bigints@1.1.0:
     resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
@@ -3396,6 +3411,11 @@ snapshots:
       '@eslint/core': 0.17.0
       levn: 0.4.1
 
+  '@gsap/react@2.1.2(gsap@3.15.0)(react@19.2.5)':
+    dependencies:
+      gsap: 3.15.0
+      react: 19.2.5
+
   '@humanfs/core@0.19.2':
     dependencies:
       '@humanfs/types': 0.15.0
@@ -4712,6 +4732,8 @@ snapshots:
   graceful-fs@4.2.11: {}
 
   grid-index@1.1.0: {}
+
+  gsap@3.15.0: {}
 
   has-bigints@1.1.0: {}
 

--- a/apps/web/src/animations/__tests__/reducedMotion.test.ts
+++ b/apps/web/src/animations/__tests__/reducedMotion.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  REDUCED_MOTION_QUERY,
+  prefersReducedMotion,
+  resolveDuration,
+  resolveDurationWithFallback,
+} from '../reducedMotion';
+
+type MatchMediaStub = typeof window.matchMedia;
+
+function mockMatchMedia(matches: boolean): MatchMediaStub {
+  return ((query: string) => ({
+    matches,
+    media: query,
+    addEventListener: () => undefined,
+    removeEventListener: () => undefined,
+    addListener: () => undefined,
+    removeListener: () => undefined,
+    dispatchEvent: () => false,
+    onchange: null,
+  })) as unknown as MatchMediaStub;
+}
+
+describe('reducedMotion helpers', () => {
+  const originalMatchMedia = window.matchMedia;
+
+  afterEach(() => {
+    // Restaurar matchMedia para no contaminar otros tests.
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      writable: true,
+      value: originalMatchMedia,
+    });
+    vi.restoreAllMocks();
+  });
+
+  it('expone la media query canónica', () => {
+    expect(REDUCED_MOTION_QUERY).toBe('(prefers-reduced-motion: reduce)');
+  });
+
+  it('prefersReducedMotion devuelve false cuando matchMedia no marca reduce', () => {
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      writable: true,
+      value: mockMatchMedia(false),
+    });
+    expect(prefersReducedMotion()).toBe(false);
+  });
+
+  it('prefersReducedMotion devuelve true cuando matchMedia marca reduce', () => {
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      writable: true,
+      value: mockMatchMedia(true),
+    });
+    expect(prefersReducedMotion()).toBe(true);
+  });
+
+  it('resolveDuration devuelve la duración original cuando no hay reducción', () => {
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      writable: true,
+      value: mockMatchMedia(false),
+    });
+    expect(resolveDuration(0.6)).toBe(0.6);
+  });
+
+  it('resolveDuration colapsa a 0 cuando se pide reducir movimiento', () => {
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      writable: true,
+      value: mockMatchMedia(true),
+    });
+    expect(resolveDuration(0.6)).toBe(0);
+  });
+
+  it('resolveDurationWithFallback aplica el fallback solicitado', () => {
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      writable: true,
+      value: mockMatchMedia(true),
+    });
+    expect(resolveDurationWithFallback(0.6, 0.05)).toBe(0.05);
+  });
+
+  it('resolveDurationWithFallback mantiene la duración base si no hay preferencia', () => {
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      writable: true,
+      value: mockMatchMedia(false),
+    });
+    expect(resolveDurationWithFallback(0.6, 0.05)).toBe(0.6);
+  });
+});

--- a/apps/web/src/animations/index.ts
+++ b/apps/web/src/animations/index.ts
@@ -1,0 +1,14 @@
+export {
+  REDUCED_MOTION_QUERY,
+  prefersReducedMotion,
+  resolveDuration,
+  resolveDurationWithFallback,
+} from './reducedMotion';
+export {
+  DURATION_DEFAULT,
+  DURATION_MICRO,
+  EASE_IN_OUT,
+  EASE_MICRO,
+  FADE_IN_OFFSET,
+  STAGGER_DEFAULT,
+} from './presets';

--- a/apps/web/src/animations/presets.ts
+++ b/apps/web/src/animations/presets.ts
@@ -1,0 +1,25 @@
+/**
+ * Presets compartidos por los componentes motion de AtlasHabita.
+ *
+ * Centralizamos los valores para mantener una sensación homogénea al
+ * animar (easings, staggers y duraciones) y facilitar cualquier ajuste
+ * en una única fuente de verdad.
+ */
+
+/** Curva de entrada suave, inspirada en el sistema de diseño. */
+export const EASE_IN_OUT = 'power2.out';
+
+/** Curva enfática para microinteracciones (hover, pulse). */
+export const EASE_MICRO = 'power1.out';
+
+/** Duración base (segundos) para entradas estándar. */
+export const DURATION_DEFAULT = 0.6;
+
+/** Duración corta para microinteracciones. */
+export const DURATION_MICRO = 0.25;
+
+/** Separación entre hijos animados en cascada. */
+export const STAGGER_DEFAULT = 0.08;
+
+/** Valor vertical de entrada (fade+slide hacia arriba). */
+export const FADE_IN_OFFSET = 24;

--- a/apps/web/src/animations/reducedMotion.ts
+++ b/apps/web/src/animations/reducedMotion.ts
@@ -1,0 +1,41 @@
+/**
+ * Helpers para detectar `prefers-reduced-motion` y adaptar duraciones de
+ * las animaciones GSAP. La filosofía es simple: si el usuario ha declarado
+ * que prefiere reducir el movimiento, colapsamos las duraciones a un valor
+ * testimonial (0) y evitamos transformaciones costosas. De este modo
+ * respetamos la guía WCAG 2.1 success criterion 2.3.3.
+ */
+
+/** Media query canónica definida por el CSSOM. */
+export const REDUCED_MOTION_QUERY = '(prefers-reduced-motion: reduce)';
+
+/**
+ * Devuelve `true` cuando el entorno soporta `matchMedia` y el usuario
+ * solicita reducir el movimiento. Se aísla en una función pura para poder
+ * simularla desde tests sin recurrir a JSDOM.
+ */
+export function prefersReducedMotion(): boolean {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+    return false;
+  }
+  return window.matchMedia(REDUCED_MOTION_QUERY).matches;
+}
+
+/**
+ * Ajusta una duración GSAP (en segundos) respetando `prefers-reduced-motion`.
+ * Cuando la preferencia está activa devolvemos `0`, que en GSAP equivale a
+ * saltar la animación y aplicar el estado final de inmediato. En caso
+ * contrario, devolvemos la duración pasada por parámetro.
+ */
+export function resolveDuration(duration: number): number {
+  return prefersReducedMotion() ? 0 : duration;
+}
+
+/**
+ * Variante que permite indicar una duración alternativa cuando el usuario
+ * prefiere reducir el movimiento (por ejemplo, un fade casi instantáneo en
+ * lugar de eliminar la animación por completo).
+ */
+export function resolveDurationWithFallback(duration: number, reducedDuration: number): number {
+  return prefersReducedMotion() ? reducedDuration : duration;
+}

--- a/apps/web/src/components/layout/ActionCards.tsx
+++ b/apps/web/src/components/layout/ActionCards.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react';
 import { ArrowRight } from 'lucide-react';
+import { MotionScale } from '../motion';
 import { Card } from '../ui/Card';
 import { cn } from '../ui/cn';
 
@@ -29,43 +30,45 @@ export function ActionCards({ items, className }: ActionCardsProps) {
     <ul className={cn('grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4', className)}>
       {items.map((item) => (
         <li key={item.id}>
-          <Card
-            as="article"
-            tone="base"
-            padding="md"
-            interactive
-            className="group relative flex h-full flex-col gap-4"
-          >
-            <header className="flex items-center justify-between">
-              <span
-                aria-hidden="true"
-                className={cn(
-                  'inline-flex h-10 w-10 items-center justify-center rounded-2xl',
-                  ACCENT_BG[item.accent ?? 'brand']
-                )}
-              >
-                {item.icon}
-              </span>
-              <ArrowRight
-                aria-hidden="true"
-                size={18}
-                className="text-ink-300 group-hover:text-brand-500 transition-colors"
-              />
-            </header>
-            <div className="flex flex-col gap-1">
-              <h3 className="font-display text-ink-900 text-base font-semibold">
-                {item.href ? (
-                  <a href={item.href} className="focus:outline-none">
-                    <span className="absolute inset-0" aria-hidden="true" />
-                    {item.title}
-                  </a>
-                ) : (
-                  item.title
-                )}
-              </h3>
-              <p className="text-ink-500 text-sm leading-relaxed">{item.description}</p>
-            </div>
-          </Card>
+          <MotionScale scale={1.03} duration={0.25} className="block h-full">
+            <Card
+              as="article"
+              tone="base"
+              padding="md"
+              interactive
+              className="group relative flex h-full flex-col gap-4 transition-shadow hover:shadow-[var(--shadow-elevated)]"
+            >
+              <header className="flex items-center justify-between">
+                <span
+                  aria-hidden="true"
+                  className={cn(
+                    'inline-flex h-10 w-10 items-center justify-center rounded-2xl',
+                    ACCENT_BG[item.accent ?? 'brand']
+                  )}
+                >
+                  {item.icon}
+                </span>
+                <ArrowRight
+                  aria-hidden="true"
+                  size={18}
+                  className="text-ink-300 group-hover:text-brand-500 transition-colors"
+                />
+              </header>
+              <div className="flex flex-col gap-1">
+                <h3 className="font-display text-ink-900 text-base font-semibold">
+                  {item.href ? (
+                    <a href={item.href} className="focus:outline-none">
+                      <span className="absolute inset-0" aria-hidden="true" />
+                      {item.title}
+                    </a>
+                  ) : (
+                    item.title
+                  )}
+                </h3>
+                <p className="text-ink-500 text-sm leading-relaxed">{item.description}</p>
+              </div>
+            </Card>
+          </MotionScale>
         </li>
       ))}
     </ul>

--- a/apps/web/src/components/layout/ChipFilters.tsx
+++ b/apps/web/src/components/layout/ChipFilters.tsx
@@ -1,4 +1,8 @@
-import type { ReactNode } from 'react';
+import { useRef, type ReactNode } from 'react';
+import gsap from 'gsap';
+import { useGSAP } from '@gsap/react';
+
+import { resolveDuration } from '@/animations';
 import { cn } from '../ui/cn';
 
 export interface ChipFilterOption {
@@ -26,8 +30,40 @@ export function ChipFilters({
   'aria-label': ariaLabel = 'Filtros rápidos',
   className,
 }: ChipFiltersProps) {
+  const groupRef = useRef<HTMLElement | null>(null);
+
+  /*
+   * Animación de entrada en cascada para los chips al montar el grupo.
+   * Usamos `node.children` para evitar combinators `>` que algunos
+   * entornos (JSDOM) no toleran en querySelectorAll.
+   */
+  useGSAP(
+    () => {
+      const node = groupRef.current;
+      if (!node) return;
+      const targets = Array.from(node.children);
+      if (targets.length === 0) return;
+      gsap.from(targets, {
+        opacity: 0,
+        y: 10,
+        duration: resolveDuration(0.35),
+        stagger: 0.05,
+        ease: 'power2.out',
+        clearProps: 'transform,opacity',
+      });
+    },
+    { scope: groupRef }
+  );
+
   return (
-    <div role="group" aria-label={ariaLabel} className={cn('flex flex-wrap gap-2', className)}>
+    <div
+      ref={(node) => {
+        groupRef.current = node;
+      }}
+      role="group"
+      aria-label={ariaLabel}
+      className={cn('flex flex-wrap gap-2', className)}
+    >
       {options.map((option) => {
         const isActive = value.includes(option.id);
         return (

--- a/apps/web/src/components/layout/OpportunityIndex.tsx
+++ b/apps/web/src/components/layout/OpportunityIndex.tsx
@@ -1,5 +1,8 @@
-import { useId } from 'react';
+import { useId, useRef } from 'react';
+import gsap from 'gsap';
+import { useGSAP } from '@gsap/react';
 
+import { resolveDuration } from '@/animations';
 import { Progress } from '../ui/Progress';
 import { cn } from '../ui/cn';
 
@@ -20,8 +23,34 @@ export function OpportunityIndex({
   // ``id``: antes se usaba un literal fijo que fallaba si el componente se
   // montaba varias veces (panel lateral + vista comparativa, por ejemplo).
   const titleId = useId();
+  const rootRef = useRef<HTMLElement | null>(null);
+
+  /*
+   * Animamos la entrada del indicador desplegándolo desde escala 0.98 y
+   * un fade muy corto. No tocamos la barra de progreso directamente para
+   * no pisar estilos que controla el sistema de diseño.
+   */
+  useGSAP(
+    () => {
+      const node = rootRef.current;
+      if (!node) return;
+      gsap.from(node, {
+        opacity: 0,
+        scale: 0.98,
+        y: 8,
+        duration: resolveDuration(0.4),
+        ease: 'power2.out',
+        clearProps: 'transform,opacity',
+      });
+    },
+    { scope: rootRef, dependencies: [value] }
+  );
+
   return (
     <section
+      ref={(node) => {
+        rootRef.current = node;
+      }}
       aria-labelledby={titleId}
       className={cn(
         'flex flex-col gap-2 rounded-2xl bg-white p-4',

--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -8,6 +8,7 @@ import {
   Map as MapIcon,
   SlidersHorizontal,
 } from 'lucide-react';
+import { MotionStagger } from '../motion';
 import { cn } from '../ui/cn';
 import { LayersPanel, type LayerOption } from './LayersPanel';
 import { UserCard } from './UserCard';
@@ -83,7 +84,13 @@ export function Sidebar({
       </a>
 
       <nav aria-label="Navegación principal">
-        <ul className="flex flex-col gap-1">
+        <MotionStagger
+          as="ul"
+          className="flex flex-col gap-1"
+          duration={0.45}
+          stagger={0.05}
+          y={12}
+        >
           {navItems.map((item) => {
             const isActive = item.id === activeNavId;
             return (
@@ -112,7 +119,7 @@ export function Sidebar({
               </li>
             );
           })}
-        </ul>
+        </MotionStagger>
       </nav>
 
       <LayersPanel

--- a/apps/web/src/components/layout/Topbar.tsx
+++ b/apps/web/src/components/layout/Topbar.tsx
@@ -1,5 +1,9 @@
-import { useId, type ReactNode } from 'react';
+import { useId, useRef, type ReactNode } from 'react';
 import { Bell, MessageCircle, Plus, Search } from 'lucide-react';
+import gsap from 'gsap';
+import { useGSAP } from '@gsap/react';
+
+import { resolveDuration } from '@/animations';
 import { Button } from '../ui/Button';
 import { IconButton } from '../ui/IconButton';
 import { cn } from '../ui/cn';
@@ -22,9 +26,30 @@ export function Topbar({
   className,
 }: TopbarProps) {
   const inputId = useId();
+  const headerRef = useRef<HTMLElement | null>(null);
+
+  // Entrada suave del topbar desde arriba. Se cancela solo cuando el
+  // usuario solicita reducir el movimiento.
+  useGSAP(
+    () => {
+      const node = headerRef.current;
+      if (!node) return;
+      gsap.from(node, {
+        y: -18,
+        opacity: 0,
+        duration: resolveDuration(0.5),
+        ease: 'power2.out',
+        clearProps: 'transform,opacity',
+      });
+    },
+    { scope: headerRef }
+  );
 
   return (
     <header
+      ref={(node) => {
+        headerRef.current = node;
+      }}
       className={cn(
         'flex h-16 items-center gap-4 border-b border-[color:var(--color-line-soft)] bg-white px-6',
         className

--- a/apps/web/src/components/layout/UserCard.tsx
+++ b/apps/web/src/components/layout/UserCard.tsx
@@ -1,4 +1,8 @@
-import type { ReactNode } from 'react';
+import { useRef, type ReactNode } from 'react';
+import gsap from 'gsap';
+import { useGSAP } from '@gsap/react';
+
+import { resolveDuration } from '@/animations';
 import { Avatar } from '../ui/Avatar';
 import { Button } from '../ui/Button';
 import { cn } from '../ui/cn';
@@ -28,8 +32,31 @@ export function UserCard({
   action,
   className,
 }: UserCardProps) {
+  const rootRef = useRef<HTMLElement | null>(null);
+
+  // Animación de entrada con un leve "pop" + fade. La combinación es
+  // barata (solo transform + opacity) y respeta prefers-reduced-motion.
+  useGSAP(
+    () => {
+      const node = rootRef.current;
+      if (!node) return;
+      gsap.from(node, {
+        opacity: 0,
+        scale: 0.96,
+        duration: resolveDuration(0.45),
+        delay: 0.15,
+        ease: 'back.out(1.2)',
+        clearProps: 'transform,opacity',
+      });
+    },
+    { scope: rootRef }
+  );
+
   return (
     <div
+      ref={(node) => {
+        rootRef.current = node;
+      }}
       className={cn(
         'bg-surface-soft flex flex-col gap-3 rounded-2xl p-3',
         'border border-[color:var(--color-line-soft)]',

--- a/apps/web/src/components/motion/MotionFadeIn.tsx
+++ b/apps/web/src/components/motion/MotionFadeIn.tsx
@@ -1,0 +1,71 @@
+import { useRef, type ElementType, type ReactNode } from 'react';
+import gsap from 'gsap';
+import { useGSAP } from '@gsap/react';
+import { DURATION_DEFAULT, EASE_IN_OUT, FADE_IN_OFFSET, resolveDuration } from '@/animations';
+
+export interface MotionFadeInProps {
+  /** Contenido a animar. */
+  children: ReactNode;
+  /** Etiqueta HTML. Por defecto `div`. */
+  as?: ElementType;
+  /** Duración en segundos. */
+  duration?: number;
+  /** Retardo antes de iniciar la animación. */
+  delay?: number;
+  /** Desplazamiento vertical inicial (positivo = entra desde abajo). */
+  y?: number;
+  /** Permite desactivar la animación (útil para tests visuales). */
+  disabled?: boolean;
+  className?: string;
+  'aria-label'?: string;
+}
+
+/**
+ * Wrapper que aplica un `fade-in` con ligero desplazamiento vertical a sus
+ * hijos usando GSAP. Respeta `prefers-reduced-motion`: en ese caso la
+ * duración se colapsa a 0 y el estado final se aplica de inmediato.
+ *
+ * Se anota con `data-motion` para que los tests puedan comprobar que el
+ * wrapper se renderiza aunque el entorno no soporte animaciones reales.
+ */
+export function MotionFadeIn({
+  children,
+  as,
+  duration = DURATION_DEFAULT,
+  delay = 0,
+  y = FADE_IN_OFFSET,
+  disabled = false,
+  className,
+  'aria-label': ariaLabel,
+}: MotionFadeInProps) {
+  const containerRef = useRef<HTMLElement | null>(null);
+
+  useGSAP(
+    () => {
+      if (disabled) return;
+      const node = containerRef.current;
+      if (!node) return;
+      gsap.from(node, {
+        opacity: 0,
+        y,
+        duration: resolveDuration(duration),
+        delay,
+        ease: EASE_IN_OUT,
+        clearProps: 'transform,opacity',
+      });
+    },
+    { scope: containerRef, dependencies: [disabled, duration, delay, y] }
+  );
+
+  const Component = (as ?? 'div') as ElementType;
+  return (
+    <Component
+      ref={containerRef}
+      className={className}
+      data-motion="fade-in"
+      aria-label={ariaLabel}
+    >
+      {children}
+    </Component>
+  );
+}

--- a/apps/web/src/components/motion/MotionScale.tsx
+++ b/apps/web/src/components/motion/MotionScale.tsx
@@ -1,0 +1,114 @@
+import {
+  useCallback,
+  useRef,
+  type ElementType,
+  type FocusEvent,
+  type PointerEvent,
+  type ReactNode,
+} from 'react';
+import gsap from 'gsap';
+import { useGSAP } from '@gsap/react';
+import { DURATION_MICRO, EASE_MICRO, prefersReducedMotion, resolveDuration } from '@/animations';
+
+export interface MotionScaleProps {
+  /** Contenido a envolver. */
+  children: ReactNode;
+  /** Etiqueta HTML. Por defecto `div`. */
+  as?: ElementType;
+  /** Escala objetivo durante hover/focus. */
+  scale?: number;
+  /** Duración de la transición. */
+  duration?: number;
+  /**
+   * Si es `true`, la animación se aplica con `gsap.from` al montar,
+   * pudiendo servir para generar un "pop" al entrar.
+   */
+  popOnMount?: boolean;
+  /** Desactiva la interacción visual. */
+  disabled?: boolean;
+  className?: string;
+  'aria-label'?: string;
+}
+
+/**
+ * Wrapper que proporciona microinteracciones de escala ante `hover` y
+ * `focus`. Usa `transform` (nunca `top/left`) para mantener 60fps y
+ * respeta `prefers-reduced-motion` evitando el efecto cuando está activo.
+ */
+export function MotionScale({
+  children,
+  as,
+  scale = 1.03,
+  duration = DURATION_MICRO,
+  popOnMount = false,
+  disabled = false,
+  className,
+  'aria-label': ariaLabel,
+}: MotionScaleProps) {
+  const containerRef = useRef<HTMLElement | null>(null);
+
+  useGSAP(
+    () => {
+      if (!popOnMount || disabled) return;
+      const node = containerRef.current;
+      if (!node) return;
+      gsap.from(node, {
+        scale: 0.94,
+        opacity: 0,
+        duration: resolveDuration(duration),
+        ease: EASE_MICRO,
+        clearProps: 'transform,opacity',
+      });
+    },
+    {
+      scope: containerRef,
+      dependencies: [popOnMount, disabled, duration],
+    }
+  );
+
+  const animateTo = useCallback(
+    (value: number) => {
+      if (disabled) return;
+      if (prefersReducedMotion()) return;
+      const node = containerRef.current;
+      if (!node) return;
+      gsap.to(node, {
+        scale: value,
+        duration,
+        ease: EASE_MICRO,
+        overwrite: 'auto',
+      });
+    },
+    [disabled, duration]
+  );
+
+  const handleEnter = useCallback(
+    (_event: PointerEvent<HTMLElement>) => animateTo(scale),
+    [animateTo, scale]
+  );
+
+  const handleLeave = useCallback((_event: PointerEvent<HTMLElement>) => animateTo(1), [animateTo]);
+
+  const handleFocus = useCallback(
+    (_event: FocusEvent<HTMLElement>) => animateTo(scale),
+    [animateTo, scale]
+  );
+
+  const handleBlur = useCallback((_event: FocusEvent<HTMLElement>) => animateTo(1), [animateTo]);
+
+  const Component = (as ?? 'div') as ElementType;
+  return (
+    <Component
+      ref={containerRef}
+      className={className}
+      data-motion="scale"
+      aria-label={ariaLabel}
+      onPointerEnter={handleEnter}
+      onPointerLeave={handleLeave}
+      onFocus={handleFocus}
+      onBlur={handleBlur}
+    >
+      {children}
+    </Component>
+  );
+}

--- a/apps/web/src/components/motion/MotionStagger.tsx
+++ b/apps/web/src/components/motion/MotionStagger.tsx
@@ -1,0 +1,91 @@
+import { useRef, type ElementType, type ReactNode } from 'react';
+import gsap from 'gsap';
+import { useGSAP } from '@gsap/react';
+import {
+  DURATION_DEFAULT,
+  EASE_IN_OUT,
+  FADE_IN_OFFSET,
+  STAGGER_DEFAULT,
+  resolveDuration,
+} from '@/animations';
+
+export interface MotionStaggerProps {
+  /** Hijos que deben animarse en cascada. */
+  children: ReactNode;
+  /** Etiqueta HTML. Por defecto `div`. */
+  as?: ElementType;
+  /** Duración de cada animación individual. */
+  duration?: number;
+  /** Retardo entre hijos (segundos). */
+  stagger?: number;
+  /** Retardo global antes de iniciar la cascada. */
+  delay?: number;
+  /** Desplazamiento vertical inicial. */
+  y?: number;
+  /**
+   * Selector para elegir qué hijos animar dentro del scope. Cuando se
+   * omite, usamos los hijos directos (`node.children`) sin depender del
+   * combinator `>` que algunos entornos de test no toleran.
+   */
+  selector?: string;
+  /** Desactiva la animación (sin afectar al render). */
+  disabled?: boolean;
+  className?: string;
+  'aria-label'?: string;
+}
+
+/**
+ * Aplica una animación de entrada en cascada a sus hijos directos.
+ * Respeta `prefers-reduced-motion`.
+ */
+export function MotionStagger({
+  children,
+  as,
+  duration = DURATION_DEFAULT,
+  stagger = STAGGER_DEFAULT,
+  delay = 0,
+  y = FADE_IN_OFFSET,
+  selector,
+  disabled = false,
+  className,
+  'aria-label': ariaLabel,
+}: MotionStaggerProps) {
+  const containerRef = useRef<HTMLElement | null>(null);
+
+  useGSAP(
+    () => {
+      if (disabled) return;
+      const node = containerRef.current;
+      if (!node) return;
+      const targets: Element[] = selector
+        ? Array.from(node.querySelectorAll(selector))
+        : Array.from(node.children);
+      if (targets.length === 0) return;
+      gsap.from(targets, {
+        opacity: 0,
+        y,
+        duration: resolveDuration(duration),
+        delay,
+        stagger,
+        ease: EASE_IN_OUT,
+        clearProps: 'transform,opacity',
+      });
+    },
+    {
+      scope: containerRef,
+      dependencies: [disabled, duration, stagger, delay, y, selector],
+    }
+  );
+
+  const Component = (as ?? 'div') as ElementType;
+  return (
+    <Component
+      ref={containerRef}
+      className={className}
+      data-motion="stagger"
+      aria-label={ariaLabel}
+    >
+      {children}
+    </Component>
+  );
+}

--- a/apps/web/src/components/motion/__tests__/MotionFadeIn.test.tsx
+++ b/apps/web/src/components/motion/__tests__/MotionFadeIn.test.tsx
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MotionFadeIn } from '../MotionFadeIn';
+
+describe('MotionFadeIn', () => {
+  it('renderiza los hijos y expone data-motion="fade-in"', () => {
+    render(
+      <MotionFadeIn aria-label="hero">
+        <p>Hola AtlasHabita</p>
+      </MotionFadeIn>
+    );
+
+    const wrapper = screen.getByLabelText('hero');
+    expect(wrapper).toBeInTheDocument();
+    expect(wrapper).toHaveAttribute('data-motion', 'fade-in');
+    expect(screen.getByText('Hola AtlasHabita')).toBeInTheDocument();
+  });
+
+  it('permite renderizar con otro tag y conserva los hijos', () => {
+    render(
+      <MotionFadeIn as="section" aria-label="section" disabled>
+        <span>contenido</span>
+      </MotionFadeIn>
+    );
+
+    const wrapper = screen.getByLabelText('section');
+    expect(wrapper.tagName.toLowerCase()).toBe('section');
+    expect(wrapper).toHaveAttribute('data-motion', 'fade-in');
+    expect(wrapper).toContainHTML('<span>contenido</span>');
+  });
+});

--- a/apps/web/src/components/motion/__tests__/MotionScale.test.tsx
+++ b/apps/web/src/components/motion/__tests__/MotionScale.test.tsx
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { MotionScale } from '../MotionScale';
+
+describe('MotionScale', () => {
+  it('renderiza los hijos y expone data-motion="scale"', () => {
+    render(
+      <MotionScale aria-label="card">
+        <button type="button">Pulsa aquí</button>
+      </MotionScale>
+    );
+
+    const wrapper = screen.getByLabelText('card');
+    expect(wrapper).toHaveAttribute('data-motion', 'scale');
+    expect(screen.getByRole('button', { name: 'Pulsa aquí' })).toBeInTheDocument();
+  });
+
+  it('gestiona eventos hover/focus sin romper el render', () => {
+    render(
+      <MotionScale as="section" aria-label="scale-section">
+        <span>inner</span>
+      </MotionScale>
+    );
+
+    const wrapper = screen.getByLabelText('scale-section');
+    // Comprobamos que los handlers no explotan aunque GSAP no pueda
+    // interpolar nada real en JSDOM.
+    fireEvent.pointerEnter(wrapper);
+    fireEvent.pointerLeave(wrapper);
+    fireEvent.focus(wrapper);
+    fireEvent.blur(wrapper);
+
+    expect(wrapper).toContainHTML('<span>inner</span>');
+  });
+
+  it('acepta la prop popOnMount sin bloquear el render', () => {
+    render(
+      <MotionScale aria-label="pop" popOnMount>
+        <span>pop</span>
+      </MotionScale>
+    );
+
+    expect(screen.getByLabelText('pop')).toHaveAttribute('data-motion', 'scale');
+  });
+});

--- a/apps/web/src/components/motion/__tests__/MotionStagger.test.tsx
+++ b/apps/web/src/components/motion/__tests__/MotionStagger.test.tsx
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import { MotionStagger } from '../MotionStagger';
+
+describe('MotionStagger', () => {
+  it('renderiza todos los hijos y marca data-motion="stagger"', () => {
+    render(
+      <MotionStagger as="ul" aria-label="lista">
+        <li>Uno</li>
+        <li>Dos</li>
+        <li>Tres</li>
+      </MotionStagger>
+    );
+
+    const wrapper = screen.getByLabelText('lista');
+    expect(wrapper).toHaveAttribute('data-motion', 'stagger');
+    expect(wrapper.tagName.toLowerCase()).toBe('ul');
+    const items = within(wrapper).getAllByRole('listitem');
+    expect(items).toHaveLength(3);
+    expect(items.map((item) => item.textContent)).toEqual(['Uno', 'Dos', 'Tres']);
+  });
+
+  it('respeta la prop disabled sin eliminar contenido', () => {
+    render(
+      <MotionStagger aria-label="group" disabled>
+        <span>Primero</span>
+        <span>Segundo</span>
+      </MotionStagger>
+    );
+
+    const wrapper = screen.getByLabelText('group');
+    expect(wrapper).toHaveAttribute('data-motion', 'stagger');
+    expect(wrapper.children).toHaveLength(2);
+  });
+});

--- a/apps/web/src/components/motion/index.ts
+++ b/apps/web/src/components/motion/index.ts
@@ -1,0 +1,6 @@
+export { MotionFadeIn } from './MotionFadeIn';
+export type { MotionFadeInProps } from './MotionFadeIn';
+export { MotionStagger } from './MotionStagger';
+export type { MotionStaggerProps } from './MotionStagger';
+export { MotionScale } from './MotionScale';
+export type { MotionScaleProps } from './MotionScale';

--- a/apps/web/src/features/activity/ActivityFeed.tsx
+++ b/apps/web/src/features/activity/ActivityFeed.tsx
@@ -7,6 +7,7 @@ import {
   type LucideIcon,
 } from 'lucide-react';
 
+import { MotionStagger } from '@/components/motion';
 import type { ActivityItem } from '@/data/mock';
 
 export type ActivityFeedProps = {
@@ -46,7 +47,7 @@ export function ActivityFeed({
           Ver todo
         </button>
       </header>
-      <ul className="flex flex-col gap-4">
+      <MotionStagger as="ul" className="flex flex-col gap-4" duration={0.5} stagger={0.07} y={12}>
         {items.map((item) => {
           const Icon = ICONS[item.icon];
           return (
@@ -65,7 +66,7 @@ export function ActivityFeed({
             </li>
           );
         })}
-      </ul>
+      </MotionStagger>
     </section>
   );
 }

--- a/apps/web/src/features/dashboard/DashboardShell.tsx
+++ b/apps/web/src/features/dashboard/DashboardShell.tsx
@@ -14,6 +14,7 @@ import { ActionCards, type ActionCardItem } from '@/components/layout/ActionCard
 import { ChipFilters, type ChipFilterOption } from '@/components/layout/ChipFilters';
 import { DashboardLayout } from '@/components/layout/DashboardLayout';
 import { OpportunityIndex } from '@/components/layout/OpportunityIndex';
+import { MotionFadeIn, MotionStagger } from '@/components/motion';
 import { Badge } from '@/components/ui/Badge';
 import { Card, CardHeader } from '@/components/ui/Card';
 import { Tag } from '@/components/ui/Tag';
@@ -72,72 +73,75 @@ export function DashboardShell() {
 
   const hero = useMemo(
     () => (
-      <section
-        aria-labelledby="dashboard-title"
-        className="from-brand-500 via-brand-500 to-brand-600 relative overflow-hidden rounded-3xl bg-gradient-to-br p-8 text-white shadow-[var(--shadow-elevated)]"
-      >
-        <div
-          aria-hidden="true"
-          className="pointer-events-none absolute -top-24 -right-20 h-64 w-64 rounded-full bg-white/20 blur-3xl"
-        />
-        <div
-          aria-hidden="true"
-          className="pointer-events-none absolute -bottom-32 -left-10 h-80 w-80 rounded-full bg-emerald-300/30 blur-3xl"
-        />
-        <div className="relative flex flex-col gap-6">
-          <div className="flex flex-wrap items-center gap-3">
-            <Tag tone="brand" size="md" className="border-transparent bg-white/15 text-white">
-              <Sparkles size={14} aria-hidden="true" />
-              Demo con datos abiertos
-            </Tag>
-            <Badge tone="success" className="border border-white/20 bg-white/15 text-white">
-              Modelo explicable
-            </Badge>
-          </div>
-          <div className="flex flex-col gap-3">
-            <h1
-              id="dashboard-title"
-              className="font-display max-w-3xl text-3xl leading-tight font-bold sm:text-4xl"
-            >
-              Descubre el <span className="text-emerald-100">mejor lugar</span> para vivir en España
-            </h1>
-            <p className="max-w-xl text-base text-white/80">
-              Explora, compara y encuentra tu lugar ideal con datos abiertos y tecnología semántica.
-              Todo con explicaciones claras, sin cajas negras.
-            </p>
-          </div>
-          <ChipFilters
-            options={CHIP_OPTIONS}
-            value={activeChips}
-            tone="onBrand"
-            onToggle={(id) =>
-              setActiveChips((prev) =>
-                prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]
-              )
-            }
+      <MotionFadeIn as="div" duration={0.75} y={32}>
+        <section
+          aria-labelledby="dashboard-title"
+          className="from-brand-500 via-brand-500 to-brand-600 relative overflow-hidden rounded-3xl bg-gradient-to-br p-8 text-white shadow-[var(--shadow-elevated)]"
+        >
+          <div
+            aria-hidden="true"
+            className="pointer-events-none absolute -top-24 -right-20 h-64 w-64 rounded-full bg-white/20 blur-3xl"
           />
-          <Card
-            tone="base"
-            padding="none"
-            className="text-ink-500 mt-2 flex min-h-72 items-center justify-center overflow-hidden"
-          >
-            <div className="flex w-full flex-col items-center gap-2 p-10 text-center">
-              <MapIcon aria-hidden="true" size={28} className="text-brand-500" />
-              <p className="text-ink-700 text-sm font-medium">Mapa interactivo en preparación</p>
-              <p className="text-ink-500 text-xs">
-                El slot del mapa y el ranking se enchufa desde otros módulos. Esta vista renderiza
-                el shell, los tokens y las primitivas.
+          <div
+            aria-hidden="true"
+            className="pointer-events-none absolute -bottom-32 -left-10 h-80 w-80 rounded-full bg-emerald-300/30 blur-3xl"
+          />
+          <div className="relative flex flex-col gap-6">
+            <div className="flex flex-wrap items-center gap-3">
+              <Tag tone="brand" size="md" className="border-transparent bg-white/15 text-white">
+                <Sparkles size={14} aria-hidden="true" />
+                Demo con datos abiertos
+              </Tag>
+              <Badge tone="success" className="border border-white/20 bg-white/15 text-white">
+                Modelo explicable
+              </Badge>
+            </div>
+            <div className="flex flex-col gap-3">
+              <h1
+                id="dashboard-title"
+                className="font-display max-w-3xl text-3xl leading-tight font-bold sm:text-4xl"
+              >
+                Descubre el <span className="text-emerald-100">mejor lugar</span> para vivir en
+                España
+              </h1>
+              <p className="max-w-xl text-base text-white/80">
+                Explora, compara y encuentra tu lugar ideal con datos abiertos y tecnología
+                semántica. Todo con explicaciones claras, sin cajas negras.
               </p>
             </div>
-          </Card>
-        </div>
-      </section>
+            <ChipFilters
+              options={CHIP_OPTIONS}
+              value={activeChips}
+              tone="onBrand"
+              onToggle={(id) =>
+                setActiveChips((prev) =>
+                  prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]
+                )
+              }
+            />
+            <Card
+              tone="base"
+              padding="none"
+              className="text-ink-500 mt-2 flex min-h-72 items-center justify-center overflow-hidden"
+            >
+              <div className="flex w-full flex-col items-center gap-2 p-10 text-center">
+                <MapIcon aria-hidden="true" size={28} className="text-brand-500" />
+                <p className="text-ink-700 text-sm font-medium">Mapa interactivo en preparación</p>
+                <p className="text-ink-500 text-xs">
+                  El slot del mapa y el ranking se enchufa desde otros módulos. Esta vista renderiza
+                  el shell, los tokens y las primitivas.
+                </p>
+              </div>
+            </Card>
+          </div>
+        </section>
+      </MotionFadeIn>
     ),
     [activeChips]
   );
 
   const side = (
-    <>
+    <MotionStagger duration={0.55} stagger={0.1} y={18} className="contents">
       <Card tone="base" padding="md" className="flex flex-col gap-4">
         <CardHeader
           title="Recomendación destacada"
@@ -185,8 +189,18 @@ export function DashboardShell() {
           </li>
         </ul>
       </Card>
-    </>
+    </MotionStagger>
   );
 
-  return <DashboardLayout hero={hero} side={side} footer={<ActionCards items={ACTION_ITEMS} />} />;
+  return (
+    <DashboardLayout
+      hero={hero}
+      side={side}
+      footer={
+        <MotionStagger duration={0.5} stagger={0.08} y={16} selector="li">
+          <ActionCards items={ACTION_ITEMS} />
+        </MotionStagger>
+      }
+    />
+  );
 }

--- a/apps/web/src/features/hero/HeroBanner.tsx
+++ b/apps/web/src/features/hero/HeroBanner.tsx
@@ -7,7 +7,11 @@ import {
   TrendingUp,
   type LucideIcon,
 } from 'lucide-react';
-import { useState } from 'react';
+import { useRef, useState } from 'react';
+import gsap from 'gsap';
+import { useGSAP } from '@gsap/react';
+
+import { resolveDuration } from '@/animations';
 
 export type HeroChip = {
   id: string;
@@ -45,6 +49,24 @@ export function HeroBanner({
   className,
 }: HeroBannerProps) {
   const [selected, setSelected] = useState(initialSelectedChipId);
+  const rootRef = useRef<HTMLElement | null>(null);
+
+  // Entrada del hero: fade + ligero slide vertical. Se limpia solo al
+  // desmontar gracias a `useGSAP` y respeta `prefers-reduced-motion`.
+  useGSAP(
+    () => {
+      const node = rootRef.current;
+      if (!node) return;
+      gsap.from(node, {
+        opacity: 0,
+        y: 24,
+        duration: resolveDuration(0.7),
+        ease: 'power2.out',
+        clearProps: 'transform,opacity',
+      });
+    },
+    { scope: rootRef }
+  );
 
   const handleSelect = (chipId: string) => {
     setSelected(chipId);
@@ -53,6 +75,9 @@ export function HeroBanner({
 
   return (
     <section
+      ref={(node) => {
+        rootRef.current = node;
+      }}
       aria-label="Buscador principal de AtlasHabita"
       className={[
         'relative overflow-hidden rounded-2xl bg-gradient-to-br from-[var(--color-brand-50)] via-white to-[var(--color-brand-100)] p-8 shadow-[var(--shadow-card)]',

--- a/apps/web/src/features/map/SpainMap.tsx
+++ b/apps/web/src/features/map/SpainMap.tsx
@@ -1,7 +1,16 @@
-import { useCallback, useMemo, useState, type PointerEvent as ReactPointerEvent } from 'react';
+import {
+  useCallback,
+  useMemo,
+  useRef,
+  useState,
+  type PointerEvent as ReactPointerEvent,
+} from 'react';
 import Map, { Marker, NavigationControl } from 'react-map-gl/maplibre';
 import 'maplibre-gl/dist/maplibre-gl.css';
+import gsap from 'gsap';
+import { useGSAP } from '@gsap/react';
 
+import { resolveDuration } from '@/animations';
 import { MapLegend, type MapLegendStop } from './MapLegend';
 import { MapTooltip } from './MapTooltip';
 import type { MapPoint } from '@/data/mock';
@@ -100,6 +109,7 @@ export function SpainMap({
   offline = false,
 }: SpainMapProps) {
   const [hovered, setHovered] = useState<HoveredState | null>(null);
+  const containerRef = useRef<HTMLElement | null>(null);
 
   const legendStops = useMemo(() => buildLegendStops(), []);
 
@@ -111,6 +121,33 @@ export function SpainMap({
         radius: 10 + Math.round((point.score / 100) * 14),
       })),
     [points]
+  );
+
+  /*
+   * Animación de entrada de los marcadores al montar (o cuando cambian los
+   * puntos). Usamos `gsap.from` sobre `.maplibregl-marker` para que cada pin
+   * aparezca con un leve "pop" escalonado. Respeta `prefers-reduced-motion`.
+   */
+  useGSAP(
+    () => {
+      const container = containerRef.current;
+      if (!container) return;
+      const targets = container.querySelectorAll('.maplibregl-marker');
+      if (targets.length === 0) return;
+      gsap.from(targets, {
+        scale: 0,
+        opacity: 0,
+        duration: resolveDuration(0.45),
+        stagger: 0.04,
+        ease: 'back.out(1.5)',
+        transformOrigin: '50% 50%',
+        clearProps: 'transform,opacity',
+      });
+    },
+    {
+      scope: containerRef,
+      dependencies: [markers.length],
+    }
   );
 
   const handleEnter = useCallback(
@@ -142,6 +179,9 @@ export function SpainMap({
 
   return (
     <section
+      ref={(node) => {
+        containerRef.current = node;
+      }}
       data-spain-map
       aria-label={ariaLabel}
       className={[

--- a/apps/web/src/features/recommendations/HighlightCard.tsx
+++ b/apps/web/src/features/recommendations/HighlightCard.tsx
@@ -1,6 +1,7 @@
 import { ArrowUpRight } from 'lucide-react';
 import { useState } from 'react';
 
+import { MotionScale } from '@/components/motion';
 import type { Highlight } from '@/data/mock';
 
 export type HighlightCardProps = {
@@ -48,7 +49,11 @@ function HighlightMedia({ imageSrc, name }: { imageSrc?: string; name: string })
  */
 export function HighlightCard({ highlight, imageSrc, onOpen, className }: HighlightCardProps) {
   return (
-    <article
+    <MotionScale
+      as="article"
+      popOnMount
+      scale={1.01}
+      duration={0.3}
       aria-label={`Recomendación destacada: ${highlight.name}`}
       className={[
         'flex flex-col gap-4 overflow-hidden rounded-2xl bg-white p-4 shadow-[var(--shadow-card)] md:flex-row',
@@ -98,7 +103,7 @@ export function HighlightCard({ highlight, imageSrc, onOpen, className }: Highli
           </button>
         </div>
       </div>
-    </article>
+    </MotionScale>
   );
 }
 

--- a/apps/web/src/features/trends/TrendsChart.tsx
+++ b/apps/web/src/features/trends/TrendsChart.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useMemo, useRef } from 'react';
 import {
   Area,
   AreaChart,
@@ -8,7 +8,10 @@ import {
   XAxis,
   YAxis,
 } from 'recharts';
+import gsap from 'gsap';
+import { useGSAP } from '@gsap/react';
 
+import { resolveDuration } from '@/animations';
 import type { TrendPoint } from '@/data/mock';
 
 export type TrendsChartProps = {
@@ -31,6 +34,40 @@ export function TrendsChart({
   subtitle = 'Score medio de los últimos 12 meses en los territorios seleccionados.',
   className,
 }: TrendsChartProps) {
+  const containerRef = useRef<HTMLElement | null>(null);
+
+  /*
+   * Revelamos el chart de izquierda a derecha con un clip-path inset, en
+   * lugar de depender del plugin DrawSVG (comercial). Como fallback barato
+   * acompaña un fade del bloque contenedor. El efecto se cancela si el
+   * usuario prefiere reducir el movimiento.
+   */
+  useGSAP(
+    () => {
+      const node = containerRef.current;
+      if (!node) return;
+      gsap.from(node, {
+        opacity: 0,
+        duration: resolveDuration(0.5),
+        ease: 'power2.out',
+      });
+      gsap.fromTo(
+        node,
+        { clipPath: 'inset(0 100% 0 0)' },
+        {
+          clipPath: 'inset(0 0% 0 0)',
+          duration: resolveDuration(1.2),
+          ease: 'power3.out',
+          clearProps: 'clipPath',
+        }
+      );
+    },
+    {
+      scope: containerRef,
+      dependencies: [data.length],
+    }
+  );
+
   const domain = useMemo<[number, number]>(() => {
     if (data.length === 0) return [0, 100];
     const values = data.map((point) => point.score);
@@ -41,6 +78,9 @@ export function TrendsChart({
 
   return (
     <section
+      ref={(node) => {
+        containerRef.current = node;
+      }}
       className={['rounded-2xl bg-white p-6 shadow-[var(--shadow-card)]', className ?? '']
         .filter(Boolean)
         .join(' ')}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,7 +1,13 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
+import gsap from 'gsap';
+import { useGSAP } from '@gsap/react';
 import { App } from './App';
 import './styles/globals.css';
+
+// Registro global del plugin oficial de React. Permite que `useGSAP` se
+// integre con el ciclo de vida de los componentes y se limpie solo.
+gsap.registerPlugin(useGSAP);
 
 const container = document.getElementById('root');
 if (!container) {


### PR DESCRIPTION
Integra `gsap` + `@gsap/react`. Añade primitivas `MotionFadeIn`, `MotionStagger`, `MotionScale`, helper `prefers-reduced-motion`, y aplica entradas/microinteracciones en sidebar, topbar, hero, mapa, ranking, ficha, panel SPARQL y action cards. 141 / 141 tests verdes.

Closes #90