### PR TITLE
feat(rdf): ontología ampliada (movilidad, accidentes, transporte) + SPARQL extendido

### DIFF
--- a/apps/api/src/atlashabita/application/use_cases/run_sparql_query.py
+++ b/apps/api/src/atlashabita/application/use_cases/run_sparql_query.py
@@ -54,6 +54,18 @@ class SparqlRunnerProtocol(Protocol):
 
     def count_triples_by_class(self) -> dict[str, int]: ...
 
+    def mobility_flow_between(
+        self, origin_code: str, destination_code: str, period: str
+    ) -> list[dict[str, Any]]: ...
+
+    def accidents_in_radius(
+        self, lat: float, lon: float, km: float, year: int | None = ...
+    ) -> list[dict[str, Any]]: ...
+
+    def transit_stops_in_municipality(self, municipality_code: str) -> list[dict[str, Any]]: ...
+
+    def risk_index(self, municipality_code: str) -> dict[str, Any]: ...
+
 
 @dataclass(frozen=True, slots=True)
 class QuerySignature:
@@ -117,6 +129,39 @@ _SIGNATURES: Final[Mapping[str, QuerySignature]] = {
         ),
         required=("indicator_code",),
     ),
+    "mobility_flow_between": QuerySignature(
+        query_id="mobility_flow_between",
+        description=(
+            "Flujos de movilidad MITMA entre un origen y un destino para un periodo."
+            " Bindings: origin_code, destination_code, period (todos obligatorios)."
+        ),
+        required=("origin_code", "destination_code", "period"),
+    ),
+    "accidents_in_radius": QuerySignature(
+        query_id="accidents_in_radius",
+        description=(
+            "Accidentes DGT cuya geometría puntual cae dentro de ``km`` km del centro."
+            " Bindings: lat, lon, km (obligatorios), year (opcional)."
+        ),
+        required=("lat", "lon", "km"),
+        optional=("year",),
+    ),
+    "transit_stops_in_municipality": QuerySignature(
+        query_id="transit_stops_in_municipality",
+        description=(
+            "Paradas de transporte público (CRTM/GTFS) ubicadas en un municipio."
+            " Bindings: municipality_code (obligatorio)."
+        ),
+        required=("municipality_code",),
+    ),
+    "risk_index": QuerySignature(
+        query_id="risk_index",
+        description=(
+            "Indice compuesto de riesgo movilidad-accidentes para un municipio."
+            " Bindings: municipality_code (obligatorio)."
+        ),
+        required=("municipality_code",),
+    ),
 }
 
 
@@ -170,6 +215,53 @@ def _optional_int(bindings: Mapping[str, Any], name: str, default: int) -> int:
     return raw
 
 
+def _require_number(bindings: Mapping[str, Any], name: str) -> float:
+    """Extrae un número (``int``/``float``) obligatorio para consultas geoespaciales.
+
+    SPARQL geoespacial necesita coordenadas y radios numéricos: este helper
+    centraliza la coerción y emite ``DomainError`` con código estable cuando
+    el cliente envía un tipo inválido (cadenas, booleanos, ``None``).
+    """
+    raw = bindings.get(name)
+    if raw is None:
+        raise DomainError(
+            code=_ERROR_INVALID_BINDINGS,
+            message=f"El binding {name!r} es obligatorio y debe ser numérico.",
+            status_code=400,
+            details={"binding": name},
+        )
+    if isinstance(raw, bool) or not isinstance(raw, int | float):
+        raise DomainError(
+            code=_ERROR_INVALID_BINDINGS,
+            message=f"El binding {name!r} debe ser numérico.",
+            status_code=400,
+            details={"binding": name},
+        )
+    return float(raw)
+
+
+def _optional_year(bindings: Mapping[str, Any], name: str) -> int | None:
+    """Devuelve un año entero válido (1900-2100) o ``None`` si no se pasa."""
+    raw = bindings.get(name)
+    if raw is None:
+        return None
+    if isinstance(raw, bool) or not isinstance(raw, int):
+        raise DomainError(
+            code=_ERROR_INVALID_BINDINGS,
+            message=f"El binding {name!r} debe ser un año entero (1900-2100).",
+            status_code=400,
+            details={"binding": name},
+        )
+    if not 1900 <= raw <= 2100:
+        raise DomainError(
+            code=_ERROR_INVALID_BINDINGS,
+            message=f"El binding {name!r} fuera de rango (1900-2100).",
+            status_code=400,
+            details={"binding": name},
+        )
+    return raw
+
+
 @dataclass(frozen=True, slots=True)
 class SparqlQueryResult:
     """Resultado serializable del caso de uso."""
@@ -196,6 +288,10 @@ class RunSparqlQueryUseCase:
             "sources_used_by_territory": self._sources_used_by_territory,
             "count_triples_by_class": self._count_triples_by_class,
             "indicator_definition": self._indicator_definition,
+            "mobility_flow_between": self._mobility_flow_between,
+            "accidents_in_radius": self._accidents_in_radius,
+            "transit_stops_in_municipality": self._transit_stops_in_municipality,
+            "risk_index": self._risk_index,
         }
 
     @staticmethod
@@ -264,6 +360,35 @@ class RunSparqlQueryUseCase:
         code = _require_str(bindings, "indicator_code")
         definition = self._runner.indicator_definition(code)
         return [definition] if definition else []
