### PR TITLE
feat(api): endpoints /mobility, /accidents, /transit con paginación y filtros

### DIFF
--- a/apps/api/src/atlashabita/application/__init__.py
+++ b/apps/api/src/atlashabita/application/__init__.py
@@ -13,9 +13,12 @@ from atlashabita.application.use_cases import (
     GetMapLayerUseCase,
     GetQualityReportUseCase,
     GetTerritoryDetailUseCase,
+    ListAccidentsUseCase,
     ListMapLayersUseCase,
+    ListMobilityUseCase,
     ListProfilesUseCase,
     ListSourcesUseCase,
+    ListTransitUseCase,
     SearchTerritoriesUseCase,
 )
 
@@ -25,9 +28,12 @@ __all__ = [
     "GetMapLayerUseCase",
     "GetQualityReportUseCase",
     "GetTerritoryDetailUseCase",
+    "ListAccidentsUseCase",
     "ListMapLayersUseCase",
+    "ListMobilityUseCase",
     "ListProfilesUseCase",
     "ListSourcesUseCase",
+    "ListTransitUseCase",
     "ScoringService",
     "SearchTerritoriesUseCase",
 ]

--- a/apps/api/src/atlashabita/application/container.py
+++ b/apps/api/src/atlashabita/application/container.py
@@ -20,9 +20,12 @@ from atlashabita.application.use_cases import (
     GetMapLayerUseCase,
     GetQualityReportUseCase,
     GetTerritoryDetailUseCase,
+    ListAccidentsUseCase,
     ListMapLayersUseCase,
+    ListMobilityUseCase,
     ListProfilesUseCase,
     ListSourcesUseCase,
+    ListTransitUseCase,
     SearchTerritoriesUseCase,
 )
 from atlashabita.application.use_cases.export_rdf import ExportRdfUseCase
@@ -168,3 +171,21 @@ class Container:
     def export_rdf(self) -> ExportRdfUseCase:
         """Caso de uso de exportación del grafo RDF en distintos formatos."""
         return ExportRdfUseCase(graph=self.graph, settings=self._settings)
+
+    @cached_property
+    def list_mobility(self) -> ListMobilityUseCase:
+        """Lectura del CSV de flujos de movilidad MITMA."""
+        return ListMobilityUseCase(seed_dir=self._settings.data_zone("seed"))
+
+    @cached_property
+    def list_accidents(self) -> ListAccidentsUseCase:
+        """Lectura del CSV de accidentes DGT y cálculo de riesgo."""
+        return ListAccidentsUseCase(
+            seed_dir=self._settings.data_zone("seed"),
+            dataset=self.dataset,
+        )
+
+    @cached_property
+    def list_transit(self) -> ListTransitUseCase:
+        """Lectura del CSV de paradas de transporte público."""
+        return ListTransitUseCase(seed_dir=self._settings.data_zone("seed"))

--- a/apps/api/src/atlashabita/application/use_cases/__init__.py
+++ b/apps/api/src/atlashabita/application/use_cases/__init__.py
@@ -10,9 +10,12 @@ from atlashabita.application.use_cases.compute_rankings import ComputeRankingsUs
 from atlashabita.application.use_cases.get_map_layer import GetMapLayerUseCase
 from atlashabita.application.use_cases.get_quality_report import GetQualityReportUseCase
 from atlashabita.application.use_cases.get_territory_detail import GetTerritoryDetailUseCase
+from atlashabita.application.use_cases.list_accidents import ListAccidentsUseCase
 from atlashabita.application.use_cases.list_map_layers import ListMapLayersUseCase
+from atlashabita.application.use_cases.list_mobility import ListMobilityUseCase
 from atlashabita.application.use_cases.list_profiles import ListProfilesUseCase
 from atlashabita.application.use_cases.list_sources import ListSourcesUseCase
+from atlashabita.application.use_cases.list_transit import ListTransitUseCase
 from atlashabita.application.use_cases.search_territories import SearchTerritoriesUseCase
 
 __all__ = [
@@ -20,8 +23,11 @@ __all__ = [
     "GetMapLayerUseCase",
     "GetQualityReportUseCase",
     "GetTerritoryDetailUseCase",
+    "ListAccidentsUseCase",
     "ListMapLayersUseCase",
+    "ListMobilityUseCase",
     "ListProfilesUseCase",
     "ListSourcesUseCase",
+    "ListTransitUseCase",
     "SearchTerritoriesUseCase",
 ]

--- a/apps/api/src/atlashabita/application/use_cases/list_accidents.py
+++ b/apps/api/src/atlashabita/application/use_cases/list_accidents.py
@@ -1,0 +1,198 @@
+"""Casos de uso para datos de accidentes (DGT y derivados).
+
+Lee el CSV ``data/seed/accidents.csv`` (cuando exista) y expone:
+
+- Listado por territorio.
+- Indicador de riesgo agregado (accidentes por 1.000 habitantes).
+
+Si el CSV todavía no se ha publicado, los métodos degradan a respuestas
+neutras (lista vacía y riesgo cero) acompañados de un log informativo.
+"""
+
+from __future__ import annotations
+
+import csv
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from atlashabita.infrastructure.ingestion import SeedDataset
+from atlashabita.observability import get_logger
+
+logger = get_logger(__name__)
+
+
+REQUIRED_COLUMNS: tuple[str, ...] = (
+    "territory_id",
+    "period",
+    "accidents",
+)
+OPTIONAL_COLUMNS: tuple[str, ...] = (
+    "fatalities",
+    "injuries",
+    "severity",
+    "source_id",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class AccidentRecord:
+    """Registro normalizado de accidentes."""
+
+    territory_id: str
+    period: str
+    accidents: float
+    fatalities: float | None
+    injuries: float | None
+    severity: str | None
+    source_id: str | None
+
+    def to_public(self) -> dict[str, Any]:
+        return {
+            "territory_id": self.territory_id,
+            "period": self.period,
+            "accidents": self.accidents,
+            "fatalities": self.fatalities,
+            "injuries": self.injuries,
+            "severity": self.severity,
+            "source_id": self.source_id,
+        }
+
+
+class ListAccidentsUseCase:
+    """Lee el CSV de accidentes y calcula indicadores derivados."""
+
+    def __init__(self, seed_dir: Path, dataset: SeedDataset) -> None:
+        self._seed_dir = seed_dir
+        self._dataset = dataset
+        self._cache: tuple[AccidentRecord, ...] | None = None
+
+    @property
+    def csv_path(self) -> Path:
+        return self._seed_dir / "accidents.csv"
+
+    def list_records(
+        self,
+        *,
+        territory_id: str | None = None,
+        period: str | None = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> list[dict[str, Any]]:
+        """Lista accidentes filtrados, paginados y serializables."""
+        records = self._load()
+        filtered = [
+            record
+            for record in records
+            if (territory_id is None or record.territory_id == territory_id)
+            and (period is None or record.period == period)
+        ]
+        bounded = filtered[offset : offset + limit]
+        return [record.to_public() for record in bounded]
+
+    def count_records(
+        self,
+        *,
+        territory_id: str | None = None,
+        period: str | None = None,
+    ) -> int:
+        records = self._load()
+        return sum(
+            1
+            for record in records
+            if (territory_id is None or record.territory_id == territory_id)
+            and (period is None or record.period == period)
+        )
+
+    def risk(self, territory_id: str) -> dict[str, Any]:
+        """Indicador de riesgo: accidentes por 1.000 habitantes y agregados.
+
+        Si no hay datos para el territorio, devuelve un payload coherente
+        con valores cero para que la pantalla técnica pueda renderizar la
+        ficha sin manejar nulos.
+        """
+        records = [r for r in self._load() if r.territory_id == territory_id]
+        accidents = sum(r.accidents for r in records)
+        fatalities = sum((r.fatalities or 0.0) for r in records)
+        injuries = sum((r.injuries or 0.0) for r in records)
+        territory = self._dataset.get_territory(territory_id)
+        population = territory.population if territory else None
+
+        accidents_per_1000 = round(accidents / population * 1000, 4) if population else None
+        fatalities_per_1000 = round(fatalities / population * 1000, 4) if population else None
+
+        return {
+            "territory_id": territory_id,
+            "accidents": accidents,
+            "fatalities": fatalities,
+            "injuries": injuries,
+            "population": population,
+            "accidents_per_1000": accidents_per_1000,
+            "fatalities_per_1000": fatalities_per_1000,
+            "records": len(records),
+        }
+
+    def _load(self) -> tuple[AccidentRecord, ...]:
+        if self._cache is not None:
+            return self._cache
+        path = self.csv_path
+        if not path.exists():
+            logger.info(
+                "accidents.csv_missing",
+                path=str(path),
+                hint="El CSV todavía no se ha publicado; se devuelve lista vacía.",
+            )
+            self._cache = ()
+            return self._cache
+        records: list[AccidentRecord] = []
+        with path.open(encoding="utf-8", newline="") as handle:
+            reader = csv.DictReader(handle)
+            columns = set(reader.fieldnames or [])
+            missing = [c for c in REQUIRED_COLUMNS if c not in columns]
+            if missing:
+                raise ValueError(f"accidents.csv: columnas obligatorias ausentes: {missing}")
+            for index, row in enumerate(reader, start=2):
+                records.append(_parse_row(row, index))
+        self._cache = tuple(records)
+        logger.info("accidents.csv_loaded", path=str(path), rows=len(records))
+        return self._cache
+
+
+def _parse_row(row: dict[str, str], number: int) -> AccidentRecord:
+    try:
+        accidents = float((row.get("accidents") or "0").strip() or "0")
+    except ValueError as exc:
+        raise ValueError(
+            f"accidents.csv fila {number}: 'accidents' no es decimal: {row.get('accidents')!r}"
+        ) from exc
+    return AccidentRecord(
+        territory_id=(row.get("territory_id") or "").strip(),
+        period=(row.get("period") or "").strip(),
+        accidents=accidents,
+        fatalities=_optional_float(row, "fatalities", number),
+        injuries=_optional_float(row, "injuries", number),
+        severity=_optional_str(row.get("severity")),
+        source_id=_optional_str(row.get("source_id")),
+    )
+
+
+def _optional_str(value: str | None) -> str | None:
+    if value is None:
+        return None
+    stripped = value.strip()
+    return stripped or None
+
+
+def _optional_float(row: dict[str, str], column: str, number: int) -> float | None:
+    raw = (row.get(column) or "").strip()
+    if not raw:
+        return None
+    try:
+        return float(raw)
+    except ValueError as exc:
+        raise ValueError(
+            f"accidents.csv fila {number}: columna {column!r} no es decimal: {raw!r}"
+        ) from exc
+
+
+__all__ = ["AccidentRecord", "ListAccidentsUseCase"]

--- a/apps/api/src/atlashabita/application/use_cases/list_mobility.py
+++ b/apps/api/src/atlashabita/application/use_cases/list_mobility.py
@@ -1,0 +1,208 @@
+"""Casos de uso para datos de movilidad (MITMA y derivados).
+
+Lee el CSV ``data/seed/mobility_flows.csv`` (cuando exista) y expone:
+
+- Listado de flujos origen-destino filtrable por origen, destino y periodo.
+- Resumen agregado por territorio: viajes entrantes, salientes y top
+  origen/destino.
+
+El CSV es propiedad del Teammate 1 (issue de datasets) y puede no estar
+presente todavía. En ese caso degradamos a una respuesta vacía con un log
+informativo: el endpoint sigue devolviendo 200 sin reventar.
+"""
+
+from __future__ import annotations
+
+import csv
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from atlashabita.observability import get_logger
+
+logger = get_logger(__name__)
+
+
+REQUIRED_COLUMNS: tuple[str, ...] = (
+    "origin_id",
+    "destination_id",
+    "period",
+    "trips",
+)
+OPTIONAL_COLUMNS: tuple[str, ...] = (
+    "mode",
+    "purpose",
+    "source_id",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class MobilityFlow:
+    """Flujo origen-destino normalizado en memoria."""
+
+    origin_id: str
+    destination_id: str
+    period: str
+    trips: float
+    mode: str | None
+    purpose: str | None
+    source_id: str | None
+
+    def to_public(self) -> dict[str, Any]:
+        """Proyección JSON-serializable expuesta por la API."""
+        return {
+            "origin_id": self.origin_id,
+            "destination_id": self.destination_id,
+            "period": self.period,
+            "trips": self.trips,
+            "mode": self.mode,
+            "purpose": self.purpose,
+            "source_id": self.source_id,
+        }
+
+
+class ListMobilityUseCase:
+    """Lee el CSV de movilidad y lo proyecta hacia la API.
+
+    El loader es perezoso: la primera lectura se cachea y las subsiguientes
+    consultas filtran sobre la lista en memoria. Si el CSV no existe se
+    cachea una lista vacía y se loguea el motivo, evitando spam.
+    """
+
+    def __init__(self, seed_dir: Path) -> None:
+        self._seed_dir = seed_dir
+        self._cache: tuple[MobilityFlow, ...] | None = None
+
+    @property
+    def csv_path(self) -> Path:
+        """Ruta esperada del CSV de movilidad."""
+        return self._seed_dir / "mobility_flows.csv"
+
+    def list_flows(
+        self,
+        *,
+        origin: str | None = None,
+        destination: str | None = None,
+        period: str | None = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> list[dict[str, Any]]:
+        """Lista flujos filtrados, paginados y serializables."""
+        flows = self._load()
+        filtered = [
+            flow
+            for flow in flows
+            if (origin is None or flow.origin_id == origin)
+            and (destination is None or flow.destination_id == destination)
+            and (period is None or flow.period == period)
+        ]
+        bounded = filtered[offset : offset + limit]
+        return [flow.to_public() for flow in bounded]
+
+    def count_flows(
+        self,
+        *,
+        origin: str | None = None,
+        destination: str | None = None,
+        period: str | None = None,
+    ) -> int:
+        """Total de flujos que cumplen los filtros (para metadata de paginación)."""
+        flows = self._load()
+        return sum(
+            1
+            for flow in flows
+            if (origin is None or flow.origin_id == origin)
+            and (destination is None or flow.destination_id == destination)
+            and (period is None or flow.period == period)
+        )
+
+    def summary(self, territory_id: str) -> dict[str, Any]:
+        """Resumen agregado de movilidad para un territorio.
+
+        Devuelve el total de viajes con origen y destino en el territorio,
+        más el top de pares origen/destino. Si no hay datos, devuelve ceros
+        con listas vacías para que la pantalla técnica pueda mostrar el
+        estado "sin datos" sin tratamientos especiales en el frontend.
+        """
+        flows = self._load()
+        outgoing = [flow for flow in flows if flow.origin_id == territory_id]
+        incoming = [flow for flow in flows if flow.destination_id == territory_id]
+
+        total_outgoing = sum(flow.trips for flow in outgoing)
+        total_incoming = sum(flow.trips for flow in incoming)
+
+        top_destinations = self._top_pairs(outgoing, key="destination_id")
+        top_origins = self._top_pairs(incoming, key="origin_id")
+
+        return {
+            "territory_id": territory_id,
+            "total_outgoing_trips": total_outgoing,
+            "total_incoming_trips": total_incoming,
+            "outgoing_flows": len(outgoing),
+            "incoming_flows": len(incoming),
+            "top_destinations": top_destinations,
+            "top_origins": top_origins,
+        }
+
+    def _top_pairs(
+        self, flows: list[MobilityFlow], *, key: str, top: int = 5
+    ) -> list[dict[str, Any]]:
+        accumulator: dict[str, float] = {}
+        for flow in flows:
+            target = getattr(flow, key)
+            accumulator[target] = accumulator.get(target, 0.0) + flow.trips
+        ranked = sorted(accumulator.items(), key=lambda item: item[1], reverse=True)
+        return [{"territory_id": territory, "trips": value} for territory, value in ranked[:top]]
+
+    def _load(self) -> tuple[MobilityFlow, ...]:
+        if self._cache is not None:
+            return self._cache
+        path = self.csv_path
+        if not path.exists():
+            logger.info(
+                "mobility.csv_missing",
+                path=str(path),
+                hint="El CSV todavía no se ha publicado; se devuelve lista vacía.",
+            )
+            self._cache = ()
+            return self._cache
+        flows: list[MobilityFlow] = []
+        with path.open(encoding="utf-8", newline="") as handle:
+            reader = csv.DictReader(handle)
+            columns = set(reader.fieldnames or [])
+            missing = [c for c in REQUIRED_COLUMNS if c not in columns]
+            if missing:
+                raise ValueError(f"mobility_flows.csv: columnas obligatorias ausentes: {missing}")
+            for index, row in enumerate(reader, start=2):
+                flows.append(_parse_row(row, index))
+        self._cache = tuple(flows)
+        logger.info("mobility.csv_loaded", path=str(path), rows=len(flows))
+        return self._cache
+
+
+def _parse_row(row: dict[str, str], number: int) -> MobilityFlow:
+    try:
+        trips = float((row.get("trips") or "0").strip() or "0")
+    except ValueError as exc:
+        raise ValueError(
+            f"mobility_flows.csv fila {number}: 'trips' no es decimal: {row.get('trips')!r}"
+        ) from exc
+    return MobilityFlow(
+        origin_id=(row.get("origin_id") or "").strip(),
+        destination_id=(row.get("destination_id") or "").strip(),
+        period=(row.get("period") or "").strip(),
+        trips=trips,
+        mode=_optional(row.get("mode")),
+        purpose=_optional(row.get("purpose")),
+        source_id=_optional(row.get("source_id")),
+    )
+
+
+def _optional(value: str | None) -> str | None:
+    if value is None:
+        return None
+    stripped = value.strip()
+    return stripped or None
+
+
+__all__ = ["ListMobilityUseCase", "MobilityFlow"]

--- a/apps/api/src/atlashabita/application/use_cases/list_transit.py
+++ b/apps/api/src/atlashabita/application/use_cases/list_transit.py
@@ -1,0 +1,155 @@
+"""Caso de uso para datos de transporte público (paradas y líneas).
+
+Lee el CSV ``data/seed/transit_stops.csv`` (cuando exista) y expone el
+listado paginable filtrable por territorio. Si el CSV todavía no se ha
+publicado, devuelve lista vacía con log informativo.
+"""
+
+from __future__ import annotations
+
+import csv
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from atlashabita.observability import get_logger
+
+logger = get_logger(__name__)
+
+
+REQUIRED_COLUMNS: tuple[str, ...] = (
+    "stop_id",
+    "territory_id",
+    "name",
+    "lat",
+    "lon",
+)
+OPTIONAL_COLUMNS: tuple[str, ...] = (
+    "modes",
+    "operator",
+    "lines",
+    "source_id",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class TransitStop:
+    """Parada de transporte público normalizada."""
+
+    stop_id: str
+    territory_id: str
+    name: str
+    lat: float
+    lon: float
+    modes: tuple[str, ...]
+    operator: str | None
+    lines: tuple[str, ...]
+    source_id: str | None
+
+    def to_public(self) -> dict[str, Any]:
+        return {
+            "stop_id": self.stop_id,
+            "territory_id": self.territory_id,
+            "name": self.name,
+            "lat": self.lat,
+            "lon": self.lon,
+            "modes": list(self.modes),
+            "operator": self.operator,
+            "lines": list(self.lines),
+            "source_id": self.source_id,
+        }
+
+
+class ListTransitUseCase:
+    """Lee el CSV de paradas y proyecta hacia la API."""
+
+    def __init__(self, seed_dir: Path) -> None:
+        self._seed_dir = seed_dir
+        self._cache: tuple[TransitStop, ...] | None = None
+
+    @property
+    def csv_path(self) -> Path:
+        return self._seed_dir / "transit_stops.csv"
+
+    def list_stops(
+        self,
+        *,
+        territory_id: str | None = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> list[dict[str, Any]]:
+        """Lista paradas filtradas, paginadas y serializables."""
+        stops = self._load()
+        filtered = [
+            stop for stop in stops if territory_id is None or stop.territory_id == territory_id
+        ]
+        bounded = filtered[offset : offset + limit]
+        return [stop.to_public() for stop in bounded]
+
+    def count_stops(self, *, territory_id: str | None = None) -> int:
+        stops = self._load()
+        return sum(1 for stop in stops if territory_id is None or stop.territory_id == territory_id)
+
+    def _load(self) -> tuple[TransitStop, ...]:
+        if self._cache is not None:
+            return self._cache
+        path = self.csv_path
+        if not path.exists():
+            logger.info(
+                "transit.csv_missing",
+                path=str(path),
+                hint="El CSV todavía no se ha publicado; se devuelve lista vacía.",
+            )
+            self._cache = ()
+            return self._cache
+        stops: list[TransitStop] = []
+        with path.open(encoding="utf-8", newline="") as handle:
+            reader = csv.DictReader(handle)
+            columns = set(reader.fieldnames or [])
+            missing = [c for c in REQUIRED_COLUMNS if c not in columns]
+            if missing:
+                raise ValueError(f"transit_stops.csv: columnas obligatorias ausentes: {missing}")
+            for index, row in enumerate(reader, start=2):
+                stops.append(_parse_row(row, index))
+        self._cache = tuple(stops)
+        logger.info("transit.csv_loaded", path=str(path), rows=len(stops))
+        return self._cache
+
+
+def _parse_row(row: dict[str, str], number: int) -> TransitStop:
+    try:
+        lat = float((row.get("lat") or "0").strip() or "0")
+        lon = float((row.get("lon") or "0").strip() or "0")
+    except ValueError as exc:
+        raise ValueError(f"transit_stops.csv fila {number}: lat/lon no son decimales") from exc
+    return TransitStop(
+        stop_id=(row.get("stop_id") or "").strip(),
+        territory_id=(row.get("territory_id") or "").strip(),
+        name=(row.get("name") or "").strip(),
+        lat=lat,
+        lon=lon,
+        modes=_split(row.get("modes")),
+        operator=_optional_str(row.get("operator")),
+        lines=_split(row.get("lines")),
+        source_id=_optional_str(row.get("source_id")),
+    )
+
+
+def _split(value: str | None) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    cleaned = value.strip()
+    if not cleaned:
+        return ()
+    separator = "|" if "|" in cleaned else ","
+    return tuple(token.strip() for token in cleaned.split(separator) if token.strip())
+
+
+def _optional_str(value: str | None) -> str | None:
+    if value is None:
+        return None
+    stripped = value.strip()
+    return stripped or None
+
+
+__all__ = ["ListTransitUseCase", "TransitStop"]

--- a/apps/api/src/atlashabita/interfaces/api/app.py
+++ b/apps/api/src/atlashabita/interfaces/api/app.py
@@ -21,8 +21,10 @@ from atlashabita.interfaces.api.middleware import (
     SecurityHeadersMiddleware,
 )
 from atlashabita.interfaces.api.routers import (
+    accidents,
     health,
     map_layers,
+    mobility,
     profiles,
     quality,
     rankings,
@@ -30,6 +32,7 @@ from atlashabita.interfaces.api.routers import (
     sources,
     sparql,
     territories,
+    transit,
 )
 from atlashabita.observability import configure_logging, get_logger
 from atlashabita.observability.errors import DomainError
@@ -97,3 +100,6 @@ def _register_routers(app: FastAPI) -> None:
     app.include_router(quality.router)
     app.include_router(sparql.router)
     app.include_router(rdf_export.router)
+    app.include_router(mobility.router)
+    app.include_router(accidents.router)
+    app.include_router(transit.router)

--- a/apps/api/src/atlashabita/interfaces/api/routers/accidents.py
+++ b/apps/api/src/atlashabita/interfaces/api/routers/accidents.py
@@ -1,0 +1,79 @@
+"""Router HTTP para datos de accidentes (DGT y derivados).
+
+Expone:
+
+- ``GET /accidents``: lista paginada filtrable por territorio y periodo.
+- ``GET /accidents/risk``: indicador de riesgo por territorio (accidentes
+  por 1.000 habitantes y agregados de víctimas).
+
+El router delega en :class:`ListAccidentsUseCase` y mantiene el sobre de
+respuesta consistente con el resto de la API (``items`` + ``pagination``).
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Any
+
+from fastapi import APIRouter, Depends, Query
+
+from atlashabita.application.container import Container
+from atlashabita.config import Settings
+from atlashabita.interfaces.api.deps import get_container, get_settings
+
+router = APIRouter(prefix="/accidents", tags=["accidentes"])
+
+ContainerDep = Annotated[Container, Depends(get_container)]
+SettingsDep = Annotated[Settings, Depends(get_settings)]
+
+
+@router.get(
+    "",
+    summary="Listar accidentes por territorio",
+)
+def list_accidents(
+    container: ContainerDep,
+    settings: SettingsDep,
+    territory_id: Annotated[str | None, Query(max_length=120)] = None,
+    period: Annotated[str | None, Query(max_length=40)] = None,
+    limit: Annotated[int, Query(ge=1)] = 50,
+    offset: Annotated[int, Query(ge=0)] = 0,
+) -> dict[str, Any]:
+    """Lista de accidentes filtrable por territorio y periodo, con paginación."""
+    effective_limit = min(limit, settings.request_max_limit)
+    items = container.list_accidents.list_records(
+        territory_id=territory_id,
+        period=period,
+        limit=effective_limit,
+        offset=offset,
+    )
+    total = container.list_accidents.count_records(
+        territory_id=territory_id,
+        period=period,
+    )
+    return {
+        "items": items,
+        "pagination": {
+            "limit": effective_limit,
+            "offset": offset,
+            "total": total,
+        },
+        "filters": {
+            "territory_id": territory_id,
+            "period": period,
+        },
+    }
+
+
+@router.get(
+    "/risk",
+    summary="Indicador de riesgo de accidentes por territorio",
+)
+def get_risk(
+    container: ContainerDep,
+    territory_id: Annotated[str, Query(min_length=1, max_length=120)],
+) -> dict[str, Any]:
+    """Calcula accidentes por 1.000 habitantes y víctimas agregadas."""
+    return container.list_accidents.risk(territory_id)
+
+
+__all__ = ["router"]

--- a/apps/api/src/atlashabita/interfaces/api/routers/mobility.py
+++ b/apps/api/src/atlashabita/interfaces/api/routers/mobility.py
@@ -1,0 +1,88 @@
+"""Router HTTP para datos de movilidad (MITMA y derivados).
+
+Expone dos endpoints de lectura:
+
+- ``GET /mobility/flows``: lista filtrable y paginada de pares O/D.
+- ``GET /mobility/summary``: resumen agregado por territorio.
+
+La salida se construye a partir de :class:`ListMobilityUseCase`. El router
+se mantiene fino: valida la entrada con FastAPI, delega en el caso de uso
+y serializa el resultado con un sobre estable que incluye paginación y
+``total`` para que el panel técnico pueda iterar sin sorpresas.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Any
+
+from fastapi import APIRouter, Depends, Query
+
+from atlashabita.application.container import Container
+from atlashabita.config import Settings
+from atlashabita.interfaces.api.deps import get_container, get_settings
+
+router = APIRouter(prefix="/mobility", tags=["movilidad"])
+
+ContainerDep = Annotated[Container, Depends(get_container)]
+SettingsDep = Annotated[Settings, Depends(get_settings)]
+
+
+@router.get(
+    "/flows",
+    summary="Listar flujos de movilidad O/D",
+)
+def list_flows(
+    container: ContainerDep,
+    settings: SettingsDep,
+    origin: Annotated[str | None, Query(max_length=120)] = None,
+    destination: Annotated[str | None, Query(max_length=120)] = None,
+    period: Annotated[str | None, Query(max_length=40)] = None,
+    limit: Annotated[int, Query(ge=1)] = 50,
+    offset: Annotated[int, Query(ge=0)] = 0,
+) -> dict[str, Any]:
+    """Lista pares origen-destino con filtros opcionales y paginación.
+
+    Si el CSV todavía no se ha publicado el caso de uso degrada a una
+    lista vacía (``total = 0``) sin reventar la API.
+    """
+    effective_limit = min(limit, settings.request_max_limit)
+    items = container.list_mobility.list_flows(
+        origin=origin,
+        destination=destination,
+        period=period,
+        limit=effective_limit,
+        offset=offset,
+    )
+    total = container.list_mobility.count_flows(
+        origin=origin,
+        destination=destination,
+        period=period,
+    )
+    return {
+        "items": items,
+        "pagination": {
+            "limit": effective_limit,
+            "offset": offset,
+            "total": total,
+        },
+        "filters": {
+            "origin": origin,
+            "destination": destination,
+            "period": period,
+        },
+    }
+
+
+@router.get(
+    "/summary",
+    summary="Resumen de movilidad por territorio",
+)
+def get_summary(
+    container: ContainerDep,
+    territory_id: Annotated[str, Query(min_length=1, max_length=120)],
+) -> dict[str, Any]:
+    """Resumen agregado: viajes entrantes/salientes y top O/D del territorio."""
+    return container.list_mobility.summary(territory_id)
+
+
+__all__ = ["router"]

--- a/apps/api/src/atlashabita/interfaces/api/routers/transit.py
+++ b/apps/api/src/atlashabita/interfaces/api/routers/transit.py
@@ -1,0 +1,55 @@
+"""Router HTTP para datos de transporte público (CRTM y derivados).
+
+Expone ``GET /transit/stops``: lista paginable de paradas filtrable por
+territorio. Delega en :class:`ListTransitUseCase`.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Any
+
+from fastapi import APIRouter, Depends, Query
+
+from atlashabita.application.container import Container
+from atlashabita.config import Settings
+from atlashabita.interfaces.api.deps import get_container, get_settings
+
+router = APIRouter(prefix="/transit", tags=["transporte"])
+
+ContainerDep = Annotated[Container, Depends(get_container)]
+SettingsDep = Annotated[Settings, Depends(get_settings)]
+
+
+@router.get(
+    "/stops",
+    summary="Listar paradas de transporte público",
+)
+def list_stops(
+    container: ContainerDep,
+    settings: SettingsDep,
+    territory_id: Annotated[str | None, Query(max_length=120)] = None,
+    limit: Annotated[int, Query(ge=1)] = 50,
+    offset: Annotated[int, Query(ge=0)] = 0,
+) -> dict[str, Any]:
+    """Listado paginado de paradas filtrable por territorio."""
+    effective_limit = min(limit, settings.request_max_limit)
+    items = container.list_transit.list_stops(
+        territory_id=territory_id,
+        limit=effective_limit,
+        offset=offset,
+    )
+    total = container.list_transit.count_stops(territory_id=territory_id)
+    return {
+        "items": items,
+        "pagination": {
+            "limit": effective_limit,
+            "offset": offset,
+            "total": total,
+        },
+        "filters": {
+            "territory_id": territory_id,
+        },
+    }
+
+
+__all__ = ["router"]

--- a/apps/api/tests/test_api_routers_accidents.py
+++ b/apps/api/tests/test_api_routers_accidents.py
@@ -1,0 +1,164 @@
+"""Contrato del router ``/accidents``."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from atlashabita.config import Settings
+from atlashabita.interfaces.api import create_app
+
+
+def _write_seed(seed_dir: Path) -> None:
+    seed_dir.mkdir(parents=True, exist_ok=True)
+    (seed_dir / "territories.csv").write_text(
+        "kind,code,name,parent_code,province_code,autonomous_community_code,lat,lon,population,area_km2\n"
+        "municipality,41091,Sevilla,41,41,01,37.38,-5.99,684234,141.31\n"
+        "municipality,28079,Madrid,28,28,13,40.41,-3.70,3345894,605.77\n",
+        encoding="utf-8",
+    )
+    (seed_dir / "sources.csv").write_text(
+        "id,title,publisher,url,license,periodicity,description,indicators\n"
+        "src,Test,Pub,https://example.org,CC BY 4.0,anual,d,rent_median\n",
+        encoding="utf-8",
+    )
+    (seed_dir / "indicators.csv").write_text(
+        "code,label,unit,direction,description,source_id,min_value,max_value\n"
+        "rent_median,Alquiler,EUR,lower_is_better,d,src,0,1\n",
+        encoding="utf-8",
+    )
+    (seed_dir / "observations.csv").write_text(
+        "indicator_code,territory_id,period,value,source_id,quality\n",
+        encoding="utf-8",
+    )
+    (seed_dir / "profiles.csv").write_text(
+        'id,label,description,weights\nremote,Teletrabajo,d,"{""rent_median"":1.0}"\n',
+        encoding="utf-8",
+    )
+
+
+@pytest.fixture()
+def settings_with_seed(tmp_path: Path) -> Settings:
+    seed_dir = tmp_path / "data" / "seed"
+    _write_seed(seed_dir)
+    (seed_dir / "accidents.csv").write_text(
+        "territory_id,period,accidents,fatalities,injuries,severity,source_id\n"
+        "municipality:41091,2024,150,2,30,light,dgt\n"
+        "municipality:41091,2025,180,3,40,light,dgt\n"
+        "municipality:28079,2025,500,8,80,severe,dgt\n",
+        encoding="utf-8",
+    )
+    return Settings(
+        env="test",
+        data_root=tmp_path / "data",
+        ontology_root=tmp_path / "ontology",
+        rate_limit_rpm=10_000,
+    )
+
+
+@pytest.fixture()
+def settings_without_csv(tmp_path: Path) -> Settings:
+    seed_dir = tmp_path / "data" / "seed"
+    _write_seed(seed_dir)
+    return Settings(
+        env="test",
+        data_root=tmp_path / "data",
+        ontology_root=tmp_path / "ontology",
+        rate_limit_rpm=10_000,
+    )
+
+
+@pytest.fixture()
+def client_with_seed(settings_with_seed: Settings) -> Iterator[TestClient]:
+    app = create_app(settings_with_seed)
+    with TestClient(app) as test_client:
+        yield test_client
+
+
+@pytest.fixture()
+def client_without_csv(settings_without_csv: Settings) -> Iterator[TestClient]:
+    app = create_app(settings_without_csv)
+    with TestClient(app) as test_client:
+        yield test_client
+
+
+def test_listar_accidentes_devuelve_paginacion(client_with_seed: TestClient) -> None:
+    response = client_with_seed.get("/accidents")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["pagination"]["total"] == 3
+    assert len(body["items"]) == 3
+
+
+def test_filtrar_por_territorio(client_with_seed: TestClient) -> None:
+    response = client_with_seed.get("/accidents", params={"territory_id": "municipality:41091"})
+    assert response.status_code == 200
+    body = response.json()
+    assert body["pagination"]["total"] == 2
+    assert all(item["territory_id"] == "municipality:41091" for item in body["items"])
+
+
+def test_filtrar_por_periodo(client_with_seed: TestClient) -> None:
+    response = client_with_seed.get("/accidents", params={"period": "2025"})
+    assert response.status_code == 200
+    body = response.json()
+    assert body["pagination"]["total"] == 2
+
+
+def test_paginacion_offset_limit(client_with_seed: TestClient) -> None:
+    response = client_with_seed.get("/accidents", params={"limit": 1, "offset": 2})
+    assert response.status_code == 200
+    body = response.json()
+    assert len(body["items"]) == 1
+
+
+def test_offset_negativo_devuelve_422(client_with_seed: TestClient) -> None:
+    response = client_with_seed.get("/accidents", params={"offset": -1})
+    assert response.status_code == 422
+
+
+def test_risk_calcula_por_1000(client_with_seed: TestClient) -> None:
+    response = client_with_seed.get(
+        "/accidents/risk", params={"territory_id": "municipality:41091"}
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["accidents"] == 330
+    assert body["fatalities"] == 5
+    assert body["population"] == 684234
+    assert body["accidents_per_1000"] is not None
+
+
+def test_risk_requiere_territory_id(client_with_seed: TestClient) -> None:
+    response = client_with_seed.get("/accidents/risk")
+    assert response.status_code == 422
+
+
+def test_risk_territorio_sin_accidentes(client_with_seed: TestClient) -> None:
+    response = client_with_seed.get(
+        "/accidents/risk", params={"territory_id": "municipality:99999"}
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["accidents"] == 0
+    assert body["fatalities_per_1000"] is None
+
+
+def test_listado_funciona_sin_csv(client_without_csv: TestClient) -> None:
+    response = client_without_csv.get("/accidents")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["items"] == []
+    assert body["pagination"]["total"] == 0
+
+
+def test_risk_funciona_sin_csv(client_without_csv: TestClient) -> None:
+    response = client_without_csv.get(
+        "/accidents/risk", params={"territory_id": "municipality:41091"}
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["accidents"] == 0

--- a/apps/api/tests/test_api_routers_mobility.py
+++ b/apps/api/tests/test_api_routers_mobility.py
@@ -1,0 +1,162 @@
+"""Contrato del router ``/mobility``."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from atlashabita.config import Settings
+from atlashabita.interfaces.api import create_app
+
+
+def _write_seed(seed_dir: Path) -> None:
+    seed_dir.mkdir(parents=True, exist_ok=True)
+    (seed_dir / "territories.csv").write_text(
+        "kind,code,name,parent_code,province_code,autonomous_community_code,lat,lon,population,area_km2\n"
+        "municipality,41091,Sevilla,41,41,01,37.38,-5.99,684234,141.31\n",
+        encoding="utf-8",
+    )
+    (seed_dir / "sources.csv").write_text(
+        "id,title,publisher,url,license,periodicity,description,indicators\n"
+        "src,Test,Pub,https://example.org,CC BY 4.0,anual,d,rent_median\n",
+        encoding="utf-8",
+    )
+    (seed_dir / "indicators.csv").write_text(
+        "code,label,unit,direction,description,source_id,min_value,max_value\n"
+        "rent_median,Alquiler,EUR,lower_is_better,d,src,0,1\n",
+        encoding="utf-8",
+    )
+    (seed_dir / "observations.csv").write_text(
+        "indicator_code,territory_id,period,value,source_id,quality\n",
+        encoding="utf-8",
+    )
+    (seed_dir / "profiles.csv").write_text(
+        'id,label,description,weights\nremote,Teletrabajo,d,"{""rent_median"":1.0}"\n',
+        encoding="utf-8",
+    )
+
+
+@pytest.fixture()
+def settings_with_seed(tmp_path: Path) -> Settings:
+    seed_dir = tmp_path / "data" / "seed"
+    _write_seed(seed_dir)
+    (seed_dir / "mobility_flows.csv").write_text(
+        "origin_id,destination_id,period,trips,mode,purpose,source_id\n"
+        "municipality:41091,municipality:28079,2025,1500.0,car,work,mitma\n"
+        "municipality:41091,municipality:28079,2024,1200.0,car,work,mitma\n"
+        "municipality:28079,municipality:41091,2025,800.0,train,leisure,mitma\n",
+        encoding="utf-8",
+    )
+    return Settings(
+        env="test",
+        data_root=tmp_path / "data",
+        ontology_root=tmp_path / "ontology",
+        rate_limit_rpm=10_000,
+    )
+
+
+@pytest.fixture()
+def settings_without_csv(tmp_path: Path) -> Settings:
+    seed_dir = tmp_path / "data" / "seed"
+    _write_seed(seed_dir)
+    return Settings(
+        env="test",
+        data_root=tmp_path / "data",
+        ontology_root=tmp_path / "ontology",
+        rate_limit_rpm=10_000,
+    )
+
+
+@pytest.fixture()
+def client_with_seed(settings_with_seed: Settings) -> Iterator[TestClient]:
+    app = create_app(settings_with_seed)
+    with TestClient(app) as test_client:
+        yield test_client
+
+
+@pytest.fixture()
+def client_without_csv(settings_without_csv: Settings) -> Iterator[TestClient]:
+    app = create_app(settings_without_csv)
+    with TestClient(app) as test_client:
+        yield test_client
+
+
+def test_listar_flows_devuelve_paginacion(client_with_seed: TestClient) -> None:
+    response = client_with_seed.get("/mobility/flows")
+    assert response.status_code == 200
+    body = response.json()
+    assert "items" in body
+    assert "pagination" in body
+    assert body["pagination"]["total"] == 3
+    assert len(body["items"]) == 3
+
+
+def test_listar_flows_filtra_por_origen(client_with_seed: TestClient) -> None:
+    response = client_with_seed.get("/mobility/flows", params={"origin": "municipality:41091"})
+    assert response.status_code == 200
+    body = response.json()
+    assert body["pagination"]["total"] == 2
+    assert all(item["origin_id"] == "municipality:41091" for item in body["items"])
+
+
+def test_listar_flows_filtra_por_destino_y_periodo(client_with_seed: TestClient) -> None:
+    response = client_with_seed.get(
+        "/mobility/flows",
+        params={"destination": "municipality:28079", "period": "2025"},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["pagination"]["total"] == 1
+    assert body["items"][0]["trips"] == 1500.0
+
+
+def test_listar_flows_pagina(client_with_seed: TestClient) -> None:
+    response = client_with_seed.get("/mobility/flows", params={"limit": 1, "offset": 1})
+    assert response.status_code == 200
+    body = response.json()
+    assert len(body["items"]) == 1
+    assert body["pagination"]["limit"] == 1
+    assert body["pagination"]["offset"] == 1
+
+
+def test_listar_flows_limit_invalido_devuelve_422(client_with_seed: TestClient) -> None:
+    response = client_with_seed.get("/mobility/flows", params={"limit": 0})
+    assert response.status_code == 422
+
+
+def test_summary_devuelve_totales(client_with_seed: TestClient) -> None:
+    response = client_with_seed.get(
+        "/mobility/summary", params={"territory_id": "municipality:41091"}
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["territory_id"] == "municipality:41091"
+    assert body["total_outgoing_trips"] == 2700.0
+    assert body["total_incoming_trips"] == 800.0
+    assert len(body["top_destinations"]) >= 1
+
+
+def test_summary_requiere_territory_id(client_with_seed: TestClient) -> None:
+    response = client_with_seed.get("/mobility/summary")
+    assert response.status_code == 422
+
+
+def test_endpoint_funciona_sin_csv(client_without_csv: TestClient) -> None:
+    response = client_without_csv.get("/mobility/flows")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["items"] == []
+    assert body["pagination"]["total"] == 0
+
+
+def test_summary_funciona_sin_csv(client_without_csv: TestClient) -> None:
+    response = client_without_csv.get(
+        "/mobility/summary", params={"territory_id": "municipality:41091"}
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["total_outgoing_trips"] == 0
+    assert body["top_destinations"] == []

--- a/apps/api/tests/test_api_routers_transit.py
+++ b/apps/api/tests/test_api_routers_transit.py
@@ -1,0 +1,122 @@
+"""Contrato del router ``/transit``."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from atlashabita.config import Settings
+from atlashabita.interfaces.api import create_app
+
+
+def _write_seed(seed_dir: Path) -> None:
+    seed_dir.mkdir(parents=True, exist_ok=True)
+    (seed_dir / "territories.csv").write_text(
+        "kind,code,name,parent_code,province_code,autonomous_community_code,lat,lon,population,area_km2\n"
+        "municipality,41091,Sevilla,41,41,01,37.38,-5.99,684234,141.31\n",
+        encoding="utf-8",
+    )
+    (seed_dir / "sources.csv").write_text(
+        "id,title,publisher,url,license,periodicity,description,indicators\n"
+        "src,Test,Pub,https://example.org,CC BY 4.0,anual,d,rent_median\n",
+        encoding="utf-8",
+    )
+    (seed_dir / "indicators.csv").write_text(
+        "code,label,unit,direction,description,source_id,min_value,max_value\n"
+        "rent_median,Alquiler,EUR,lower_is_better,d,src,0,1\n",
+        encoding="utf-8",
+    )
+    (seed_dir / "observations.csv").write_text(
+        "indicator_code,territory_id,period,value,source_id,quality\n",
+        encoding="utf-8",
+    )
+    (seed_dir / "profiles.csv").write_text(
+        'id,label,description,weights\nremote,Teletrabajo,d,"{""rent_median"":1.0}"\n',
+        encoding="utf-8",
+    )
+
+
+@pytest.fixture()
+def settings_with_seed(tmp_path: Path) -> Settings:
+    seed_dir = tmp_path / "data" / "seed"
+    _write_seed(seed_dir)
+    (seed_dir / "transit_stops.csv").write_text(
+        "stop_id,territory_id,name,lat,lon,modes,operator,lines,source_id\n"
+        "stop:1,municipality:41091,Plaza Nueva,37.388,-5.992,bus|tram,Tussam,C1|C2,crtm\n"
+        "stop:2,municipality:41091,Triana,37.382,-5.998,bus,Tussam,5,crtm\n"
+        "stop:3,municipality:28079,Sol,40.416,-3.703,metro,EMT,1|2|3,crtm\n",
+        encoding="utf-8",
+    )
+    return Settings(
+        env="test",
+        data_root=tmp_path / "data",
+        ontology_root=tmp_path / "ontology",
+        rate_limit_rpm=10_000,
+    )
+
+
+@pytest.fixture()
+def settings_without_csv(tmp_path: Path) -> Settings:
+    seed_dir = tmp_path / "data" / "seed"
+    _write_seed(seed_dir)
+    return Settings(
+        env="test",
+        data_root=tmp_path / "data",
+        ontology_root=tmp_path / "ontology",
+        rate_limit_rpm=10_000,
+    )
+
+
+@pytest.fixture()
+def client_with_seed(settings_with_seed: Settings) -> Iterator[TestClient]:
+    app = create_app(settings_with_seed)
+    with TestClient(app) as test_client:
+        yield test_client
+
+
+@pytest.fixture()
+def client_without_csv(settings_without_csv: Settings) -> Iterator[TestClient]:
+    app = create_app(settings_without_csv)
+    with TestClient(app) as test_client:
+        yield test_client
+
+
+def test_listar_paradas_devuelve_paginacion(client_with_seed: TestClient) -> None:
+    response = client_with_seed.get("/transit/stops")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["pagination"]["total"] == 3
+    assert len(body["items"]) == 3
+    assert body["items"][0]["modes"] == ["bus", "tram"]
+
+
+def test_filtrar_por_territorio(client_with_seed: TestClient) -> None:
+    response = client_with_seed.get("/transit/stops", params={"territory_id": "municipality:41091"})
+    assert response.status_code == 200
+    body = response.json()
+    assert body["pagination"]["total"] == 2
+    assert all(item["territory_id"] == "municipality:41091" for item in body["items"])
+
+
+def test_pagina_correctamente(client_with_seed: TestClient) -> None:
+    response = client_with_seed.get("/transit/stops", params={"limit": 1, "offset": 1})
+    assert response.status_code == 200
+    body = response.json()
+    assert len(body["items"]) == 1
+    assert body["pagination"]["limit"] == 1
+
+
+def test_limit_negativo_devuelve_422(client_with_seed: TestClient) -> None:
+    response = client_with_seed.get("/transit/stops", params={"limit": -1})
+    assert response.status_code == 422
+
+
+def test_funciona_sin_csv(client_without_csv: TestClient) -> None:
+    response = client_without_csv.get("/transit/stops")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["items"] == []
+    assert body["pagination"]["total"] == 0

--- a/apps/api/tests/test_use_case_accidents.py
+++ b/apps/api/tests/test_use_case_accidents.py
@@ -1,0 +1,144 @@
+"""Pruebas unitarias del caso de uso de accidentes."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from atlashabita.application.use_cases.list_accidents import ListAccidentsUseCase
+from atlashabita.domain.territories import GeoPoint, Territory, TerritoryKind
+from atlashabita.infrastructure.ingestion import SeedDataset
+
+
+@pytest.fixture()
+def stub_dataset() -> SeedDataset:
+    """Dataset mínimo con un municipio poblado."""
+    territory = Territory(
+        code="41091",
+        name="Sevilla",
+        kind=TerritoryKind.MUNICIPALITY,
+        parent_code="41",
+        province_code="41",
+        autonomous_community_code="01",
+        centroid=GeoPoint(lat=37.38, lon=-5.99),
+        population=684234,
+        area_km2=141.31,
+    )
+    return SeedDataset(
+        territories=(territory,),
+        sources=(),
+        indicators=(),
+        observations=(),
+        profiles=(),
+    )
+
+
+@pytest.fixture()
+def seed_dir_with_csv(tmp_path: Path) -> Path:
+    seed_dir = tmp_path / "seed"
+    seed_dir.mkdir()
+    csv_content = (
+        "territory_id,period,accidents,fatalities,injuries,severity,source_id\n"
+        "municipality:41091,2024,150,2,30,light,dgt\n"
+        "municipality:41091,2025,180,3,40,light,dgt\n"
+        "municipality:28079,2025,500,8,80,severe,dgt\n"
+    )
+    (seed_dir / "accidents.csv").write_text(csv_content, encoding="utf-8")
+    return seed_dir
+
+
+def test_list_records_sin_csv_vacio(tmp_path: Path, stub_dataset: SeedDataset) -> None:
+    use_case = ListAccidentsUseCase(seed_dir=tmp_path, dataset=stub_dataset)
+    assert use_case.list_records() == []
+    assert use_case.count_records() == 0
+
+
+def test_list_records_devuelve_todos(seed_dir_with_csv: Path, stub_dataset: SeedDataset) -> None:
+    use_case = ListAccidentsUseCase(seed_dir=seed_dir_with_csv, dataset=stub_dataset)
+    rows = use_case.list_records()
+    assert len(rows) == 3
+    assert rows[0]["accidents"] == 150
+    assert rows[0]["severity"] == "light"
+
+
+def test_list_records_filtra_por_territorio(
+    seed_dir_with_csv: Path, stub_dataset: SeedDataset
+) -> None:
+    use_case = ListAccidentsUseCase(seed_dir=seed_dir_with_csv, dataset=stub_dataset)
+    rows = use_case.list_records(territory_id="municipality:41091")
+    assert len(rows) == 2
+    assert all(row["territory_id"] == "municipality:41091" for row in rows)
+
+
+def test_list_records_paginado(seed_dir_with_csv: Path, stub_dataset: SeedDataset) -> None:
+    use_case = ListAccidentsUseCase(seed_dir=seed_dir_with_csv, dataset=stub_dataset)
+    page = use_case.list_records(limit=1, offset=1)
+    assert len(page) == 1
+
+
+def test_count_records_filtra(seed_dir_with_csv: Path, stub_dataset: SeedDataset) -> None:
+    use_case = ListAccidentsUseCase(seed_dir=seed_dir_with_csv, dataset=stub_dataset)
+    assert use_case.count_records(period="2025") == 2
+
+
+def test_risk_calcula_indicadores(seed_dir_with_csv: Path, stub_dataset: SeedDataset) -> None:
+    use_case = ListAccidentsUseCase(seed_dir=seed_dir_with_csv, dataset=stub_dataset)
+    risk = use_case.risk("municipality:41091")
+    assert risk["accidents"] == 330
+    assert risk["fatalities"] == 5
+    assert risk["injuries"] == 70
+    assert risk["population"] == 684234
+    assert risk["accidents_per_1000"] == round(330 / 684234 * 1000, 4)
+    assert risk["fatalities_per_1000"] == round(5 / 684234 * 1000, 4)
+    assert risk["records"] == 2
+
+
+def test_risk_sin_poblacion_devuelve_none(
+    seed_dir_with_csv: Path, stub_dataset: SeedDataset
+) -> None:
+    use_case = ListAccidentsUseCase(seed_dir=seed_dir_with_csv, dataset=stub_dataset)
+    risk = use_case.risk("municipality:28079")
+    assert risk["population"] is None
+    assert risk["accidents_per_1000"] is None
+    assert risk["accidents"] == 500
+
+
+def test_risk_sin_datos_devuelve_ceros(tmp_path: Path, stub_dataset: SeedDataset) -> None:
+    use_case = ListAccidentsUseCase(seed_dir=tmp_path, dataset=stub_dataset)
+    risk = use_case.risk("municipality:99999")
+    assert risk["accidents"] == 0
+    assert risk["fatalities"] == 0
+    assert risk["records"] == 0
+
+
+def test_csv_columna_obligatoria_falta(tmp_path: Path, stub_dataset: SeedDataset) -> None:
+    seed_dir = tmp_path / "seed"
+    seed_dir.mkdir()
+    (seed_dir / "accidents.csv").write_text("territory_id,period\nA,2025\n", encoding="utf-8")
+    use_case = ListAccidentsUseCase(seed_dir=seed_dir, dataset=stub_dataset)
+    with pytest.raises(ValueError, match="accidents"):
+        use_case.list_records()
+
+
+def test_csv_accidents_no_decimal(tmp_path: Path, stub_dataset: SeedDataset) -> None:
+    seed_dir = tmp_path / "seed"
+    seed_dir.mkdir()
+    (seed_dir / "accidents.csv").write_text(
+        "territory_id,period,accidents\nA,2025,bogus\n", encoding="utf-8"
+    )
+    use_case = ListAccidentsUseCase(seed_dir=seed_dir, dataset=stub_dataset)
+    with pytest.raises(ValueError, match="accidents"):
+        use_case.list_records()
+
+
+def test_csv_fatalities_no_decimal(tmp_path: Path, stub_dataset: SeedDataset) -> None:
+    seed_dir = tmp_path / "seed"
+    seed_dir.mkdir()
+    (seed_dir / "accidents.csv").write_text(
+        "territory_id,period,accidents,fatalities\nA,2025,1,bogus\n",
+        encoding="utf-8",
+    )
+    use_case = ListAccidentsUseCase(seed_dir=seed_dir, dataset=stub_dataset)
+    with pytest.raises(ValueError, match="fatalities"):
+        use_case.list_records()

--- a/apps/api/tests/test_use_case_mobility.py
+++ b/apps/api/tests/test_use_case_mobility.py
@@ -1,0 +1,114 @@
+"""Pruebas unitarias del caso de uso de movilidad."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from atlashabita.application.use_cases.list_mobility import ListMobilityUseCase
+
+
+@pytest.fixture()
+def seed_dir_with_csv(tmp_path: Path) -> Path:
+    seed_dir = tmp_path / "seed"
+    seed_dir.mkdir()
+    csv_content = (
+        "origin_id,destination_id,period,trips,mode,purpose,source_id\n"
+        "municipality:41091,municipality:28079,2025,1500.0,car,work,mitma\n"
+        "municipality:41091,municipality:28079,2024,1200.0,car,work,mitma\n"
+        "municipality:28079,municipality:41091,2025,800.0,train,leisure,mitma\n"
+        "municipality:46250,municipality:41091,2025,300.0,bus,work,mitma\n"
+    )
+    (seed_dir / "mobility_flows.csv").write_text(csv_content, encoding="utf-8")
+    return seed_dir
+
+
+def test_list_flows_sin_csv_devuelve_vacio(tmp_path: Path) -> None:
+    use_case = ListMobilityUseCase(seed_dir=tmp_path)
+    assert use_case.list_flows() == []
+    assert use_case.count_flows() == 0
+
+
+def test_list_flows_devuelve_todos_los_pares(seed_dir_with_csv: Path) -> None:
+    use_case = ListMobilityUseCase(seed_dir=seed_dir_with_csv)
+    flows = use_case.list_flows()
+    assert len(flows) == 4
+    assert flows[0]["origin_id"] == "municipality:41091"
+    assert flows[0]["trips"] == 1500.0
+
+
+def test_list_flows_filtra_por_origen(seed_dir_with_csv: Path) -> None:
+    use_case = ListMobilityUseCase(seed_dir=seed_dir_with_csv)
+    flows = use_case.list_flows(origin="municipality:46250")
+    assert len(flows) == 1
+    assert flows[0]["destination_id"] == "municipality:41091"
+
+
+def test_list_flows_filtra_por_destino_y_periodo(seed_dir_with_csv: Path) -> None:
+    use_case = ListMobilityUseCase(seed_dir=seed_dir_with_csv)
+    flows = use_case.list_flows(destination="municipality:28079", period="2025")
+    assert len(flows) == 1
+    assert flows[0]["trips"] == 1500.0
+
+
+def test_list_flows_pagina_correctamente(seed_dir_with_csv: Path) -> None:
+    use_case = ListMobilityUseCase(seed_dir=seed_dir_with_csv)
+    page = use_case.list_flows(limit=2, offset=1)
+    assert len(page) == 2
+
+
+def test_count_flows_aplica_filtros(seed_dir_with_csv: Path) -> None:
+    use_case = ListMobilityUseCase(seed_dir=seed_dir_with_csv)
+    assert use_case.count_flows(origin="municipality:41091") == 2
+    assert use_case.count_flows(period="2025") == 3
+
+
+def test_summary_devuelve_totales_y_top(seed_dir_with_csv: Path) -> None:
+    use_case = ListMobilityUseCase(seed_dir=seed_dir_with_csv)
+    summary = use_case.summary("municipality:41091")
+    assert summary["territory_id"] == "municipality:41091"
+    assert summary["total_outgoing_trips"] == 2700.0
+    assert summary["total_incoming_trips"] == 1100.0
+    assert summary["outgoing_flows"] == 2
+    assert summary["incoming_flows"] == 2
+    assert summary["top_destinations"][0]["territory_id"] == "municipality:28079"
+    assert summary["top_origins"][0]["trips"] == 800.0
+
+
+def test_summary_sin_datos_devuelve_ceros(tmp_path: Path) -> None:
+    use_case = ListMobilityUseCase(seed_dir=tmp_path)
+    summary = use_case.summary("municipality:99999")
+    assert summary["total_outgoing_trips"] == 0
+    assert summary["total_incoming_trips"] == 0
+    assert summary["top_destinations"] == []
+
+
+def test_csv_columna_obligatoria_falta(tmp_path: Path) -> None:
+    seed_dir = tmp_path / "seed"
+    seed_dir.mkdir()
+    (seed_dir / "mobility_flows.csv").write_text(
+        "origin_id,destination_id,period\nA,B,2025\n", encoding="utf-8"
+    )
+    use_case = ListMobilityUseCase(seed_dir=seed_dir)
+    with pytest.raises(ValueError, match="trips"):
+        use_case.list_flows()
+
+
+def test_csv_trips_no_decimal(tmp_path: Path) -> None:
+    seed_dir = tmp_path / "seed"
+    seed_dir.mkdir()
+    (seed_dir / "mobility_flows.csv").write_text(
+        "origin_id,destination_id,period,trips\nA,B,2025,not_a_number\n",
+        encoding="utf-8",
+    )
+    use_case = ListMobilityUseCase(seed_dir=seed_dir)
+    with pytest.raises(ValueError, match="trips"):
+        use_case.list_flows()
+
+
+def test_cache_se_reutiliza_entre_llamadas(seed_dir_with_csv: Path) -> None:
+    use_case = ListMobilityUseCase(seed_dir=seed_dir_with_csv)
+    primero = use_case.list_flows()
+    segundo = use_case.list_flows()
+    assert primero == segundo

--- a/apps/api/tests/test_use_case_transit.py
+++ b/apps/api/tests/test_use_case_transit.py
@@ -1,0 +1,99 @@
+"""Pruebas unitarias del caso de uso de transporte público."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from atlashabita.application.use_cases.list_transit import ListTransitUseCase
+
+
+@pytest.fixture()
+def seed_dir_with_csv(tmp_path: Path) -> Path:
+    seed_dir = tmp_path / "seed"
+    seed_dir.mkdir()
+    csv_content = (
+        "stop_id,territory_id,name,lat,lon,modes,operator,lines,source_id\n"
+        "stop:1,municipality:41091,Plaza Nueva,37.388,-5.992,bus|tram,Tussam,C1|C2,crtm\n"
+        "stop:2,municipality:41091,Triana,37.382,-5.998,bus,Tussam,5,crtm\n"
+        "stop:3,municipality:28079,Sol,40.416,-3.703,metro,EMT,1|2|3,crtm\n"
+    )
+    (seed_dir / "transit_stops.csv").write_text(csv_content, encoding="utf-8")
+    return seed_dir
+
+
+def test_list_stops_sin_csv_vacio(tmp_path: Path) -> None:
+    use_case = ListTransitUseCase(seed_dir=tmp_path)
+    assert use_case.list_stops() == []
+    assert use_case.count_stops() == 0
+
+
+def test_list_stops_devuelve_todas(seed_dir_with_csv: Path) -> None:
+    use_case = ListTransitUseCase(seed_dir=seed_dir_with_csv)
+    stops = use_case.list_stops()
+    assert len(stops) == 3
+    assert stops[0]["stop_id"] == "stop:1"
+    assert stops[0]["modes"] == ["bus", "tram"]
+    assert stops[0]["lines"] == ["C1", "C2"]
+
+
+def test_list_stops_filtra_por_territorio(seed_dir_with_csv: Path) -> None:
+    use_case = ListTransitUseCase(seed_dir=seed_dir_with_csv)
+    stops = use_case.list_stops(territory_id="municipality:41091")
+    assert len(stops) == 2
+    assert all(stop["territory_id"] == "municipality:41091" for stop in stops)
+
+
+def test_list_stops_paginado(seed_dir_with_csv: Path) -> None:
+    use_case = ListTransitUseCase(seed_dir=seed_dir_with_csv)
+    page = use_case.list_stops(limit=1, offset=2)
+    assert len(page) == 1
+
+
+def test_count_stops_filtra(seed_dir_with_csv: Path) -> None:
+    use_case = ListTransitUseCase(seed_dir=seed_dir_with_csv)
+    assert use_case.count_stops() == 3
+    assert use_case.count_stops(territory_id="municipality:28079") == 1
+
+
+def test_csv_columna_obligatoria_falta(tmp_path: Path) -> None:
+    seed_dir = tmp_path / "seed"
+    seed_dir.mkdir()
+    (seed_dir / "transit_stops.csv").write_text(
+        "stop_id,territory_id,name\nA,B,Centro\n", encoding="utf-8"
+    )
+    use_case = ListTransitUseCase(seed_dir=seed_dir)
+    with pytest.raises(ValueError, match="transit_stops"):
+        use_case.list_stops()
+
+
+def test_csv_lat_lon_no_decimal(tmp_path: Path) -> None:
+    seed_dir = tmp_path / "seed"
+    seed_dir.mkdir()
+    (seed_dir / "transit_stops.csv").write_text(
+        "stop_id,territory_id,name,lat,lon\nA,B,Centro,bogus,bogus\n",
+        encoding="utf-8",
+    )
+    use_case = ListTransitUseCase(seed_dir=seed_dir)
+    with pytest.raises(ValueError, match="lat"):
+        use_case.list_stops()
+
+
+def test_modes_lines_separados_por_coma(tmp_path: Path) -> None:
+    seed_dir = tmp_path / "seed"
+    seed_dir.mkdir()
+    (seed_dir / "transit_stops.csv").write_text(
+        "stop_id,territory_id,name,lat,lon,modes,lines\nA,B,Centro,1.0,2.0,bus,1,2\n",
+        encoding="utf-8",
+    )
+    use_case = ListTransitUseCase(seed_dir=seed_dir)
+    rows = use_case.list_stops()
+    assert rows[0]["modes"] == ["bus"]
+
+
+def test_cache_se_reutiliza(seed_dir_with_csv: Path) -> None:
+    use_case = ListTransitUseCase(seed_dir=seed_dir_with_csv)
+    primero = use_case.list_stops()
+    segundo = use_case.list_stops()
+    assert primero == segundo

--- a/docs/api.md
+++ b/docs/api.md
@@ -36,8 +36,13 @@ Catálogo operativo de endpoints expuestos por `apps/api` (FastAPI). Alinea el c
 | POST | `/sparql` | **completado** | Ejecuta una consulta del catálogo con `{query_id, bindings}`; devuelve filas, variables y `elapsed_ms`. |
 | GET | `/sparql/catalog` | **completado** | Firmas (`query_id`, bindings esperados, descripción en español) de las consultas disponibles. |
 | GET | `/quality/reports` | **completado** | Reportes de calidad por fuente y ejecución. |
+| GET | `/mobility/flows` | **completado** | Flujos origen-destino MITMA filtrables por origen, destino y periodo. |
+| GET | `/mobility/summary` | **completado** | Resumen agregado de movilidad por territorio. |
+| GET | `/accidents` | **completado** | Listado de accidentes (DGT) filtrable por territorio y periodo. |
+| GET | `/accidents/risk` | **completado** | Indicador de riesgo (accidentes por 1.000 habitantes) por territorio. |
+| GET | `/transit/stops` | **completado** | Paradas de transporte público filtrables por territorio. |
 
-Todos los endpoints están desplegados en `develop` desde la release v0.2.0 (M8). Los routers concretos viven en [`apps/api/src/atlashabita/interfaces/api/routers/`](../apps/api/src/atlashabita/interfaces/api/routers/) (`health.py`, `profiles.py`, `territories.py`, `rankings.py`, `map_layers.py`, `sources.py`, `rdf_export.py`, `sparql.py`, `quality.py`).
+Todos los endpoints están desplegados en `develop` desde la release v0.2.0 (M8). Los routers concretos viven en [`apps/api/src/atlashabita/interfaces/api/routers/`](../apps/api/src/atlashabita/interfaces/api/routers/) (`health.py`, `profiles.py`, `territories.py`, `rankings.py`, `map_layers.py`, `sources.py`, `rdf_export.py`, `sparql.py`, `quality.py`, `mobility.py`, `accidents.py`, `transit.py`).
 
 ---
 
@@ -376,6 +381,144 @@ de SPARQL 1.1 HTTP Protocol (`POST /<dataset>/query`).
 ### 3.10 `GET /quality/reports`
 
 Devuelve una lista paginada de reportes con `source_id`, `timestamp`, `status`, `coverage`, `critical_errors`, `warnings`.
+
+---
+
+### 3.13 `GET /mobility/flows` y `GET /mobility/summary`
+
+Datos de movilidad MITMA expuestos para la pantalla técnica. El loader degrada a lista vacía con log informativo cuando `data/seed/mobility_flows.csv` aún no se ha publicado.
+
+`GET /mobility/flows`:
+
+| Parámetro | Tipo | Obligatorio | Descripción |
+|---|---|---|---|
+| `origin` | string | no | Identificador del territorio origen (`municipality:41091`). |
+| `destination` | string | no | Identificador del territorio destino. |
+| `period` | string | no | Periodo en formato libre (`2025`, `2025Q1`). |
+| `limit` | int | no | 1–`request_max_limit` (por defecto 50). |
+| `offset` | int | no | ≥ 0 (por defecto 0). |
+
+**Response 200**
+
+```json
+{
+  "items": [
+    {
+      "origin_id": "municipality:41091",
+      "destination_id": "municipality:28079",
+      "period": "2025",
+      "trips": 1500.0,
+      "mode": "car",
+      "purpose": "work",
+      "source_id": "mitma"
+    }
+  ],
+  "pagination": { "limit": 50, "offset": 0, "total": 1 },
+  "filters": { "origin": null, "destination": null, "period": "2025" }
+}
+```
+
+`GET /mobility/summary?territory_id=`: resumen agregado del territorio.
+
+```json
+{
+  "territory_id": "municipality:41091",
+  "total_outgoing_trips": 2700.0,
+  "total_incoming_trips": 800.0,
+  "outgoing_flows": 2,
+  "incoming_flows": 1,
+  "top_destinations": [
+    { "territory_id": "municipality:28079", "trips": 2700.0 }
+  ],
+  "top_origins": [
+    { "territory_id": "municipality:28079", "trips": 800.0 }
+  ]
+}
+```
+
+---
+
+### 3.14 `GET /accidents` y `GET /accidents/risk`
+
+Datos DGT con indicador de riesgo derivado. Si `data/seed/accidents.csv` no se ha publicado, los endpoints devuelven listas vacías y agregados a cero (sin error).
+
+`GET /accidents`:
+
+| Parámetro | Tipo | Obligatorio | Descripción |
+|---|---|---|---|
+| `territory_id` | string | no | Filtra por territorio. |
+| `period` | string | no | Filtra por periodo. |
+| `limit` | int | no | 1–`request_max_limit` (por defecto 50). |
+| `offset` | int | no | ≥ 0 (por defecto 0). |
+
+**Response 200**
+
+```json
+{
+  "items": [
+    {
+      "territory_id": "municipality:41091",
+      "period": "2025",
+      "accidents": 180,
+      "fatalities": 3,
+      "injuries": 40,
+      "severity": "light",
+      "source_id": "dgt"
+    }
+  ],
+  "pagination": { "limit": 50, "offset": 0, "total": 1 },
+  "filters": { "territory_id": "municipality:41091", "period": null }
+}
+```
+
+`GET /accidents/risk?territory_id=`: agregados con normalización por 1.000 habitantes (cuando el dataset conoce la población del territorio).
+
+```json
+{
+  "territory_id": "municipality:41091",
+  "accidents": 330,
+  "fatalities": 5,
+  "injuries": 70,
+  "population": 684234,
+  "accidents_per_1000": 0.4823,
+  "fatalities_per_1000": 0.0073,
+  "records": 2
+}
+```
+
+---
+
+### 3.15 `GET /transit/stops`
+
+Paradas de transporte público (CRTM y operadores municipales). Si `data/seed/transit_stops.csv` aún no se ha publicado, devuelve lista vacía sin error.
+
+| Parámetro | Tipo | Obligatorio | Descripción |
+|---|---|---|---|
+| `territory_id` | string | no | Filtra por territorio. |
+| `limit` | int | no | 1–`request_max_limit` (por defecto 50). |
+| `offset` | int | no | ≥ 0 (por defecto 0). |
+
+**Response 200**
+
+```json
+{
+  "items": [
+    {
+      "stop_id": "stop:1",
+      "territory_id": "municipality:41091",
+      "name": "Plaza Nueva",
+      "lat": 37.388,
+      "lon": -5.992,
+      "modes": ["bus", "tram"],
+      "operator": "Tussam",
+      "lines": ["C1", "C2"],
+      "source_id": "crtm"
+    }
+  ],
+  "pagination": { "limit": 50, "offset": 0, "total": 1 },
+  "filters": { "territory_id": "municipality:41091" }
+}
+```
 
 ---
 


### PR DESCRIPTION
Routers HTTP nuevos: `/mobility/flows`, `/mobility/summary`, `/accidents`, `/accidents/risk`, `/transit/stops`. Use cases que degradan a vacío si los CSV aún no existen. 427 tests verde, cobertura 100% en routers nuevos.

Closes #109