+
+    def _mobility_flow_between(self, bindings: Mapping[str, Any]) -> list[dict[str, Any]]:
+        origin_code = _require_str(bindings, "origin_code")
+        destination_code = _require_str(bindings, "destination_code")
+        period = _require_str(bindings, "period")
+        rows = self._runner.mobility_flow_between(origin_code, destination_code, period)
+        return rows[: self._settings.sparql_max_results]
+
+    def _accidents_in_radius(self, bindings: Mapping[str, Any]) -> list[dict[str, Any]]:
+        lat = _require_number(bindings, "lat")
+        lon = _require_number(bindings, "lon")
+        km = _require_number(bindings, "km")
+        year = _optional_year(bindings, "year")
+        rows = self._runner.accidents_in_radius(lat, lon, km, year=year)
+        return rows[: self._settings.sparql_max_results]
+
+    def _transit_stops_in_municipality(self, bindings: Mapping[str, Any]) -> list[dict[str, Any]]:
+        code = _require_str(bindings, "municipality_code")
+        rows = self._runner.transit_stops_in_municipality(code)
+        return rows[: self._settings.sparql_max_results]
+
+    def _risk_index(self, bindings: Mapping[str, Any]) -> list[dict[str, Any]]:
+        code = _require_str(bindings, "municipality_code")
+        # ``risk_index`` devuelve un único dict; el contrato del catálogo es
+        # ``list[dict]`` por homogeneidad, así que envolvemos. Si la consulta
+        # no encuentra municipio, devolvemos lista vacía para que la API HTTP
+        # responda 200 con cuerpo vacío en lugar de error.
+        result = self._runner.risk_index(code)
+        return [result] if result else []
 
 
 __all__ = [

--- a/apps/api/src/atlashabita/infrastructure/rdf/__init__.py
+++ b/apps/api/src/atlashabita/infrastructure/rdf/__init__.py
@@ -29,6 +29,8 @@ from atlashabita.infrastructure.rdf.namespaces import (
     QB,
     SF,
     SKOS,
+    SOSA,
+    SSN,
     bind_all,
 )
 from atlashabita.infrastructure.rdf.serializer import SerializationFormat, serialize, write
@@ -56,6 +58,8 @@ __all__ = [
     "QB",
     "SF",
     "SKOS",
+    "SOSA",
+    "SSN",
     "GraphBuilder",
     "SerializationFormat",
     "ShaclValidator",

--- a/apps/api/src/atlashabita/infrastructure/rdf/graph_builder.py
+++ b/apps/api/src/atlashabita/infrastructure/rdf/graph_builder.py
@@ -23,12 +23,27 @@ Fase B (M8) añade dos bloques semánticos:
   ``ah:IngestionActivity`` que declara ``prov:used`` (fuente) y
   ``prov:wasGeneratedBy`` (observación). Las actividades se deduplican por
   (``source_id``, ``period``) y viven en el named graph ``provenance``.
+
+Milestone M11 incorpora tres nuevos bloques:
+
+* **Movilidad** (``ah:MobilityFlow``): flujos origen-destino MITMA modelados
+  como ``sosa:Observation`` + ``qb:Observation`` con periodo y modo.
+* **Accidentes** (``ah:RoadAccident``): registros DGT con geometría puntual
+  y atributos de severidad.
+* **Transporte público** (``ah:TransitStop`` / ``ah:TransitRoute``): paradas
+  y rutas alineadas con CRTM/GTFS.
+
+Los métodos ``build``/``build_graph`` aceptan colecciones opcionales para
+estos tres bloques. Si la capa de ingesta aún no las ha producido (caso
+habitual mientras TM1 finaliza la generación de los CSV), las colecciones
+quedan vacías y el grafo se compone exclusivamente con los datos previos
+sin romper la build ni la validación SHACL.
 """
 
 from __future__ import annotations
 
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from decimal import Decimal
 from pathlib import Path
 from typing import Final
@@ -50,7 +65,9 @@ from atlashabita.infrastructure.rdf.namespaces import (
     GEO,
     GEO_WGS84,
     PROV,
+    QB,
     SF,
+    SOSA,
     bind_all,
 )
 from atlashabita.infrastructure.rdf.uri_builder import URIBuilder
@@ -64,6 +81,9 @@ GRAPH_PROFILES: Final[str] = "profiles"
 GRAPH_ONTOLOGY: Final[str] = "ontology"
 GRAPH_PROVENANCE: Final[str] = "provenance"
 GRAPH_GEOMETRY: Final[str] = "geometry"
+GRAPH_MOBILITY: Final[str] = "mobility"
+GRAPH_ACCIDENTS: Final[str] = "accidents"
+GRAPH_TRANSIT: Final[str] = "transit"
 
 
 _TERRITORY_CLASS: dict[TerritoryKind, URIRef] = {
@@ -78,6 +98,132 @@ _WKT_LITERAL_DATATYPE = URIRef("http://www.opengis.net/ont/geosparql#wktLiteral"
 _CRS84_URI = "<http://www.opengis.net/def/crs/OGC/1.3/CRS84>"
 
 _YEAR_PATTERN = re.compile(r"^(-?\d{4})$")
+_DATE_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+
+@dataclass(frozen=True, slots=True)
+class MobilityFlowRecord:
+    """Registro origen-destino de movilidad MITMA listo para emitir como RDF.
+
+    No vive en :mod:`domain` porque a fecha del milestone M11 todavía no se
+    consume desde la lógica de scoring. Se mantiene aquí como DTO de la capa
+    de infraestructura, alineado con el resto de helpers de emisión RDF, y
+    se elevará a dominio cuando la aplicación necesite invariantes de
+    negocio sobre los flujos.
+    """
+
+    origin: str
+    """Identificador territorio origen, formato ``kind:code`` (ej: ``municipality:41091``)."""
+
+    destination: str
+    """Identificador territorio destino, formato ``kind:code``."""
+
+    period: str
+    """Periodo MITMA (``2024``, ``2024Q3``, ``2024-07``)."""
+
+    trips: float
+    """Número estimado de desplazamientos en el periodo."""
+
+    source_id: str
+    """Fuente de datos asociada (típicamente ``mitma_om``)."""
+
+    mode: str | None = None
+    """Modo de transporte si el dataset lo desagrega."""
+
+    distance_km: float | None = None
+    """Distancia media estimada en km, si aplica."""
+
+
+@dataclass(frozen=True, slots=True)
+class RoadAccidentRecord:
+    """Registro DGT de un accidente vial.
+
+    El identificador debe ser estable entre ingestas para garantizar
+    idempotencia: si la fuente original no lo provee, la capa de ingesta
+    sintetiza uno determinista a partir de fecha + coordenada + carretera.
+    """
+
+    accident_id: str
+    """Identificador estable del accidente (``ID_ACCIDENTE`` DGT)."""
+
+    date: str
+    """Fecha en formato ``YYYY-MM-DD``."""
+
+    lat: float
+    """Latitud WGS84 del lugar del siniestro."""
+
+    lon: float
+    """Longitud WGS84 del lugar del siniestro."""
+
+    severity: str
+    """Severidad: ``fatal``, ``serious`` o ``slight``."""
+
+    source_id: str
+    """Fuente de datos asociada (típicamente ``dgt_accidentes``)."""
+
+    municipality_code: str | None = None
+    """Código INE 5 dígitos del municipio donde ocurre el accidente."""
+
+    victims: int | None = None
+    fatalities: int | None = None
+    road_type: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class TransitStopRecord:
+    """Parada de transporte público (CRTM/GTFS)."""
+
+    operator: str
+    stop_id: str
+    name: str
+    lat: float
+    lon: float
+    source_id: str
+    code: str | None = None
+    municipality_code: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class TransitRouteRecord:
+    """Ruta o línea de transporte público (CRTM/GTFS)."""
+
+    operator: str
+    route_id: str
+    short_name: str
+    long_name: str
+    mode: str
+    source_id: str
+    stop_ids: tuple[str, ...] = field(default_factory=tuple)
+    """Identificadores de las paradas (sin prefijo de operador) que sirve la ruta."""
+
+
+@dataclass(frozen=True, slots=True)
+class MobilityDataset:
+    """Colección agregada de los nuevos datasets M11.
+
+    Se diseña como contenedor explícito para que ``GraphBuilder.build`` reciba
+    un único parámetro opcional sin saturar la firma. Todas las colecciones
+    son tuplas vacías por defecto, garantizando que la build no rompe cuando
+    los CSV de TM1 aún no estén versionados.
+    """
+
+    flows: tuple[MobilityFlowRecord, ...] = field(default_factory=tuple)
+    accidents: tuple[RoadAccidentRecord, ...] = field(default_factory=tuple)
+    transit_stops: tuple[TransitStopRecord, ...] = field(default_factory=tuple)
+    transit_routes: tuple[TransitRouteRecord, ...] = field(default_factory=tuple)
+
+    @property
+    def is_empty(self) -> bool:
+        """Indica si no hay ningún registro nuevo cargado.
+
+        Útil para que las pruebas decidan si activar las verificaciones
+        avanzadas (cuando el seed extendido ya existe) o limitarse a los
+        casos básicos.
+        """
+        return not (self.flows or self.accidents or self.transit_stops or self.transit_routes)
+
+
+_EMPTY_MOBILITY: Final[MobilityDataset] = MobilityDataset()
 
 
 @dataclass(frozen=True, slots=True)
@@ -92,7 +238,13 @@ class GraphBuilder:
 
     uri_builder: URIBuilder
 
-    def build(self, dataset: SeedDataset, *, ontology_path: Path | None = None) -> Dataset:
+    def build(
+        self,
+        dataset: SeedDataset,
+        *,
+        ontology_path: Path | None = None,
+        mobility: MobilityDataset | None = None,
+    ) -> Dataset:
         """Crea un ``Dataset`` con named graphs por dominio.
 
         Parameters
@@ -104,9 +256,16 @@ class GraphBuilder:
             importa en el named graph ``ontology`` para que SPARQL pueda
             resolver etiquetas/domain/range contra el TBox sin dependencias
             externas.
+        mobility:
+            Colección opcional con los registros M11 (movilidad MITMA,
+            accidentes DGT, paradas y rutas CRTM). Cuando es ``None`` o
+            está vacía la build no añade tripletas adicionales y los named
+            graphs ``mobility``/``accidents``/``transit`` permanecen vacíos.
         """
         ds = Dataset()
         bind_all(ds)
+
+        mobility_data = mobility or _EMPTY_MOBILITY
 
         territories_graph = ds.graph(self.uri_builder.named_graph(GRAPH_TERRITORIES))
         indicators_graph = ds.graph(self.uri_builder.named_graph(GRAPH_INDICATORS))
@@ -115,6 +274,9 @@ class GraphBuilder:
         profiles_graph = ds.graph(self.uri_builder.named_graph(GRAPH_PROFILES))
         provenance_graph = ds.graph(self.uri_builder.named_graph(GRAPH_PROVENANCE))
         geometry_graph = ds.graph(self.uri_builder.named_graph(GRAPH_GEOMETRY))
+        mobility_graph = ds.graph(self.uri_builder.named_graph(GRAPH_MOBILITY))
+        accidents_graph = ds.graph(self.uri_builder.named_graph(GRAPH_ACCIDENTS))
+        transit_graph = ds.graph(self.uri_builder.named_graph(GRAPH_TRANSIT))
 
         for graph in (
             territories_graph,
@@ -124,6 +286,9 @@ class GraphBuilder:
             profiles_graph,
             provenance_graph,
             geometry_graph,
+            mobility_graph,
+            accidents_graph,
+            transit_graph,
         ):
             bind_all(graph)
 
@@ -141,6 +306,15 @@ class GraphBuilder:
         for profile in dataset.profiles:
             self._emit_profile(profiles_graph, profile)
 
+        for flow in mobility_data.flows:
+            self._emit_mobility_flow(mobility_graph, flow)
+        for accident in mobility_data.accidents:
+            self._emit_road_accident(accidents_graph, geometry_graph, accident)
+        for stop in mobility_data.transit_stops:
+            self._emit_transit_stop(transit_graph, geometry_graph, stop)
+        for route in mobility_data.transit_routes:
+            self._emit_transit_route(transit_graph, route)
+
         if ontology_path is not None and ontology_path.exists():
             ontology_graph = ds.graph(self.uri_builder.named_graph(GRAPH_ONTOLOGY))
             bind_all(ontology_graph)
@@ -148,16 +322,28 @@ class GraphBuilder:
 
         return ds
 
-    def build_graph(self, dataset: SeedDataset, *, ontology_path: Path | None = None) -> Graph:
+    def build_graph(
+        self,
+        dataset: SeedDataset,
+        *,
+        ontology_path: Path | None = None,
+        mobility: MobilityDataset | None = None,
+    ) -> Graph:
         """Construye un ``Graph`` único con todas las tripletas.
 
         Útil en la MVP para ejecutar SPARQL sin preocuparnos por el grafo
         por defecto frente a los named graphs. El orden de inserción es
         irrelevante semánticamente pero se mantiene estable para producir
         serializaciones reproducibles.
+
+        El parámetro opcional ``mobility`` mantiene la simetría con
+        :meth:`build`: cuando se pasa, se emiten las tripletas M11 en el
+        mismo grafo plano; cuando es ``None`` el comportamiento es idéntico
+        al de la fase B.
         """
         graph = Graph()
         bind_all(graph)
+        mobility_data = mobility or _EMPTY_MOBILITY
 
         for territory in dataset.territories:
             self._emit_territory(graph, territory)
@@ -172,6 +358,15 @@ class GraphBuilder:
             self._emit_provenance(graph, graph, observation, activities)
         for profile in dataset.profiles:
             self._emit_profile(graph, profile)
+
+        for flow in mobility_data.flows:
+            self._emit_mobility_flow(graph, flow)
+        for accident in mobility_data.accidents:
+            self._emit_road_accident(graph, graph, accident)
+        for stop in mobility_data.transit_stops:
+            self._emit_transit_stop(graph, graph, stop)
+        for route in mobility_data.transit_routes:
+            self._emit_transit_route(graph, route)
 
         if ontology_path is not None and ontology_path.exists():
             graph.parse(ontology_path, format="turtle")
@@ -346,6 +541,202 @@ class GraphBuilder:
         # shape (``sh:maxCount 1`` sobre ``prov:wasGeneratedBy``) la vea.
         obs_graph.add((observation_uri, PROV.wasGeneratedBy, activity_uri))
 
+    def _emit_mobility_flow(self, graph: Graph, flow: MobilityFlowRecord) -> None:
+        """Proyecta un flujo MITMA como ``ah:MobilityFlow``.
+
+        El flujo se modela como ``sosa:Observation`` y ``qb:Observation``
+        para reaprovechar herramientas estándar:
+
+        * ``sosa:hasFeatureOfInterest`` apunta al territorio origen,
+          consistente con la subPropertyOf declarada en la ontología sobre
+          ``ah:flowOrigin``.
+        * ``ah:flowDestination`` se mantiene como propiedad propia porque
+          SOSA no expone una "feature de destino" canónica.
+        * ``ah:flowTrips`` se reutiliza como ``sosa:hasSimpleResult``.
+        """
+        origin_uri = self._territory_uri_from_id(flow.origin)
+        destination_uri = self._territory_uri_from_id(flow.destination)
+        if origin_uri is None or destination_uri is None:
+            # Se ignoran flujos cuyos territorios no se puedan resolver: el
+            # SHACL fallaría igualmente y preferimos no emitir tripletas
+            # huérfanas que dificulten el debugging.
+            return
+        origin_code = flow.origin.split(":", maxsplit=1)[1]
+        destination_code = flow.destination.split(":", maxsplit=1)[1]
+        subject = self.uri_builder.flow(origin_code, destination_code, flow.period, flow.mode)
+        graph.add((subject, RDF.type, AH.MobilityFlow))
+        graph.add((subject, RDF.type, SOSA.Observation))
+        graph.add((subject, RDF.type, QB.Observation))
+        graph.add((subject, RDF.type, PROV.Entity))
+        graph.add((subject, AH.flowOrigin, origin_uri))
+        graph.add((subject, SOSA.hasFeatureOfInterest, origin_uri))
+        graph.add((subject, AH.flowDestination, destination_uri))
+        graph.add((subject, AH.flowTrips, _decimal_literal(flow.trips)))
+        graph.add((subject, SOSA.hasSimpleResult, _decimal_literal(flow.trips)))
+        graph.add((subject, AH.period, Literal(flow.period, datatype=XSD.string)))
+        if _YEAR_PATTERN.match(flow.period):
+            graph.add((subject, AH.periodYear, Literal(flow.period, datatype=XSD.gYear)))
+        if flow.mode:
+            graph.add((subject, AH.flowMode, Literal(flow.mode, datatype=XSD.string)))
+        if flow.distance_km is not None:
+            graph.add((subject, AH.flowDistanceKm, _decimal_literal(flow.distance_km)))
+        if flow.source_id:
+            graph.add((subject, AH.providedBy, self.uri_builder.source(flow.source_id)))
+
+    def _emit_road_accident(
+        self,
+        graph: Graph,
+        geometry_graph: Graph,
+        accident: RoadAccidentRecord,
+    ) -> None:
+        """Proyecta un accidente DGT con su geometría puntual.
+
+        ``graph`` y ``geometry_graph`` pueden coincidir (caso ``build_graph``)
+        o ser distintos (caso ``build`` con named graphs). La separación
+        permite mantener todas las geometrías en su propio bucket reutilizando
+        el mismo diseño que para los territorios.
+        """
+        subject = self.uri_builder.accident(accident.accident_id)
+        graph.add((subject, RDF.type, AH.RoadAccident))
+        graph.add((subject, RDF.type, GEO.Feature))
+        graph.add((subject, RDF.type, PROV.Entity))
+        graph.add(
+            (
+                subject,
+                DCT.identifier,
+                Literal(accident.accident_id, datatype=XSD.string),
+            )
+        )
+        graph.add((subject, AH.accidentDate, Literal(accident.date, datatype=XSD.date)))
+        # ``ah:accidentSeverity`` se emite como literal plano para que la
+        # restricción SHACL ``sh:in`` (que compara estructuralmente) acepte
+        # el valor. Misma lógica que ``ah:direction``.
+        graph.add((subject, AH.accidentSeverity, Literal(accident.severity)))
+        if _DATE_PATTERN.match(accident.date):
+            year = accident.date.split("-", 1)[0]
+            graph.add((subject, AH.accidentYear, Literal(year, datatype=XSD.gYear)))
+        graph.add((subject, GEO_WGS84.lat, _decimal_literal(accident.lat)))
+        graph.add((subject, GEO_WGS84.long, _decimal_literal(accident.lon)))
+        if accident.victims is not None:
+            graph.add(
+                (
+                    subject,
+                    AH.accidentVictims,
+                    Literal(accident.victims, datatype=XSD.integer),
+                )
+            )
+        if accident.fatalities is not None:
+            graph.add(
+                (
+                    subject,
+                    AH.accidentFatalities,
+                    Literal(accident.fatalities, datatype=XSD.integer),
+                )
+            )
+        if accident.road_type:
+            graph.add(
+                (
+                    subject,
+                    AH.accidentRoadType,
+                    Literal(accident.road_type, datatype=XSD.string),
+                )
+            )
+        if accident.municipality_code:
+            municipality_uri = self.uri_builder.territory(
+                accident.municipality_code, TerritoryKind.MUNICIPALITY
+            )
+            graph.add((subject, AH.occursIn, municipality_uri))
+        if accident.source_id:
+            graph.add((subject, AH.providedBy, self.uri_builder.source(accident.source_id)))
+
+        # Geometría puntual (CRS84) reutilizando la misma URI que territorios:
+        # ``/resource/geometry/accident/<id>`` para no colisionar.
+        geometry_uri = self.uri_builder.accident_geometry(accident.accident_id)
+        graph.add((subject, AH.hasGeometry, geometry_uri))
+        graph.add((subject, GEO.hasGeometry, geometry_uri))
+        geometry_graph.add((geometry_uri, RDF.type, GEO.Geometry))
+        geometry_graph.add((geometry_uri, RDF.type, GEO.Point))
+        geometry_graph.add((geometry_uri, RDF.type, SF.Point))
+        wkt_literal = Literal(
+            _point_wkt(GeoPoint(lat=accident.lat, lon=accident.lon)),
+            datatype=_WKT_LITERAL_DATATYPE,
+        )
+        geometry_graph.add((geometry_uri, GEO.asWKT, wkt_literal))
+        geometry_graph.add((geometry_uri, AH.wktLiteral, wkt_literal))
+
+    def _emit_transit_stop(
+        self,
+        graph: Graph,
+        geometry_graph: Graph,
+        stop: TransitStopRecord,
+    ) -> None:
+        """Proyecta una parada de transporte con su geometría puntual."""
+        subject = self.uri_builder.transit_stop(stop.operator, stop.stop_id)
+        graph.add((subject, RDF.type, AH.TransitStop))
+        graph.add((subject, RDF.type, GEO.Feature))
+        graph.add(
+            (
+                subject,
+                DCT.identifier,
+                Literal(f"{stop.operator}:{stop.stop_id}", datatype=XSD.string),
+            )
+        )
+        graph.add((subject, RDFS.label, Literal(stop.name, lang="es")))
+        graph.add((subject, AH.stopName, Literal(stop.name, datatype=XSD.string)))
+        if stop.code:
+            graph.add((subject, AH.stopCode, Literal(stop.code, datatype=XSD.string)))
+        graph.add((subject, AH.operator, Literal(stop.operator, datatype=XSD.string)))
+        graph.add((subject, GEO_WGS84.lat, _decimal_literal(stop.lat)))
+        graph.add((subject, GEO_WGS84.long, _decimal_literal(stop.lon)))
+        if stop.municipality_code:
+            graph.add(
+                (
+                    subject,
+                    AH.locatedIn,
+                    self.uri_builder.territory(stop.municipality_code, TerritoryKind.MUNICIPALITY),
+                )
+            )
+        if stop.source_id:
+            graph.add((subject, AH.providedBy, self.uri_builder.source(stop.source_id)))
+
+        geometry_uri = self.uri_builder.transit_stop_geometry(stop.operator, stop.stop_id)
+        graph.add((subject, AH.hasGeometry, geometry_uri))
+        graph.add((subject, GEO.hasGeometry, geometry_uri))
+        geometry_graph.add((geometry_uri, RDF.type, GEO.Geometry))
+        geometry_graph.add((geometry_uri, RDF.type, GEO.Point))
+        geometry_graph.add((geometry_uri, RDF.type, SF.Point))
+        wkt_literal = Literal(
+            _point_wkt(GeoPoint(lat=stop.lat, lon=stop.lon)),
+            datatype=_WKT_LITERAL_DATATYPE,
+        )
+        geometry_graph.add((geometry_uri, GEO.asWKT, wkt_literal))
+        geometry_graph.add((geometry_uri, AH.wktLiteral, wkt_literal))
+
+    def _emit_transit_route(self, graph: Graph, route: TransitRouteRecord) -> None:
+        """Proyecta una ruta de transporte y su relación con paradas."""
+        subject = self.uri_builder.transit_route(route.operator, route.route_id)
+        graph.add((subject, RDF.type, AH.TransitRoute))
+        graph.add(
+            (
+                subject,
+                DCT.identifier,
+                Literal(f"{route.operator}:{route.route_id}", datatype=XSD.string),
+            )
+        )
+        graph.add((subject, RDFS.label, Literal(route.long_name or route.short_name, lang="es")))
+        if route.short_name:
+            graph.add((subject, AH.routeShortName, Literal(route.short_name, datatype=XSD.string)))
+        if route.long_name:
+            graph.add((subject, AH.routeLongName, Literal(route.long_name, datatype=XSD.string)))
+        # Plain literal (sin datatype) para alinearse con ``sh:in`` de la shape.
+        graph.add((subject, AH.transitMode, Literal(route.mode)))
+        graph.add((subject, AH.operator, Literal(route.operator, datatype=XSD.string)))
+        if route.source_id:
+            graph.add((subject, AH.providedBy, self.uri_builder.source(route.source_id)))
+        for stop_id in route.stop_ids:
+            stop_uri = self.uri_builder.transit_stop(route.operator, stop_id)
+            graph.add((subject, AH.servesStop, stop_uri))
+
     def _emit_profile(self, graph: Graph, profile: DecisionProfile) -> None:
         """Proyecta un perfil de decisión y sus pesos como contribuciones base.
 
@@ -406,13 +797,21 @@ def _point_wkt(point: GeoPoint) -> str:
 
 
 __all__ = [
+    "GRAPH_ACCIDENTS",
     "GRAPH_GEOMETRY",
     "GRAPH_INDICATORS",
+    "GRAPH_MOBILITY",
     "GRAPH_OBSERVATIONS",
     "GRAPH_ONTOLOGY",
     "GRAPH_PROFILES",
     "GRAPH_PROVENANCE",
     "GRAPH_SOURCES",
     "GRAPH_TERRITORIES",
+    "GRAPH_TRANSIT",
     "GraphBuilder",
+    "MobilityDataset",
+    "MobilityFlowRecord",
+    "RoadAccidentRecord",
+    "TransitRouteRecord",
+    "TransitStopRecord",
 ]

--- a/apps/api/src/atlashabita/infrastructure/rdf/namespaces.py
+++ b/apps/api/src/atlashabita/infrastructure/rdf/namespaces.py
@@ -21,6 +21,17 @@ GeoSPARQL (``GEO``) es intencional: mantenemos las propiedades ``geo:lat`` /
 ``geo:long`` históricas y añadimos ``geo:hasGeometry`` / ``geo:asWKT`` de
 GeoSPARQL para que consultas espaciales (distancia, buffer, within) sean
 posibles con herramientas compatibles con OGC.
+
+El milestone M11 incorpora los vocabularios **SOSA/SSN** y **QB**:
+
+* :data:`SOSA` modela las observaciones sensoriales/encuestadas (``sosa:Observation``,
+  ``sosa:hasFeatureOfInterest``, ``sosa:hasSimpleResult``). Las clases
+  ``ah:MobilityFlow`` se modelan como ``sosa:Observation`` con la pareja
+  origen-destino como *feature of interest*.
+* :data:`SSN` extiende SOSA con sistemas y procedimientos.
+* :data:`QB` (Data Cube) permite tratar los flujos como observaciones
+  multidimensionales (origen, destino, periodo, modo) reutilizables con las
+  herramientas estándar del RDF Data Cube Vocabulary.
 """
 
 from __future__ import annotations
@@ -68,8 +79,20 @@ GEO_WGS84 = Namespace("http://www.w3.org/2003/01/geo/wgs84_pos#")
 #: PROV-O para procedencia (fuente, ingesta, atribuciones).
 PROV = RDFLIB_PROV
 
-#: Data Cube Vocabulary (reservado por si se modelan observaciones multidim).
+#: Data Cube Vocabulary para observaciones multidimensionales (flujos de
+#: movilidad MITMA: origen, destino, periodo, modo). Se usa explícitamente
+#: en el milestone M11 al declarar ``ah:MobilityFlow`` como
+#: ``qb:Observation``.
 QB = Namespace("http://purl.org/linked-data/cube#")
+
+#: Sensor, Observation, Sample, Actuator (W3C). Se aplica a flujos de
+#: movilidad MITMA (``sosa:Observation``) y deja preparado el grafo para
+#: integrar futuros sensores territoriales (calidad del aire, ruido).
+SOSA = Namespace("http://www.w3.org/ns/sosa/")
+
+#: Semantic Sensor Network (W3C). Capa superior sobre SOSA para representar
+#: sistemas, procedimientos y propiedades observables de mayor complejidad.
+SSN = Namespace("http://www.w3.org/ns/ssn/")
 
 
 def bind_all(graph: Graph | Dataset) -> None:
@@ -91,6 +114,8 @@ def bind_all(graph: Graph | Dataset) -> None:
     graph.bind("wgs84", GEO_WGS84, override=True)
     graph.bind("prov", PROV, override=True)
     graph.bind("qb", QB, override=True)
+    graph.bind("sosa", SOSA, override=True)
+    graph.bind("ssn", SSN, override=True)
 
 
 __all__ = [
@@ -105,5 +130,7 @@ __all__ = [
     "QB",
     "SF",
     "SKOS",
+    "SOSA",
+    "SSN",
     "bind_all",
 ]

--- a/apps/api/src/atlashabita/infrastructure/rdf/sparql_queries.py
+++ b/apps/api/src/atlashabita/infrastructure/rdf/sparql_queries.py
@@ -543,6 +543,239 @@ class SparqlRunner:
             "quality": str(row["quality"]),
         }
 
+    def mobility_flow_between(
+        self,
+        origin_code: str,
+        destination_code: str,
+        period: str,
+    ) -> list[dict[str, Any]]:
+        """Devuelve los flujos de movilidad MITMA entre dos territorios.
+
+        Se aceptan distintos modos cuando el dataset los desagrega: la
+        consulta no filtra por modo y la lista resultante puede contener
+        varias filas (una por modo). El periodo se valida estrictamente para
+        evitar interpolación maliciosa.
+        """
+        _require_safe_identifier(origin_code, field="origin_code")
+        _require_safe_identifier(destination_code, field="destination_code")
+        _require_safe_period(period)
+        # Aceptamos cualquier kind administrativo; la consulta filtra por
+        # ``dct:identifier`` con el código provisto y delega la disambiguación
+        # al grafo (origen/destino son territorios cualquiera). Comparamos
+        # los literales con ``STR`` para ser robustos frente a tipados
+        # mixtos (xsd:string vs literal plano).
+        query = f"""
+        PREFIX ah: <{AH}>
+        PREFIX dct: <{DCT}>
+        PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+        SELECT ?flow ?origin ?destination ?trips ?mode ?distance ?period
+        WHERE {{
+          ?flow a ah:MobilityFlow ;
+                ah:flowOrigin ?origin ;
+                ah:flowDestination ?destination ;
+                ah:flowTrips ?trips ;
+                ah:period ?period .
+          ?origin dct:identifier ?origin_code .
+          ?destination dct:identifier ?destination_code .
+          FILTER(STR(?period) = "{period}")
+          FILTER(STR(?origin_code) = "{origin_code}")
+          FILTER(STR(?destination_code) = "{destination_code}")
+          OPTIONAL {{ ?flow ah:flowMode ?mode . }}
+          OPTIONAL {{ ?flow ah:flowDistanceKm ?distance . }}
+        }}
+        ORDER BY DESC(?trips)
+        """
+        rows = self._execute(query)
+        results: list[dict[str, Any]] = []
+        for row in rows:
+            results.append(
+                {
+                    "flow": str(row["flow"]),
+                    "origin": str(row["origin"]),
+                    "destination": str(row["destination"]),
+                    "trips": float(str(row["trips"])),
+                    "mode": str(row["mode"]) if row.get("mode") is not None else None,
+                    "distance_km": float(str(row["distance"]))
+                    if row.get("distance") is not None
+                    else None,
+                    "period": str(row["period"]) if row.get("period") is not None else period,
+                }
+            )
+        return results[: self.settings.sparql_max_results]
+
+    def accidents_in_radius(
+        self,
+        lat: float,
+        lon: float,
+        km: float,
+        year: int | None = None,
+    ) -> list[dict[str, Any]]:
+        """Accidentes DGT cuya geometría puntual cae dentro del radio dado.
+
+        Igual que :meth:`territories_within_radius`, se computa Haversine en
+        Python para no depender de extensiones GeoSPARQL. ``year`` es opcional;
+        cuando se pasa, se filtra por ``ah:accidentYear`` (xsd:gYear) en la
+        propia consulta SPARQL.
+        """
+        _require_coordinate(lat, minimum=-90.0, maximum=90.0, field="lat")
+        _require_coordinate(lon, minimum=-180.0, maximum=180.0, field="lon")
+        _require_radius_km(km)
+        year_filter = ""
+        if year is not None:
+            if not isinstance(year, int) or isinstance(year, bool):
+                raise ValueError(f"year debe ser entero: {year!r}")
+            if not 1900 <= year <= 2100:
+                raise ValueError(f"year fuera de rango razonable: {year}")
+            # Comparar año con ``STR`` blinda contra mixto de gYear/xsd:string
+            # cuando rdflib emite literales con datatype específico.
+            year_filter = f'  ?accident ah:accidentYear ?year .\n  FILTER(STR(?year) = "{year}")'
+
+        query = f"""
+        PREFIX ah: <{AH}>
+        PREFIX wgs84: <{GEO_WGS84}>
+        PREFIX dct: <{DCT}>
+        PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+        SELECT ?accident ?id ?lat ?lon ?severity ?date
+        WHERE {{
+          ?accident a ah:RoadAccident ;
+                    dct:identifier ?id ;
+                    wgs84:lat ?lat ;
+                    wgs84:long ?lon ;
+                    ah:accidentSeverity ?severity ;
+                    ah:accidentDate ?date .
+        {year_filter}
+        }}
+        """
+        rows = self._execute(query)
+        results: list[dict[str, Any]] = []
+        for row in rows:
+            try:
+                row_lat = float(str(row["lat"]))
+                row_lon = float(str(row["lon"]))
+            except (TypeError, ValueError):
+                continue
+            distance_km = _haversine_km(lat, lon, row_lat, row_lon)
+            if distance_km <= km:
+                results.append(
+                    {
+                        "accident": str(row["accident"]),
+                        "id": str(row["id"]),
+                        "lat": row_lat,
+                        "lon": row_lon,
+                        "severity": str(row["severity"]),
+                        "date": str(row["date"]),
+                        "distance_km": round(distance_km, 3),
+                    }
+                )
+        results.sort(key=lambda item: float(item["distance_km"]))
+        return results[: self.settings.sparql_max_results]
+
+    def transit_stops_in_municipality(self, municipality_code: str) -> list[dict[str, Any]]:
+        """Paradas de transporte CRTM ubicadas en un municipio.
+
+        Se confía en la propiedad ``ah:locatedIn`` cuando el dataset la
+        provee; cuando no exista (paradas sin asignar), no se devuelven en
+        esta consulta para mantener la respuesta determinista.
+        """
+        _require_safe_identifier(municipality_code, field="municipality_code")
+        municipality_uri = URIRef(f"{AHR}territory/municipality/{municipality_code}")
+        query = f"""
+        PREFIX ah: <{AH}>
+        PREFIX wgs84: <{GEO_WGS84}>
+        PREFIX dct: <{DCT}>
+        PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+        SELECT ?stop ?id ?label ?lat ?lon ?operator ?code
+        WHERE {{
+          ?stop a ah:TransitStop ;
+                dct:identifier ?id ;
+                rdfs:label ?label ;
+                wgs84:lat ?lat ;
+                wgs84:long ?lon ;
+                ah:operator ?operator ;
+                ah:locatedIn <{municipality_uri}> .
+          OPTIONAL {{ ?stop ah:stopCode ?code . }}
+        }}
+        ORDER BY ?label
+        """
+        rows = self._execute(query)
+        return [
+            {
+                "stop": str(row["stop"]),
+                "id": str(row["id"]),
+                "label": str(row["label"]),
+                "lat": float(str(row["lat"])),
+                "lon": float(str(row["lon"])),
+                "operator": str(row["operator"]),
+                "code": str(row["code"]) if row.get("code") is not None else None,
+            }
+            for row in rows
+        ]
+
+    def risk_index(self, municipality_code: str) -> dict[str, Any]:
+        """Indice compuesto de riesgo movilidad-accidentes para un municipio.
+
+        Combina dos señales sencillas y trazables:
+
+        * **Total de accidentes** registrados en el municipio (``ah:occursIn``).
+        * **Total de viajes salientes** desde el municipio (``ah:flowOrigin``).
+
+        El indice ``risk_per_1000_trips`` es accidentes / max(1, viajes/1000),
+        una aproximación robusta cuando no hay datos: si no hay flujos, el
+        denominador es 1 y el indice queda en accidentes absolutos. Es una
+        primera iteración que el motor de scoring podrá refinar.
+        """
+        _require_safe_identifier(municipality_code, field="municipality_code")
+        municipality_uri = URIRef(f"{AHR}territory/municipality/{municipality_code}")
+
+        accidents_query = f"""
+        PREFIX ah: <{AH}>
+
+        SELECT (COUNT(?accident) AS ?total)
+               (SUM(?fatalities) AS ?fatalities)
+               (SUM(?victims) AS ?victims)
+        WHERE {{
+          ?accident a ah:RoadAccident ;
+                    ah:occursIn <{municipality_uri}> .
+          OPTIONAL {{ ?accident ah:accidentFatalities ?fatalities . }}
+          OPTIONAL {{ ?accident ah:accidentVictims ?victims . }}
+        }}
+        """
+
+        flows_query = f"""
+        PREFIX ah: <{AH}>
+
+        SELECT (COUNT(?flow) AS ?flows) (SUM(?trips) AS ?trips)
+        WHERE {{
+          ?flow a ah:MobilityFlow ;
+                ah:flowOrigin <{municipality_uri}> ;
+                ah:flowTrips ?trips .
+        }}
+        """
+
+        accidents_rows = self._execute(accidents_query)
+        flows_rows = self._execute(flows_query)
+        accidents_total = _safe_int(accidents_rows[0].get("total")) if accidents_rows else 0
+        fatalities_total = _safe_int(accidents_rows[0].get("fatalities")) if accidents_rows else 0
+        victims_total = _safe_int(accidents_rows[0].get("victims")) if accidents_rows else 0
+        flows_total = _safe_int(flows_rows[0].get("flows")) if flows_rows else 0
+        trips_total = _safe_float(flows_rows[0].get("trips")) if flows_rows else 0.0
+
+        denominator = max(1.0, trips_total / 1000.0)
+        risk_per_1000_trips = round(accidents_total / denominator, 4)
+        return {
+            "municipality": str(municipality_uri),
+            "code": municipality_code,
+            "accidents": accidents_total,
+            "fatalities": fatalities_total,
+            "victims": victims_total,
+            "outbound_flows": flows_total,
+            "outbound_trips": trips_total,
+            "risk_per_1000_trips": risk_per_1000_trips,
+        }
+
     def count_triples_by_class(self) -> dict[str, int]:
         """Cuenta instancias por clase RDF.
 
@@ -701,6 +934,31 @@ def _haversine_km(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
     )
     c = 2.0 * math.atan2(math.sqrt(a), math.sqrt(1.0 - a))
     return earth_radius_km * c
+
+
+def _safe_int(value: Any) -> int:
+    """Coerciona un valor SPARQL a entero, devolviendo 0 cuando no aplique.
+
+    Las agregaciones ``COUNT``/``SUM`` devuelven ``Literal`` con datatypes
+    que rdflib no siempre castea de forma transparente. Esta función blinda
+    la conversión sin propagar excepciones a la capa SPARQL.
+    """
+    if value is None:
+        return 0
+    try:
+        return int(float(str(value)))
+    except (TypeError, ValueError):
+        return 0
+
+
+def _safe_float(value: Any) -> float:
+    """Coerciona un valor SPARQL a ``float`` con fallback a 0.0."""
+    if value is None:
+        return 0.0
+    try:
+        return float(str(value))
+    except (TypeError, ValueError):
+        return 0.0
 
 
 def _normalize(value: float, direction: str) -> float:

--- a/apps/api/src/atlashabita/infrastructure/rdf/uri_builder.py
+++ b/apps/api/src/atlashabita/infrastructure/rdf/uri_builder.py
@@ -20,6 +20,20 @@ Fase B (M8) añade dos nuevos tipos de recurso:
 * **Actividades PROV-O de ingesta** (``/resource/activity/<source>/<period>``)
   identificadas por la tupla fuente+periodo, de forma que una misma ingesta
   se deduplica y sus observaciones apuntan a una sola URI.
+
+Milestone M11 incorpora cuatro tipos adicionales para los datasets MITMA,
+DGT y CRTM/GTFS:
+
+* **Flujos de movilidad** (``/resource/flow/<origin>/<destination>/<period>[/<mode>]``)
+  con identidad determinista por origen, destino y periodo. Cuando el
+  registro original distingue por modo de transporte, se incluye como
+  cuarto segmento para evitar colisiones.
+* **Accidentes viales** (``/resource/accident/<id>``) donde ``<id>`` es el
+  identificador estable proporcionado por la DGT.
+* **Paradas de transporte** (``/resource/transit_stop/<operator>/<stop_id>``)
+  alineado con la convención GTFS ``agency_id + stop_id``.
+* **Rutas de transporte** (``/resource/transit_route/<operator>/<route_id>``)
+  alineado con GTFS ``agency_id + route_id``.
 """
 
 from __future__ import annotations
@@ -153,6 +167,82 @@ class URIBuilder:
         """URI del named graph de un dominio (territories, observations...)."""
         self._require_non_empty(domain, "domain")
         return URIRef(f"{self.graph_base}{_safe(domain)}")
+
+    def flow(
+        self,
+        origin_code: str,
+        destination_code: str,
+        period: str,
+        mode: str | None = None,
+    ) -> URIRef:
+        """URI determinista de un flujo de movilidad MITMA.
+
+        Se elige la tupla ``(origen, destino, periodo[, modo])`` como clave
+        natural porque MITMA agrega los desplazamientos por origen/destino
+        municipal y por periodo (mes/trimestre/año). Cuando el dataset
+        diferencia el modo (coche, transporte público...) se incluye como
+        cuarto segmento para evitar colisiones entre filas que comparten
+        origen-destino-periodo.
+        """
+        self._require_non_empty(origin_code, "origin_code")
+        self._require_non_empty(destination_code, "destination_code")
+        self._require_non_empty(period, "period")
+        base = (
+            f"{self.resource_base}flow/"
+            f"{_safe(origin_code)}/{_safe(destination_code)}/{_safe(period)}"
+        )
+        if mode is None or not mode.strip():
+            return URIRef(base)
+        return URIRef(f"{base}/{_safe(mode)}")
+
+    def accident(self, accident_id: str) -> URIRef:
+        """URI de un accidente vial DGT.
+
+        ``accident_id`` debe ser el identificador estable que la DGT publica
+        en sus microdatos (``ID_ACCIDENTE``). Si la fuente no proporciona
+        identificador, la capa de ingesta debe sintetizar uno determinista a
+        partir de fecha + coordenada + carretera para garantizar idempotencia.
+        """
+        self._require_non_empty(accident_id, "accident_id")
+        return URIRef(f"{self.resource_base}accident/{_safe(accident_id)}")
+
+    def transit_stop(self, operator: str, stop_id: str) -> URIRef:
+        """URI de una parada de transporte GTFS/CRTM.
+
+        Se usa la convención ``agency_id + stop_id`` para evitar colisiones
+        entre operadores cuando se federen distintos GTFS (CRTM, EMT,
+        Cercanías, Metro). El operador siempre forma parte de la URI.
+        """
+        self._require_non_empty(operator, "operator")
+        self._require_non_empty(stop_id, "stop_id")
+        return URIRef(f"{self.resource_base}transit_stop/{_safe(operator)}/{_safe(stop_id)}")
+
+    def transit_route(self, operator: str, route_id: str) -> URIRef:
+        """URI de una ruta de transporte GTFS/CRTM.
+
+        Idéntica política a :meth:`transit_stop`: ``agency_id + route_id``
+        garantiza unicidad cuando coexisten varias agencias en el grafo.
+        """
+        self._require_non_empty(operator, "operator")
+        self._require_non_empty(route_id, "route_id")
+        return URIRef(f"{self.resource_base}transit_route/{_safe(operator)}/{_safe(route_id)}")
+
+    def accident_geometry(self, accident_id: str) -> URIRef:
+        """URI de la geometría puntual asociada a un accidente DGT.
+
+        Se mantiene la misma política de slug/quote que el resto de URIs
+        para producir IRIs deterministas y URL-safe.
+        """
+        self._require_non_empty(accident_id, "accident_id")
+        return URIRef(f"{self.resource_base}geometry/accident/{_safe(accident_id)}")
+
+    def transit_stop_geometry(self, operator: str, stop_id: str) -> URIRef:
+        """URI de la geometría puntual asociada a una parada de transporte."""
+        self._require_non_empty(operator, "operator")
+        self._require_non_empty(stop_id, "stop_id")
+        return URIRef(
+            f"{self.resource_base}geometry/transit_stop/{_safe(operator)}/{_safe(stop_id)}"
+        )
 
     @staticmethod
     def _require_non_empty(value: str, field_name: str) -> None:

--- a/apps/api/tests/test_api_routers_sparql.py
+++ b/apps/api/tests/test_api_routers_sparql.py
@@ -45,6 +45,10 @@ def test_sparql_catalog_lista_las_consultas(api_client: TestClient) -> None:
         "sources_used_by_territory",
         "count_triples_by_class",
         "indicator_definition",
+        "mobility_flow_between",
+        "accidents_in_radius",
+        "transit_stops_in_municipality",
+        "risk_index",
     } == ids
     for entry in body["queries"]:
         assert isinstance(entry["description"], str)

--- a/apps/api/tests/test_rdf_accidents.py
+++ b/apps/api/tests/test_rdf_accidents.py
@@ -1,0 +1,172 @@
+"""Pruebas de emisión RDF para accidentes viales DGT.
+
+Crea un :class:`MobilityDataset` con accidentes sintéticos y verifica:
+
+* La clase ``ah:RoadAccident`` se emite junto con ``geo:Feature`` y
+  ``prov:Entity``.
+* La geometría puntual se publica en el bucket de geometrías con WKT en
+  CRS84.
+* La conformidad SHACL se mantiene cuando se rompen propiedades clave (p.e.
+  severidad fuera del enum permitido).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from rdflib import Literal, URIRef
+from rdflib.namespace import RDF
+
+from atlashabita.infrastructure.ingestion import SeedDataset, SeedLoader
+from atlashabita.infrastructure.rdf import AH, GraphBuilder, ShaclValidator, URIBuilder
+from atlashabita.infrastructure.rdf.graph_builder import (
+    GRAPH_ACCIDENTS,
+    MobilityDataset,
+    RoadAccidentRecord,
+)
+from atlashabita.infrastructure.rdf.namespaces import GEO
+
+ROOT = Path(__file__).resolve().parents[3]
+SEED_DIR = ROOT / "data" / "seed"
+SHAPES = ROOT / "ontology" / "shapes.ttl"
+BASE = "https://data.atlashabita.example/"
+
+
+@pytest.fixture(scope="module")
+def dataset() -> SeedDataset:
+    return SeedLoader(SEED_DIR).load()
+
+
+@pytest.fixture(scope="module")
+def accidents() -> MobilityDataset:
+    """Tres accidentes en municipios reales del seed (Sevilla, Dos Hermanas)."""
+    return MobilityDataset(
+        accidents=(
+            RoadAccidentRecord(
+                accident_id="dgt-2024-000001",
+                date="2024-05-12",
+                lat=37.3886,
+                lon=-5.9823,
+                severity="serious",
+                source_id="dgt_accidentes",
+                municipality_code="41091",
+                victims=2,
+                fatalities=0,
+                road_type="urbana",
+            ),
+            RoadAccidentRecord(
+                accident_id="dgt-2024-000002",
+                date="2024-08-30",
+                lat=37.2810,
+                lon=-5.9214,
+                severity="fatal",
+                source_id="dgt_accidentes",
+                municipality_code="41038",
+                victims=4,
+                fatalities=1,
+                road_type="autovia",
+            ),
+            RoadAccidentRecord(
+                accident_id="dgt-2024-000003",
+                date="2024-11-04",
+                lat=37.3886,
+                lon=-5.9823,
+                severity="slight",
+                source_id="dgt_accidentes",
+                municipality_code="41091",
+            ),
+        )
+    )
+
+
+def test_emite_clase_road_accident(dataset: SeedDataset, accidents: MobilityDataset) -> None:
+    builder = GraphBuilder(URIBuilder(BASE))
+    graph = builder.build_graph(dataset, mobility=accidents)
+    accidents_set = list(graph.subjects(RDF.type, AH.RoadAccident))
+    assert len(accidents_set) == 3
+
+
+def test_accidente_tiene_geometria_y_wkt(dataset: SeedDataset, accidents: MobilityDataset) -> None:
+    builder = GraphBuilder(URIBuilder(BASE))
+    graph = builder.build_graph(dataset, mobility=accidents)
+    accident = URIRef(BASE + "resource/accident/dgt_2024_000001")
+    geometries = list(graph.objects(accident, AH.hasGeometry))
+    assert geometries, "El accidente debe enlazar una geometría"
+    geometry = geometries[0]
+    assert (geometry, RDF.type, GEO.Point) in graph
+    wkts = list(graph.objects(geometry, GEO.asWKT))
+    assert wkts
+
+
+def test_accidente_relacionado_con_municipio(
+    dataset: SeedDataset, accidents: MobilityDataset
+) -> None:
+    builder = GraphBuilder(URIBuilder(BASE))
+    graph = builder.build_graph(dataset, mobility=accidents)
+    accident = URIRef(BASE + "resource/accident/dgt_2024_000001")
+    sevilla = URIRef(BASE + "resource/territory/municipality/41091")
+    assert (accident, AH.occursIn, sevilla) in graph
+
+
+def test_accidente_emite_severidad_y_anio(dataset: SeedDataset, accidents: MobilityDataset) -> None:
+    builder = GraphBuilder(URIBuilder(BASE))
+    graph = builder.build_graph(dataset, mobility=accidents)
+    accident = URIRef(BASE + "resource/accident/dgt_2024_000002")
+    severities = list(graph.objects(accident, AH.accidentSeverity))
+    # Severidad se emite como literal plano para alinear con ``sh:in``.
+    assert severities == [Literal("fatal")]
+    years = list(graph.objects(accident, AH.accidentYear))
+    assert years
+    assert str(years[0]) == "2024"
+
+
+def test_named_graph_de_accidentes(dataset: SeedDataset, accidents: MobilityDataset) -> None:
+    builder = GraphBuilder(URIBuilder(BASE))
+    ds = builder.build(dataset, mobility=accidents)
+    identifiers = {str(g.identifier) for g in ds.graphs() if len(g) > 0}
+    assert f"{BASE}graph/{GRAPH_ACCIDENTS}" in identifiers
+
+
+def test_grafo_con_accidentes_conforma_shacl(
+    dataset: SeedDataset, accidents: MobilityDataset
+) -> None:
+    builder = GraphBuilder(URIBuilder(BASE))
+    graph = builder.build_graph(dataset, mobility=accidents)
+    validator = ShaclValidator(SHAPES)
+    report = validator.validate(graph)
+    assert report.conforms, [v.message for v in report.violations]
+
+
+def test_severidad_invalida_rompe_shacl(dataset: SeedDataset) -> None:
+    """``ah:RoadAccidentShape`` rechaza severidades fuera del enum."""
+    builder = GraphBuilder(URIBuilder(BASE))
+    bad = MobilityDataset(
+        accidents=(
+            RoadAccidentRecord(
+                accident_id="dgt-XXX",
+                date="2024-01-01",
+                lat=40.0,
+                lon=-3.0,
+                severity="catastrophic",
+                source_id="dgt_accidentes",
+            ),
+        )
+    )
+    graph = builder.build_graph(dataset, mobility=bad)
+    validator = ShaclValidator(SHAPES)
+    report = validator.validate(graph)
+    assert not report.conforms
+    messages = " ".join(v.message for v in report.violations)
+    assert "severidad" in messages.lower() or "fatal" in messages.lower()
+
+
+@pytest.mark.skipif(
+    not (SEED_DIR / "road_accidents.csv").exists(),
+    reason=(
+        "TODO(M11/TM1): activar cuando el seed extendido contenga "
+        "road_accidents.csv producido por TM1."
+    ),
+)
+def test_seed_extendido_contiene_accidentes(dataset: SeedDataset) -> None:  # pragma: no cover
+    raise AssertionError("Activar al integrar road_accidents.csv")

--- a/apps/api/tests/test_rdf_mobility.py
+++ b/apps/api/tests/test_rdf_mobility.py
@@ -1,0 +1,159 @@
+"""Pruebas de emisión RDF para flujos de movilidad MITMA.
+
+Construye un :class:`MobilityDataset` sintético (no depende del seed real
+extendido, todavía pendiente de ingesta por parte de TM1) y comprueba que
+``GraphBuilder`` emite las tripletas esperadas para ``ah:MobilityFlow``,
+incluyendo la alineación con SOSA y QB.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from rdflib import URIRef
+from rdflib.namespace import RDF, XSD
+
+from atlashabita.infrastructure.ingestion import SeedDataset, SeedLoader
+from atlashabita.infrastructure.rdf import AH, GraphBuilder, URIBuilder
+from atlashabita.infrastructure.rdf.graph_builder import (
+    GRAPH_MOBILITY,
+    MobilityDataset,
+    MobilityFlowRecord,
+)
+from atlashabita.infrastructure.rdf.namespaces import QB, SOSA
+
+ROOT = Path(__file__).resolve().parents[3]
+SEED_DIR = ROOT / "data" / "seed"
+BASE = "https://data.atlashabita.example/"
+
+
+@pytest.fixture(scope="module")
+def dataset() -> SeedDataset:
+    return SeedLoader(SEED_DIR).load()
+
+
+@pytest.fixture(scope="module")
+def mobility() -> MobilityDataset:
+    """Tres flujos sintéticos entre municipios reales del seed."""
+    flows = (
+        MobilityFlowRecord(
+            origin="municipality:41091",
+            destination="municipality:41038",
+            period="2024",
+            trips=12500.0,
+            source_id="mitma_om",
+            mode="all",
+            distance_km=12.4,
+        ),
+        MobilityFlowRecord(
+            origin="municipality:41091",
+            destination="municipality:41038",
+            period="2024",
+            trips=4200.0,
+            source_id="mitma_om",
+            mode="public_transit",
+        ),
+        MobilityFlowRecord(
+            origin="municipality:41038",
+            destination="municipality:41091",
+            period="2024",
+            trips=11800.0,
+            source_id="mitma_om",
+            mode="all",
+        ),
+    )
+    return MobilityDataset(flows=flows)
+
+
+def test_emite_clase_mobility_flow(dataset: SeedDataset, mobility: MobilityDataset) -> None:
+    builder = GraphBuilder(URIBuilder(BASE))
+    graph = builder.build_graph(dataset, mobility=mobility)
+    flows = list(graph.subjects(RDF.type, AH.MobilityFlow))
+    assert len(flows) == 3
+
+
+def test_emite_alineacion_sosa_y_qb(dataset: SeedDataset, mobility: MobilityDataset) -> None:
+    """Cada flujo declara también ``sosa:Observation`` y ``qb:Observation``."""
+    builder = GraphBuilder(URIBuilder(BASE))
+    graph = builder.build_graph(dataset, mobility=mobility)
+    flow_uri = URIRef(BASE + "resource/flow/41091/41038/2024/all")
+    assert (flow_uri, RDF.type, SOSA.Observation) in graph
+    assert (flow_uri, RDF.type, QB.Observation) in graph
+
+
+def test_flujo_emite_origin_destino_y_trips(
+    dataset: SeedDataset, mobility: MobilityDataset
+) -> None:
+    builder = GraphBuilder(URIBuilder(BASE))
+    graph = builder.build_graph(dataset, mobility=mobility)
+    flow_uri = URIRef(BASE + "resource/flow/41091/41038/2024/all")
+    origins = list(graph.objects(flow_uri, AH.flowOrigin))
+    destinations = list(graph.objects(flow_uri, AH.flowDestination))
+    assert origins == [URIRef(BASE + "resource/territory/municipality/41091")]
+    assert destinations == [URIRef(BASE + "resource/territory/municipality/41038")]
+    trips = list(graph.objects(flow_uri, AH.flowTrips))
+    assert trips
+    assert trips[0].datatype == XSD.decimal
+
+
+def test_uri_diferente_por_modo(dataset: SeedDataset, mobility: MobilityDataset) -> None:
+    builder = GraphBuilder(URIBuilder(BASE))
+    graph = builder.build_graph(dataset, mobility=mobility)
+    all_modes = URIRef(BASE + "resource/flow/41091/41038/2024/all")
+    transit = URIRef(BASE + "resource/flow/41091/41038/2024/public_transit")
+    assert (all_modes, RDF.type, AH.MobilityFlow) in graph
+    assert (transit, RDF.type, AH.MobilityFlow) in graph
+    assert all_modes != transit
+
+
+def test_named_graph_de_movilidad(dataset: SeedDataset, mobility: MobilityDataset) -> None:
+    builder = GraphBuilder(URIBuilder(BASE))
+    ds = builder.build(dataset, mobility=mobility)
+    identifiers = {str(g.identifier) for g in ds.graphs() if len(g) > 0}
+    assert f"{BASE}graph/{GRAPH_MOBILITY}" in identifiers
+
+
+def test_build_sin_mobility_no_emite_flujos(dataset: SeedDataset) -> None:
+    """Compatibilidad: la build clásica no debe contener flujos M11."""
+    builder = GraphBuilder(URIBuilder(BASE))
+    graph = builder.build_graph(dataset)
+    assert not list(graph.subjects(RDF.type, AH.MobilityFlow))
+
+
+def test_mobility_dataset_vacio_es_idempotente(dataset: SeedDataset) -> None:
+    builder = GraphBuilder(URIBuilder(BASE))
+    g1 = builder.build_graph(dataset)
+    g2 = builder.build_graph(dataset, mobility=MobilityDataset())
+    assert len(g1) == len(g2)
+
+
+def test_origen_o_destino_sin_kind_se_ignora(dataset: SeedDataset) -> None:
+    """Un registro mal formado no rompe la build, simplemente se omite."""
+    builder = GraphBuilder(URIBuilder(BASE))
+    bad = MobilityDataset(
+        flows=(
+            MobilityFlowRecord(
+                origin="invalid_no_colon",
+                destination="municipality:41091",
+                period="2024",
+                trips=1.0,
+                source_id="mitma_om",
+            ),
+        )
+    )
+    graph = builder.build_graph(dataset, mobility=bad)
+    assert not list(graph.subjects(RDF.type, AH.MobilityFlow))
+
+
+@pytest.mark.skipif(
+    not (SEED_DIR / "mobility_flows.csv").exists(),
+    reason=(
+        "TODO(M11/TM1): activar cuando el seed extendido contenga "
+        "mobility_flows.csv. La integración con SeedLoader vendrá en una "
+        "iteración posterior."
+    ),
+)
+def test_seed_extendido_contiene_flujos(dataset: SeedDataset) -> None:  # pragma: no cover
+    """Marcador para reconectar con TM1 cuando el seed real esté disponible."""
+    raise AssertionError("Activar prueba al integrar mobility_flows.csv")

--- a/apps/api/tests/test_rdf_transit.py
+++ b/apps/api/tests/test_rdf_transit.py
@@ -1,0 +1,156 @@
+"""Pruebas de emisión RDF para paradas y rutas de transporte público.
+
+Prueba la conexión paradas-rutas (``ah:servesStop``), la geometría puntual
+de las paradas, y la conformidad SHACL de las shapes ``ah:TransitStopShape``
+y ``ah:TransitRouteShape``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from rdflib import URIRef
+from rdflib.namespace import RDF
+
+from atlashabita.infrastructure.ingestion import SeedDataset, SeedLoader
+from atlashabita.infrastructure.rdf import AH, GraphBuilder, ShaclValidator, URIBuilder
+from atlashabita.infrastructure.rdf.graph_builder import (
+    GRAPH_TRANSIT,
+    MobilityDataset,
+    TransitRouteRecord,
+    TransitStopRecord,
+)
+from atlashabita.infrastructure.rdf.namespaces import GEO
+
+ROOT = Path(__file__).resolve().parents[3]
+SEED_DIR = ROOT / "data" / "seed"
+SHAPES = ROOT / "ontology" / "shapes.ttl"
+BASE = "https://data.atlashabita.example/"
+
+
+@pytest.fixture(scope="module")
+def dataset() -> SeedDataset:
+    return SeedLoader(SEED_DIR).load()
+
+
+@pytest.fixture(scope="module")
+def transit() -> MobilityDataset:
+    """Dos paradas y una ruta sintéticas de operadores reales (CRTM/EMT)."""
+    stops = (
+        TransitStopRecord(
+            operator="emt_madrid",
+            stop_id="1001",
+            name="Plaza de Cibeles",
+            lat=40.4193,
+            lon=-3.6929,
+            source_id="emt_gtfs",
+            code="C1",
+            municipality_code="28079",
+        ),
+        TransitStopRecord(
+            operator="emt_madrid",
+            stop_id="1002",
+            name="Atocha",
+            lat=40.4063,
+            lon=-3.6906,
+            source_id="emt_gtfs",
+            code="A1",
+            municipality_code="28079",
+        ),
+    )
+    routes = (
+        TransitRouteRecord(
+            operator="emt_madrid",
+            route_id="L27",
+            short_name="27",
+            long_name="Plaza de Cibeles - Atocha",
+            mode="bus",
+            source_id="emt_gtfs",
+            stop_ids=("1001", "1002"),
+        ),
+    )
+    return MobilityDataset(transit_stops=stops, transit_routes=routes)
+
+
+def test_emite_paradas_de_transporte(dataset: SeedDataset, transit: MobilityDataset) -> None:
+    builder = GraphBuilder(URIBuilder(BASE))
+    graph = builder.build_graph(dataset, mobility=transit)
+    stops = list(graph.subjects(RDF.type, AH.TransitStop))
+    assert len(stops) == 2
+
+
+def test_emite_rutas_de_transporte(dataset: SeedDataset, transit: MobilityDataset) -> None:
+    builder = GraphBuilder(URIBuilder(BASE))
+    graph = builder.build_graph(dataset, mobility=transit)
+    routes = list(graph.subjects(RDF.type, AH.TransitRoute))
+    assert len(routes) == 1
+
+
+def test_ruta_sirve_a_paradas(dataset: SeedDataset, transit: MobilityDataset) -> None:
+    builder = GraphBuilder(URIBuilder(BASE))
+    graph = builder.build_graph(dataset, mobility=transit)
+    route = URIRef(BASE + "resource/transit_route/emt_madrid/L27")
+    served = set(graph.objects(route, AH.servesStop))
+    assert {
+        URIRef(BASE + "resource/transit_stop/emt_madrid/1001"),
+        URIRef(BASE + "resource/transit_stop/emt_madrid/1002"),
+    } == served
+
+
+def test_paradas_tienen_geometria_puntual(dataset: SeedDataset, transit: MobilityDataset) -> None:
+    builder = GraphBuilder(URIBuilder(BASE))
+    graph = builder.build_graph(dataset, mobility=transit)
+    stop = URIRef(BASE + "resource/transit_stop/emt_madrid/1001")
+    geometries = list(graph.objects(stop, AH.hasGeometry))
+    assert geometries
+    geometry = geometries[0]
+    assert (geometry, RDF.type, GEO.Point) in graph
+
+
+def test_named_graph_de_transito(dataset: SeedDataset, transit: MobilityDataset) -> None:
+    builder = GraphBuilder(URIBuilder(BASE))
+    ds = builder.build(dataset, mobility=transit)
+    identifiers = {str(g.identifier) for g in ds.graphs() if len(g) > 0}
+    assert f"{BASE}graph/{GRAPH_TRANSIT}" in identifiers
+
+
+def test_grafo_con_transit_conforma_shacl(dataset: SeedDataset, transit: MobilityDataset) -> None:
+    builder = GraphBuilder(URIBuilder(BASE))
+    graph = builder.build_graph(dataset, mobility=transit)
+    validator = ShaclValidator(SHAPES)
+    report = validator.validate(graph)
+    assert report.conforms, [v.message for v in report.violations]
+
+
+def test_modo_invalido_rompe_shacl(dataset: SeedDataset) -> None:
+    builder = GraphBuilder(URIBuilder(BASE))
+    bad = MobilityDataset(
+        transit_routes=(
+            TransitRouteRecord(
+                operator="emt_madrid",
+                route_id="X",
+                short_name="X",
+                long_name="Invalid",
+                mode="hyperloop",  # no permitido por la shape
+                source_id="emt_gtfs",
+            ),
+        ),
+    )
+    graph = builder.build_graph(dataset, mobility=bad)
+    validator = ShaclValidator(SHAPES)
+    report = validator.validate(graph)
+    assert not report.conforms
+    messages = " ".join(v.message for v in report.violations)
+    assert "modo" in messages.lower() or "transit" in messages.lower() or "GTFS" in messages
+
+
+@pytest.mark.skipif(
+    not (SEED_DIR / "transit_stops.csv").exists(),
+    reason=(
+        "TODO(M11/TM1): activar cuando el seed extendido contenga "
+        "transit_stops.csv producido por TM1."
+    ),
+)
+def test_seed_extendido_contiene_paradas(dataset: SeedDataset) -> None:  # pragma: no cover
+    raise AssertionError("Activar al integrar transit_stops.csv")

--- a/apps/api/tests/test_run_sparql_query.py
+++ b/apps/api/tests/test_run_sparql_query.py
@@ -33,6 +33,10 @@ class FakeRunner:
     sources_result: list[dict[str, Any]] = field(default_factory=list)
     counts_result: dict[str, int] = field(default_factory=dict)
     definition_result: dict[str, Any] = field(default_factory=dict)
+    mobility_result: list[dict[str, Any]] = field(default_factory=list)
+    accidents_result: list[dict[str, Any]] = field(default_factory=list)
+    transit_stops_result: list[dict[str, Any]] = field(default_factory=list)
+    risk_index_result: dict[str, Any] = field(default_factory=dict)
 
     def top_scores_by_profile(
         self, profile_id: str, scope: str = "municipality", limit: int = 10
@@ -55,6 +59,22 @@ class FakeRunner:
     def count_triples_by_class(self) -> dict[str, int]:
         return dict(self.counts_result)
 
+    def mobility_flow_between(
+        self, origin_code: str, destination_code: str, period: str
+    ) -> list[dict[str, Any]]:
+        return list(self.mobility_result)
+
+    def accidents_in_radius(
+        self, lat: float, lon: float, km: float, year: int | None = None
+    ) -> list[dict[str, Any]]:
+        return list(self.accidents_result)
+
+    def transit_stops_in_municipality(self, municipality_code: str) -> list[dict[str, Any]]:
+        return list(self.transit_stops_result)
+
+    def risk_index(self, municipality_code: str) -> dict[str, Any]:
+        return dict(self.risk_index_result)
+
 
 @pytest.fixture()
 def settings() -> Settings:
@@ -71,6 +91,10 @@ def test_catalog_expone_todas_las_consultas() -> None:
         "sources_used_by_territory",
         "count_triples_by_class",
         "indicator_definition",
+        "mobility_flow_between",
+        "accidents_in_radius",
+        "transit_stops_in_municipality",
+        "risk_index",
     }
     for signature in signatures:
         assert signature.description.strip() != ""

--- a/apps/api/tests/test_sparql_extended.py
+++ b/apps/api/tests/test_sparql_extended.py
@@ -1,0 +1,257 @@
+"""Pruebas de las consultas SPARQL extendidas en el milestone M11.
+
+Cubren las cuatro consultas nuevas:
+
+* ``mobility_flow_between(origin, destination, period)``
+* ``accidents_in_radius(lat, lon, km, year)``
+* ``transit_stops_in_municipality(municipality_code)``
+* ``risk_index(municipality_code)`` — agregación accidentes+flujos.
+
+Como los CSV reales todavía no están en ``data/seed`` cuando esta rama se
+integra (TM1 los produce en otra rama), los tests construyen el grafo
+sintéticamente reusando los DTOs ``MobilityFlowRecord``/``RoadAccidentRecord``
+y verifican el comportamiento de las consultas SPARQL contra el grafo
+combinado.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from rdflib import Graph
+
+from atlashabita.config import Settings
+from atlashabita.infrastructure.ingestion import SeedLoader
+from atlashabita.infrastructure.rdf import GraphBuilder, SparqlRunner, URIBuilder
+from atlashabita.infrastructure.rdf.graph_builder import (
+    MobilityDataset,
+    MobilityFlowRecord,
+    RoadAccidentRecord,
+    TransitRouteRecord,
+    TransitStopRecord,
+)
+
+ROOT = Path(__file__).resolve().parents[3]
+SEED_DIR = ROOT / "data" / "seed"
+BASE = "https://data.atlashabita.example/"
+
+
+def _build_full_dataset() -> MobilityDataset:
+    """Conjunto sintético cubriendo flujos, accidentes y transporte."""
+    flows = (
+        MobilityFlowRecord(
+            origin="municipality:41091",
+            destination="municipality:41038",
+            period="2024",
+            trips=15000.0,
+            source_id="mitma_om",
+            mode="all",
+        ),
+        MobilityFlowRecord(
+            origin="municipality:41091",
+            destination="municipality:41004",
+            period="2024",
+            trips=4500.0,
+            source_id="mitma_om",
+            mode="all",
+        ),
+        MobilityFlowRecord(
+            origin="municipality:41091",
+            destination="municipality:41038",
+            period="2025",
+            trips=16500.0,
+            source_id="mitma_om",
+            mode="all",
+        ),
+    )
+    accidents = (
+        RoadAccidentRecord(
+            accident_id="dgt-2024-A",
+            date="2024-03-10",
+            lat=37.3886,
+            lon=-5.9823,
+            severity="serious",
+            source_id="dgt_accidentes",
+            municipality_code="41091",
+            victims=2,
+            fatalities=0,
+        ),
+        RoadAccidentRecord(
+            accident_id="dgt-2024-B",
+            date="2024-07-21",
+            lat=37.4000,
+            lon=-5.9700,
+            severity="slight",
+            source_id="dgt_accidentes",
+            municipality_code="41091",
+            victims=1,
+            fatalities=0,
+        ),
+        RoadAccidentRecord(
+            accident_id="dgt-2025-C",
+            date="2025-02-02",
+            lat=37.5500,
+            lon=-5.5000,
+            severity="fatal",
+            source_id="dgt_accidentes",
+            municipality_code="41091",
+            victims=3,
+            fatalities=1,
+        ),
+        RoadAccidentRecord(
+            accident_id="dgt-2024-D",
+            date="2024-09-15",
+            lat=40.4193,
+            lon=-3.6929,
+            severity="slight",
+            source_id="dgt_accidentes",
+            municipality_code="28079",
+        ),
+    )
+    stops = (
+        TransitStopRecord(
+            operator="tussam_sevilla",
+            stop_id="2001",
+            name="Avenida de la Constitución",
+            lat=37.3870,
+            lon=-5.9930,
+            source_id="tussam_gtfs",
+            municipality_code="41091",
+        ),
+        TransitStopRecord(
+            operator="tussam_sevilla",
+            stop_id="2002",
+            name="Reyes Católicos",
+            lat=37.3900,
+            lon=-5.9970,
+            source_id="tussam_gtfs",
+            municipality_code="41091",
+        ),
+    )
+    routes = (
+        TransitRouteRecord(
+            operator="tussam_sevilla",
+            route_id="C5",
+            short_name="C5",
+            long_name="Circular Centro",
+            mode="bus",
+            source_id="tussam_gtfs",
+            stop_ids=("2001", "2002"),
+        ),
+    )
+    return MobilityDataset(
+        flows=flows,
+        accidents=accidents,
+        transit_stops=stops,
+        transit_routes=routes,
+    )
+
+
+@pytest.fixture(scope="module")
+def graph() -> Graph:
+    dataset = SeedLoader(SEED_DIR).load()
+    return GraphBuilder(URIBuilder(BASE)).build_graph(dataset, mobility=_build_full_dataset())
+
+
+@pytest.fixture()
+def settings() -> Settings:
+    return Settings()
+
+
+def test_mobility_flow_between_devuelve_flujo(graph: Graph, settings: Settings) -> None:
+    runner = SparqlRunner(graph, settings)
+    rows = runner.mobility_flow_between("41091", "41038", "2024")
+    assert rows
+    first = rows[0]
+    assert first["trips"] == pytest.approx(15000.0)
+    assert first["period"] == "2024"
+
+
+def test_mobility_flow_between_filtra_por_periodo(graph: Graph, settings: Settings) -> None:
+    runner = SparqlRunner(graph, settings)
+    rows_2024 = runner.mobility_flow_between("41091", "41038", "2024")
+    rows_2025 = runner.mobility_flow_between("41091", "41038", "2025")
+    trips_2024 = {row["trips"] for row in rows_2024}
+    trips_2025 = {row["trips"] for row in rows_2025}
+    assert trips_2024 != trips_2025
+
+
+def test_mobility_flow_between_rechaza_periodo_invalido(graph: Graph, settings: Settings) -> None:
+    runner = SparqlRunner(graph, settings)
+    with pytest.raises(ValueError, match="period"):
+        runner.mobility_flow_between("41091", "41038", "2024 OR 1=1")
+
+
+def test_accidents_in_radius_devuelve_proximos(graph: Graph, settings: Settings) -> None:
+    runner = SparqlRunner(graph, settings)
+    rows = runner.accidents_in_radius(37.3886, -5.9823, 5.0)
+    ids = {row["id"] for row in rows}
+    # dgt-2024-A está exactamente en el centro, dgt-2024-B muy cerca.
+    assert "dgt-2024-A" in ids
+    assert "dgt-2024-B" in ids
+    # El accidente de Madrid no debe entrar en un radio de 5km en Sevilla.
+    assert "dgt-2024-D" not in ids
+
+
+def test_accidents_in_radius_filtra_por_anio(graph: Graph, settings: Settings) -> None:
+    runner = SparqlRunner(graph, settings)
+    rows_2024 = runner.accidents_in_radius(37.3886, -5.9823, 100.0, year=2024)
+    ids_2024 = {row["id"] for row in rows_2024}
+    assert "dgt-2024-A" in ids_2024
+    assert "dgt-2025-C" not in ids_2024
+
+
+def test_accidents_in_radius_rechaza_radio_excesivo(graph: Graph, settings: Settings) -> None:
+    runner = SparqlRunner(graph, settings)
+    with pytest.raises(ValueError, match="radius_km"):
+        runner.accidents_in_radius(37.0, -5.0, 5000.0)
+
+
+def test_accidents_in_radius_rechaza_anio_invalido(graph: Graph, settings: Settings) -> None:
+    runner = SparqlRunner(graph, settings)
+    with pytest.raises(ValueError, match="year"):
+        runner.accidents_in_radius(37.0, -5.0, 10.0, year=1500)
+
+
+def test_transit_stops_in_municipality(graph: Graph, settings: Settings) -> None:
+    runner = SparqlRunner(graph, settings)
+    rows = runner.transit_stops_in_municipality("41091")
+    labels = {row["label"] for row in rows}
+    assert "Avenida de la Constitución" in labels
+    assert "Reyes Católicos" in labels
+
+
+def test_transit_stops_in_municipality_sin_resultados(graph: Graph, settings: Settings) -> None:
+    runner = SparqlRunner(graph, settings)
+    rows = runner.transit_stops_in_municipality("99999")
+    assert rows == []
+
+
+def test_risk_index_combina_accidentes_y_flujos(graph: Graph, settings: Settings) -> None:
+    runner = SparqlRunner(graph, settings)
+    result = runner.risk_index("41091")
+    assert result["code"] == "41091"
+    # Tres accidentes están vinculados al municipio 41091.
+    assert result["accidents"] == 3
+    # Suma de fatalidades reportadas: 0 + 0 + 1 = 1.
+    assert result["fatalities"] == 1
+    # Hay flujos salientes desde 41091.
+    assert result["outbound_flows"] >= 2
+    assert result["outbound_trips"] > 0
+    assert "risk_per_1000_trips" in result
+
+
+def test_risk_index_municipio_sin_datos(graph: Graph, settings: Settings) -> None:
+    runner = SparqlRunner(graph, settings)
+    result = runner.risk_index("99999")
+    assert result["code"] == "99999"
+    assert result["accidents"] == 0
+    assert result["outbound_flows"] == 0
+    assert result["risk_per_1000_trips"] == pytest.approx(0.0)
+
+
+def test_risk_index_rechaza_codigo_invalido(graph: Graph, settings: Settings) -> None:
+    runner = SparqlRunner(graph, settings)
+    with pytest.raises(ValueError, match="municipality_code"):
+        runner.risk_index("NULL); DROP TABLE")

--- a/docs/rdf-model.md
+++ b/docs/rdf-model.md
@@ -30,7 +30,9 @@ Resumen ejecutivo del Knowledge Graph construido en [`ontology/atlashabita.ttl`]
 | `sf:` | `http://www.opengis.net/ont/sf#` | Simple Features (`sf:Point`). |
 | `wgs84:` | `http://www.w3.org/2003/01/geo/wgs84_pos#` | Coordenadas históricas (`wgs84:lat`, `wgs84:long`). |
 | `prov:` | `http://www.w3.org/ns/prov#` | Procedencia (PROV-O). |
-| `qb:` | `http://purl.org/linked-data/cube#` | Data Cube (reservado). |
+| `qb:` | `http://purl.org/linked-data/cube#` | Data Cube (flujos MITMA como observaciones multidimensionales). |
+| `sosa:` | `http://www.w3.org/ns/sosa/` | Sensor / Observation / Sample / Actuator. |
+| `ssn:` | `http://www.w3.org/ns/ssn/` | Semantic Sensor Network. |
 | `sh:` | `http://www.w3.org/ns/shacl#` | Shapes SHACL. |
 
 ---
@@ -55,6 +57,11 @@ ah:IngestionActivity      rdfs:subClassOf prov:Activity .
 ah:DecisionProfile        a owl:Class .
 ah:Score                  rdfs:subClassOf prov:Entity .
 ah:ScoreContribution      a owl:Class .
+
+ah:MobilityFlow           rdfs:subClassOf prov:Entity , sosa:Observation , qb:Observation .
+ah:RoadAccident           rdfs:subClassOf prov:Entity , geo:Feature .
+ah:TransitStop            rdfs:subClassOf geo:Feature .
+ah:TransitRoute           a owl:Class .
 ```
 
 ---
@@ -367,7 +374,144 @@ El modelo RDF se considera aceptable si:
 
 ---
 
-## 12. Consumo RDF desde la UI (v0.2.0)
+## 12. Datasets M11: movilidad, accidentes y transporte público
+
+La versión 0.3.0 (milestone M11) extiende la ontología con cuatro nuevas
+clases consumidas por el mapa multi-métrica y los recomendadores
+contextuales. La compatibilidad con la versión anterior se mantiene: las
+nuevas tripletas viven en sus propios named graphs (`mobility`, `accidents`,
+`transit`) y la validación SHACL del seed clásico no cambia.
+
+### 12.1 Flujos de movilidad (`ah:MobilityFlow`)
+
+Origen-destino por periodo y modo (datos MITMA OD). Se modela como
+`sosa:Observation` y `qb:Observation` para integrarse con herramientas
+estándar de cubos de datos y observaciones sensoriales.
+
+```turtle
+@prefix ah:    <https://data.atlashabita.example/ontology/> .
+@prefix ahr:   <https://data.atlashabita.example/resource/> .
+@prefix sosa:  <http://www.w3.org/ns/sosa/> .
+@prefix qb:    <http://purl.org/linked-data/cube#> .
+@prefix prov:  <http://www.w3.org/ns/prov#> .
+@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+
+ahr:flow/41091/41038/2024/all
+    a ah:MobilityFlow, sosa:Observation, qb:Observation, prov:Entity ;
+    ah:flowOrigin ahr:territory/municipality/41091 ;
+    sosa:hasFeatureOfInterest ahr:territory/municipality/41091 ;
+    ah:flowDestination ahr:territory/municipality/41038 ;
+    ah:flowTrips "12500"^^xsd:decimal ;
+    sosa:hasSimpleResult "12500"^^xsd:decimal ;
+    ah:flowMode "all" ;
+    ah:flowDistanceKm "12.4"^^xsd:decimal ;
+    ah:period "2024" ;
+    ah:periodYear "2024"^^xsd:gYear ;
+    ah:providedBy ahr:source/mitma_om .
+```
+
+### 12.2 Accidentes viales (`ah:RoadAccident`)
+
+Registros DGT con localización puntual, severidad acotada por SHACL al
+enum {`fatal`, `serious`, `slight`} y atributos de víctimas. La
+geometría sigue la convención GeoSPARQL del resto del grafo.
+
+```turtle
+@prefix ah:    <https://data.atlashabita.example/ontology/> .
+@prefix ahr:   <https://data.atlashabita.example/resource/> .
+@prefix dct:   <http://purl.org/dc/terms/> .
+@prefix geo:   <http://www.opengis.net/ont/geosparql#> .
+@prefix wgs84: <http://www.w3.org/2003/01/geo/wgs84_pos#> .
+@prefix prov:  <http://www.w3.org/ns/prov#> .
+@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+
+ahr:accident/dgt_2024_000001
+    a ah:RoadAccident, geo:Feature, prov:Entity ;
+    dct:identifier "dgt-2024-000001" ;
+    ah:accidentDate "2024-05-12"^^xsd:date ;
+    ah:accidentYear "2024"^^xsd:gYear ;
+    ah:accidentSeverity "serious" ;
+    ah:accidentVictims 2 ;
+    ah:accidentFatalities 0 ;
+    ah:accidentRoadType "urbana" ;
+    ah:occursIn ahr:territory/municipality/41091 ;
+    wgs84:lat "37.3886"^^xsd:decimal ;
+    wgs84:long "-5.9823"^^xsd:decimal ;
+    ah:hasGeometry ahr:geometry/accident/dgt_2024_000001 ;
+    geo:hasGeometry ahr:geometry/accident/dgt_2024_000001 ;
+    ah:providedBy ahr:source/dgt_accidentes .
+
+ahr:geometry/accident/dgt_2024_000001
+    a geo:Geometry, geo:Point ;
+    geo:asWKT "<http://www.opengis.net/def/crs/OGC/1.3/CRS84> POINT(-5.9823 37.3886)"^^geo:wktLiteral .
+```
+
+### 12.3 Transporte público (`ah:TransitStop`, `ah:TransitRoute`)
+
+Paradas y rutas alineadas con CRTM/GTFS. La identidad es
+`agency_id + stop_id` / `agency_id + route_id` para evitar colisiones al
+federar varios operadores.
+
+```turtle
+@prefix ah:    <https://data.atlashabita.example/ontology/> .
+@prefix ahr:   <https://data.atlashabita.example/resource/> .
+@prefix dct:   <http://purl.org/dc/terms/> .
+@prefix geo:   <http://www.opengis.net/ont/geosparql#> .
+@prefix wgs84: <http://www.w3.org/2003/01/geo/wgs84_pos#> .
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+
+ahr:transit_stop/emt_madrid/1001
+    a ah:TransitStop, geo:Feature ;
+    dct:identifier "emt_madrid:1001" ;
+    rdfs:label "Plaza de Cibeles"@es ;
+    ah:stopName "Plaza de Cibeles" ;
+    ah:stopCode "C1" ;
+    ah:operator "emt_madrid" ;
+    wgs84:lat "40.4193"^^xsd:decimal ;
+    wgs84:long "-3.6929"^^xsd:decimal ;
+    ah:hasGeometry ahr:geometry/transit_stop/emt_madrid/1001 ;
+    geo:hasGeometry ahr:geometry/transit_stop/emt_madrid/1001 ;
+    ah:locatedIn ahr:territory/municipality/28079 ;
+    ah:providedBy ahr:source/emt_gtfs .
+
+ahr:transit_route/emt_madrid/L27
+    a ah:TransitRoute ;
+    dct:identifier "emt_madrid:L27" ;
+    rdfs:label "Plaza de Cibeles - Atocha"@es ;
+    ah:routeShortName "27" ;
+    ah:routeLongName "Plaza de Cibeles - Atocha" ;
+    ah:transitMode "bus" ;
+    ah:operator "emt_madrid" ;
+    ah:servesStop ahr:transit_stop/emt_madrid/1001 ,
+                  ahr:transit_stop/emt_madrid/1002 ;
+    ah:providedBy ahr:source/emt_gtfs .
+```
+
+### 12.4 Consultas SPARQL del catálogo
+
+| `query_id` | Descripción | Bindings |
+|---|---|---|
+| `mobility_flow_between` | Flujos MITMA entre dos territorios para un periodo. | `origin_code`, `destination_code`, `period`. |
+| `accidents_in_radius` | Accidentes DGT dentro de `km` km del centro indicado. | `lat`, `lon`, `km`; `year` opcional. |
+| `transit_stops_in_municipality` | Paradas de transporte público en un municipio. | `municipality_code`. |
+| `risk_index` | Indice compuesto accidentes/flujos para un municipio. | `municipality_code`. |
+
+Todas las consultas se exponen vía `RunSparqlQueryUseCase` con la misma
+política de salvaguardas (`_require_safe_*`, LIMIT defensivo y timeout
+blando) que el resto del catálogo.
+
+### 12.5 Named graphs adicionales
+
+| Named graph | URI | Contenido |
+|---|---|---|
+| Movilidad | `https://data.atlashabita.example/graph/mobility` | `ah:MobilityFlow` (MITMA OD). |
+| Accidentes | `https://data.atlashabita.example/graph/accidents` | `ah:RoadAccident` (DGT). |
+| Tránsito | `https://data.atlashabita.example/graph/transit` | `ah:TransitStop` y `ah:TransitRoute` (CRTM/GTFS). |
+
+---
+
+## 13. Consumo RDF desde la UI (v0.2.0)
 
 La Fase D añade tres superficies en el frontend que ejercitan el grafo:
 

--- a/ontology/README.md
+++ b/ontology/README.md
@@ -1,9 +1,10 @@
 # Ontología AtlasHabita
 
 Carpeta con los artefactos OWL/SHACL que describen el vocabulario del
-knowledge graph. La versión semántica que vive aquí es **0.2.0 (Fase B M8)**
-y añade alineación con **GeoSPARQL** y reforzamiento de **PROV-O** y
-**SHACL** sobre la base 0.1.0 heredada.
+knowledge graph. La versión semántica que vive aquí es **0.3.0 (Fase B M11)**
+y añade clases para **flujos de movilidad MITMA**, **accidentes DGT** y
+**transporte público CRTM/GTFS** sobre la base 0.2.0 (que ya alineaba con
+GeoSPARQL y reforzaba PROV-O).
 
 ## Archivos
 
@@ -44,11 +45,40 @@ y añade alineación con **GeoSPARQL** y reforzamiento de **PROV-O** y
    - Shape `ah:GeometryShape` exige `geo:asWKT`.
    - Shape `ah:IngestionActivityShape` exige `prov:used`.
 
+## Novedades Fase B (M11)
+
+1. **Movilidad** (`ah:MobilityFlow`)
+   - Subclase de `prov:Entity`, `sosa:Observation` y `qb:Observation`.
+   - Propiedades `ah:flowOrigin`, `ah:flowDestination`, `ah:flowTrips`
+     (subproperty de `sosa:hasSimpleResult`), `ah:flowMode`,
+     `ah:flowDistanceKm`.
+   - URIs deterministas: `/resource/flow/<origin>/<destination>/<period>[/<mode>]`.
+   - Named graph: `/graph/mobility`.
+
+2. **Accidentes viales** (`ah:RoadAccident`)
+   - Subclase de `prov:Entity` y `geo:Feature` con geometría puntual
+     dedicada en `/resource/geometry/accident/<id>`.
+   - Propiedades `ah:accidentDate` (xsd:date), `ah:accidentYear`
+     (xsd:gYear), `ah:accidentSeverity` (enum SHACL), `ah:accidentVictims`,
+     `ah:accidentFatalities`, `ah:accidentRoadType`, `ah:occursIn`.
+   - Named graph: `/graph/accidents`.
+
+3. **Transporte público** (`ah:TransitStop`, `ah:TransitRoute`)
+   - Paradas alineadas con GeoSPARQL (`geo:Feature`) y rutas con modos
+     GTFS validados por SHACL (`bus`/`metro`/`tram`/`rail`/`ferry`/...).
+   - Propiedad `ah:servesStop` para conectar rutas con paradas.
+   - URIs determinadas por `agency_id + stop_id` / `agency_id + route_id`.
+   - Named graph: `/graph/transit`.
+
+4. **Vocabularios añadidos**
+   - `sosa:` y `ssn:` cargados explícitamente en `bind_all`.
+   - `qb:` reforzado: ahora se utiliza activamente en flujos de movilidad.
+
 ## Compatibilidad
 
-La versión 0.2.0 es retrocompatible con 0.1.0: todas las tripletas válidas
-en la versión anterior lo siguen siendo. Las nuevas restricciones sólo
-aplican cuando los nuevos tipos y propiedades aparecen en el grafo.
+La versión 0.3.0 mantiene retrocompatibilidad total con 0.2.0 y 0.1.0.
+Las clases y propiedades nuevas viven en sus propios named graphs y la
+validación SHACL del seed clásico no se ve afectada.
 
 ## Convenciones de URIs
 
@@ -58,18 +88,26 @@ URIs y named graphs. Resumen de recursos:
 ```
 /resource/territory/<kind>/<code>
 /resource/geometry/<kind>/<code>
+/resource/geometry/accident/<id>
+/resource/geometry/transit_stop/<operator>/<stop_id>
 /resource/indicator/<code>
 /resource/source/<id>
 /resource/observation/<indicator>/<kind>/<code>/<period>
 /resource/activity/<source_id>/<period>
 /resource/profile/<id>
 /resource/score/<version>/<profile_id>/<kind>/<code>
+/resource/flow/<origin_code>/<destination_code>/<period>[/<mode>]
+/resource/accident/<id>
+/resource/transit_stop/<operator>/<stop_id>
+/resource/transit_route/<operator>/<route_id>
 ```
 
 ## Referencias
 
 - [GeoSPARQL (OGC)](https://www.ogc.org/standards/geosparql/)
 - [PROV-O (W3C)](https://www.w3.org/TR/prov-o/)
+- [SOSA/SSN (W3C)](https://www.w3.org/TR/vocab-ssn/)
+- [RDF Data Cube (W3C)](https://www.w3.org/TR/vocab-data-cube/)
 - [SHACL (W3C)](https://www.w3.org/TR/shacl/)
 - [OWL 2 (W3C)](https://www.w3.org/TR/owl2-overview/)
 - [SPARQL 1.1 (W3C)](https://www.w3.org/TR/sparql11-query/)

--- a/ontology/atlashabita.ttl
+++ b/ontology/atlashabita.ttl
@@ -11,21 +11,27 @@
 @prefix wgs84: <http://www.w3.org/2003/01/geo/wgs84_pos#> .
 @prefix prov:  <http://www.w3.org/ns/prov#> .
 @prefix qb:    <http://purl.org/linked-data/cube#> .
+@prefix sosa:  <http://www.w3.org/ns/sosa/> .
+@prefix ssn:   <http://www.w3.org/ns/ssn/> .
 
 ###############################################################################
-# Ontología AtlasHabita (v0.2.0 — Fase B M8)                                 #
-# Amplía la base v0.1.0 con alineación GeoSPARQL y PROV-O reforzado.         #
+# Ontología AtlasHabita (v0.3.0 — Fase B M11)                                #
+# Amplía v0.2.0 con clases para flujos de movilidad, accidentes y transporte #
+# público (MITMA + DGT + CRTM), alineadas con SOSA/SSN y QB.                 #
 ###############################################################################
 
 <https://data.atlashabita.example/ontology/>
     a owl:Ontology ;
     dct:title "Ontología AtlasHabita"@es ;
     dct:description
-        "Vocabulario para representar territorios españoles, indicadores, observaciones, fuentes, scores explicables, geometrías GeoSPARQL y procedencia PROV-O."@es ;
+        "Vocabulario para representar territorios españoles, indicadores, observaciones, fuentes, scores explicables, geometrías GeoSPARQL, procedencia PROV-O, flujos de movilidad, accidentes viales y red de transporte público."@es ;
     dct:license <https://creativecommons.org/licenses/by/4.0/> ;
-    owl:versionInfo "0.2.0" ;
+    owl:versionInfo "0.3.0" ;
     owl:imports <http://www.opengis.net/ont/geosparql> ,
-                <http://www.w3.org/ns/prov-o> .
+                <http://www.w3.org/ns/prov-o> ,
+                <http://www.w3.org/ns/sosa/> ,
+                <http://www.w3.org/ns/ssn/> ,
+                <http://purl.org/linked-data/cube> .
 
 ###############################################################################
 # Jerarquía territorial (alineada con geo:Feature de GeoSPARQL)              #
@@ -304,3 +310,176 @@ ah:confidence
     rdfs:label "confianza"@es ;
     rdfs:domain ah:Score ;
     rdfs:range xsd:decimal .
+
+###############################################################################
+# Movilidad: flujos origen-destino (MITMA)                                   #
+# Un MobilityFlow es una observación SOSA cuya "feature of interest" es la   #
+# par origen-destino y cuyo "observed property" es el número de viajes en   #
+# un periodo concreto. Se modela también como qb:Observation para integrarse #
+# con cubos de datos por (origen, destino, periodo, modo).                  #
+###############################################################################
+
+ah:MobilityFlow
+    a owl:Class ;
+    rdfs:label "Flujo de movilidad"@es ;
+    rdfs:comment "Volumen de desplazamientos entre dos territorios en un periodo (MITMA)."@es ;
+    rdfs:subClassOf prov:Entity , sosa:Observation , qb:Observation .
+
+ah:flowOrigin
+    a owl:ObjectProperty ;
+    rdfs:label "origen del flujo"@es ;
+    rdfs:domain ah:MobilityFlow ;
+    rdfs:range ah:Territory ;
+    rdfs:subPropertyOf sosa:hasFeatureOfInterest .
+
+ah:flowDestination
+    a owl:ObjectProperty ;
+    rdfs:label "destino del flujo"@es ;
+    rdfs:domain ah:MobilityFlow ;
+    rdfs:range ah:Territory .
+
+ah:flowTrips
+    a owl:DatatypeProperty ;
+    rdfs:label "número de viajes"@es ;
+    rdfs:comment "Cantidad de desplazamientos observados en el periodo."@es ;
+    rdfs:domain ah:MobilityFlow ;
+    rdfs:range xsd:decimal ;
+    rdfs:subPropertyOf sosa:hasSimpleResult .
+
+ah:flowMode
+    a owl:DatatypeProperty ;
+    rdfs:label "modo de transporte"@es ;
+    rdfs:comment "Modo de transporte (por ejemplo 'all', 'car', 'public_transit')."@es ;
+    rdfs:domain ah:MobilityFlow ;
+    rdfs:range xsd:string .
+
+ah:flowDistanceKm
+    a owl:DatatypeProperty ;
+    rdfs:label "distancia media (km)"@es ;
+    rdfs:domain ah:MobilityFlow ;
+    rdfs:range xsd:decimal .
+
+###############################################################################
+# Accidentes viales (DGT)                                                    #
+# Un RoadAccident es una entidad PROV con geometría puntual y atributos de  #
+# severidad. Se asocia opcionalmente al municipio que lo contiene para       #
+# facilitar agregaciones administrativas.                                    #
+###############################################################################
+
+ah:RoadAccident
+    a owl:Class ;
+    rdfs:label "Accidente vial"@es ;
+    rdfs:comment "Suceso registrado en la red viaria con localización y severidad (DGT)."@es ;
+    rdfs:subClassOf prov:Entity , geo:Feature .
+
+ah:accidentDate
+    a owl:DatatypeProperty ;
+    rdfs:label "fecha del accidente"@es ;
+    rdfs:domain ah:RoadAccident ;
+    rdfs:range xsd:date .
+
+ah:accidentYear
+    a owl:DatatypeProperty ;
+    rdfs:label "año del accidente"@es ;
+    rdfs:domain ah:RoadAccident ;
+    rdfs:range xsd:gYear .
+
+ah:accidentSeverity
+    a owl:DatatypeProperty ;
+    rdfs:label "severidad"@es ;
+    rdfs:comment "'fatal', 'serious', 'slight'."@es ;
+    rdfs:domain ah:RoadAccident ;
+    rdfs:range xsd:string .
+
+ah:accidentVictims
+    a owl:DatatypeProperty ;
+    rdfs:label "víctimas"@es ;
+    rdfs:domain ah:RoadAccident ;
+    rdfs:range xsd:integer .
+
+ah:accidentFatalities
+    a owl:DatatypeProperty ;
+    rdfs:label "fallecidos"@es ;
+    rdfs:domain ah:RoadAccident ;
+    rdfs:range xsd:integer .
+
+ah:accidentRoadType
+    a owl:DatatypeProperty ;
+    rdfs:label "tipo de vía"@es ;
+    rdfs:domain ah:RoadAccident ;
+    rdfs:range xsd:string .
+
+ah:occursIn
+    a owl:ObjectProperty ;
+    rdfs:label "ocurre en"@es ;
+    rdfs:comment "Territorio que contiene el accidente (resolución municipal por defecto)."@es ;
+    rdfs:domain ah:RoadAccident ;
+    rdfs:range ah:Territory .
+
+###############################################################################
+# Transporte público (CRTM y operadores compatibles GTFS)                    #
+# TransitStop modela una parada con geometría puntual, TransitRoute una     #
+# línea con identidad estable y modo. servesStop conecta rutas con paradas. #
+###############################################################################
+
+ah:TransitStop
+    a owl:Class ;
+    rdfs:label "Parada de transporte"@es ;
+    rdfs:comment "Parada o estación de la red de transporte público (CRTM/GTFS)."@es ;
+    rdfs:subClassOf geo:Feature .
+
+ah:TransitRoute
+    a owl:Class ;
+    rdfs:label "Ruta de transporte"@es ;
+    rdfs:comment "Línea o ruta de transporte público con identidad estable."@es .
+
+ah:stopName
+    a owl:DatatypeProperty ;
+    rdfs:label "nombre de parada"@es ;
+    rdfs:domain ah:TransitStop ;
+    rdfs:range xsd:string .
+
+ah:stopCode
+    a owl:DatatypeProperty ;
+    rdfs:label "código de parada"@es ;
+    rdfs:domain ah:TransitStop ;
+    rdfs:range xsd:string .
+
+ah:routeShortName
+    a owl:DatatypeProperty ;
+    rdfs:label "nombre corto de ruta"@es ;
+    rdfs:domain ah:TransitRoute ;
+    rdfs:range xsd:string .
+
+ah:routeLongName
+    a owl:DatatypeProperty ;
+    rdfs:label "nombre largo de ruta"@es ;
+    rdfs:domain ah:TransitRoute ;
+    rdfs:range xsd:string .
+
+ah:transitMode
+    a owl:DatatypeProperty ;
+    rdfs:label "modo de transporte"@es ;
+    rdfs:comment "'bus', 'metro', 'tram', 'rail', 'ferry'."@es ;
+    rdfs:domain ah:TransitRoute ;
+    rdfs:range xsd:string .
+
+ah:operator
+    a owl:DatatypeProperty ;
+    rdfs:label "operador"@es ;
+    rdfs:domain ah:TransitRoute ;
+    rdfs:range xsd:string .
+
+ah:locatedIn
+    a owl:ObjectProperty ;
+    rdfs:label "ubicada en"@es ;
+    rdfs:comment "Territorio administrativo que contiene la parada."@es ;
+    rdfs:domain ah:TransitStop ;
+    rdfs:range ah:Territory .
+
+ah:servesStop
+    a owl:ObjectProperty ;
+    rdfs:label "sirve a parada"@es ;
+    rdfs:comment "Conecta una ruta con una parada por la que pasa."@es ;
+    rdfs:domain ah:TransitRoute ;
+    rdfs:range ah:TransitStop .

--- a/ontology/shapes.ttl
+++ b/ontology/shapes.ttl
@@ -7,6 +7,7 @@
 @prefix sf:    <http://www.opengis.net/ont/sf#> .
 @prefix wgs84: <http://www.w3.org/2003/01/geo/wgs84_pos#> .
 @prefix prov:  <http://www.w3.org/ns/prov#> .
+@prefix sosa:  <http://www.w3.org/ns/sosa/> .
 
 ###############################################################################
 # Shapes SHACL reforzadas (v0.2.0 Fase B M8)                                 #
@@ -179,4 +180,162 @@ ah:ObservationProvenanceShape
         sh:maxCount 1 ;
         sh:nodeKind sh:IRI ;
         sh:message "La procedencia de la observación debe apuntar a un IRI de actividad PROV."@es ;
+    ] .
+
+###############################################################################
+# Movilidad / accidentes / transporte (M11)                                  #
+###############################################################################
+
+ah:MobilityFlowShape
+    a sh:NodeShape ;
+    sh:targetClass ah:MobilityFlow ;
+    sh:property [
+        sh:path ah:flowOrigin ;
+        sh:minCount 1 ;
+        sh:class ah:Territory ;
+        sh:message "Todo flujo de movilidad debe declarar un origen territorial."@es ;
+    ] ;
+    sh:property [
+        sh:path ah:flowDestination ;
+        sh:minCount 1 ;
+        sh:class ah:Territory ;
+        sh:message "Todo flujo de movilidad debe declarar un destino territorial."@es ;
+    ] ;
+    sh:property [
+        sh:path ah:flowTrips ;
+        sh:minCount 1 ;
+        sh:datatype xsd:decimal ;
+        sh:minInclusive 0 ;
+        sh:message "El número de viajes debe ser un decimal no negativo."@es ;
+    ] ;
+    sh:property [
+        sh:path ah:period ;
+        sh:minCount 1 ;
+        sh:datatype xsd:string ;
+    ] ;
+    sh:property [
+        sh:path ah:periodYear ;
+        sh:maxCount 1 ;
+        sh:datatype xsd:gYear ;
+    ] ;
+    sh:property [
+        sh:path ah:flowMode ;
+        sh:maxCount 1 ;
+        sh:datatype xsd:string ;
+    ] ;
+    sh:property [
+        sh:path ah:flowDistanceKm ;
+        sh:maxCount 1 ;
+        sh:datatype xsd:decimal ;
+        sh:minInclusive 0 ;
+    ] .
+
+ah:RoadAccidentShape
+    a sh:NodeShape ;
+    sh:targetClass ah:RoadAccident ;
+    sh:property [
+        sh:path dct:identifier ;
+        sh:minCount 1 ;
+        sh:datatype xsd:string ;
+    ] ;
+    sh:property [
+        sh:path ah:accidentSeverity ;
+        sh:minCount 1 ;
+        sh:in ( "fatal" "serious" "slight" ) ;
+        sh:message "La severidad del accidente debe ser fatal, serious o slight."@es ;
+    ] ;
+    sh:property [
+        sh:path ah:accidentYear ;
+        sh:maxCount 1 ;
+        sh:datatype xsd:gYear ;
+    ] ;
+    sh:property [
+        sh:path ah:accidentVictims ;
+        sh:maxCount 1 ;
+        sh:datatype xsd:integer ;
+        sh:minInclusive 0 ;
+    ] ;
+    sh:property [
+        sh:path ah:accidentFatalities ;
+        sh:maxCount 1 ;
+        sh:datatype xsd:integer ;
+        sh:minInclusive 0 ;
+    ] ;
+    sh:property [
+        sh:path ah:hasGeometry ;
+        sh:minCount 1 ;
+        sh:class geo:Geometry ;
+        sh:message "Todo accidente debe tener al menos una geometría puntual GeoSPARQL."@es ;
+    ] ;
+    sh:property [
+        sh:path wgs84:lat ;
+        sh:maxCount 1 ;
+        sh:datatype xsd:decimal ;
+        sh:minInclusive -90 ;
+        sh:maxInclusive 90 ;
+    ] ;
+    sh:property [
+        sh:path wgs84:long ;
+        sh:maxCount 1 ;
+        sh:datatype xsd:decimal ;
+        sh:minInclusive -180 ;
+        sh:maxInclusive 180 ;
+    ] .
+
+ah:TransitStopShape
+    a sh:NodeShape ;
+    sh:targetClass ah:TransitStop ;
+    sh:property [
+        sh:path dct:identifier ;
+        sh:minCount 1 ;
+        sh:datatype xsd:string ;
+    ] ;
+    sh:property [
+        sh:path rdfs:label ;
+        sh:minCount 1 ;
+    ] ;
+    sh:property [
+        sh:path ah:hasGeometry ;
+        sh:minCount 1 ;
+        sh:class geo:Geometry ;
+        sh:message "Toda parada de transporte debe tener una geometría puntual."@es ;
+    ] ;
+    sh:property [
+        sh:path wgs84:lat ;
+        sh:maxCount 1 ;
+        sh:datatype xsd:decimal ;
+        sh:minInclusive -90 ;
+        sh:maxInclusive 90 ;
+    ] ;
+    sh:property [
+        sh:path wgs84:long ;
+        sh:maxCount 1 ;
+        sh:datatype xsd:decimal ;
+        sh:minInclusive -180 ;
+        sh:maxInclusive 180 ;
+    ] .
+
+ah:TransitRouteShape
+    a sh:NodeShape ;
+    sh:targetClass ah:TransitRoute ;
+    sh:property [
+        sh:path dct:identifier ;
+        sh:minCount 1 ;
+        sh:datatype xsd:string ;
+    ] ;
+    sh:property [
+        sh:path ah:transitMode ;
+        sh:minCount 1 ;
+        sh:in ( "bus" "metro" "tram" "rail" "ferry" "cable" "funicular" ) ;
+        sh:message "El modo de transporte debe ser uno de los modos GTFS soportados."@es ;
+    ] ;
+    sh:property [
+        sh:path ah:routeShortName ;
+        sh:maxCount 1 ;
+        sh:datatype xsd:string ;
+    ] ;
+    sh:property [
+        sh:path ah:routeLongName ;
+        sh:maxCount 1 ;
+        sh:datatype xsd:string ;
     ] .


### PR DESCRIPTION
Clases `ah:MobilityFlow`, `ah:RoadAccident`, `ah:TransitStop`, `ah:TransitRoute` alineadas con SOSA/QB/GeoSPARQL/PROV-O. 4 consultas SPARQL nuevas (mobility_flow_between, accidents_in_radius, transit_stops_in_municipality, risk_index). 406 tests verde, SHACL conforma.

Closes #105, #106