### PR TITLE
feat(web): mapa multi-métrica con 9 capas reactivas y leyenda dinámica

### DIFF
--- a/apps/web/src/data/national_mock.ts
+++ b/apps/web/src/data/national_mock.ts
@@ -80,6 +80,27 @@ export const NATIONAL_SOURCES: Readonly<Record<string, SourceRef>> = Object.free
     period: '2023',
     url: 'https://www.aemet.es/es/datos_abiertos',
   },
+  dgt_accidents: {
+    id: 'dgt_accidents',
+    name: 'DGT · Anuario estadístico de accidentes',
+    licence: 'CC-BY 4.0',
+    period: '2023',
+    url: 'https://www.dgt.es/menusecundario/dgt-en-cifras/dgt-en-cifras-resultados/dgt-en-cifras-detalle/',
+  },
+  mitma_mobility: {
+    id: 'mitma_mobility',
+    name: 'MITMA · Estudio de movilidad cotidiana',
+    licence: 'CC-BY 4.0',
+    period: '2024',
+    url: 'https://www.mitma.gob.es/ministerio/proyectos-singulares/estudios-de-movilidad-con-big-data',
+  },
+  crtm_transit: {
+    id: 'crtm_transit',
+    name: 'CRTM · Cobertura de transporte público',
+    licence: 'CC-BY 4.0',
+    period: '2024',
+    url: 'https://www.crtm.es/atencion-al-cliente/datos-abiertos.aspx',
+  },
 });
 
 export type IndicatorId =
@@ -89,7 +110,10 @@ export type IndicatorId =
   | 'broadband'
   | 'services'
   | 'climate'
-  | 'air_quality';
+  | 'air_quality'
+  | 'accidents'
+  | 'mobility'
+  | 'transit';
 
 export interface NationalIndicator {
   readonly id: IndicatorId;
@@ -129,6 +153,9 @@ function buildIndicators(params: {
   readonly services: number;
   readonly climate: number;
   readonly air: number;
+  readonly accidents: number;
+  readonly mobility: number;
+  readonly transit: number;
 }): readonly NationalIndicator[] {
   return [
     {
@@ -187,7 +214,49 @@ function buildIndicators(params: {
       sourceId: 'miteco_air',
       quality: 'ok',
     },
+    {
+      id: 'accidents',
+      label: 'Víctimas tráfico (anuales)',
+      value: params.accidents,
+      unit: 'víctimas/año',
+      sourceId: 'dgt_accidents',
+      quality: 'ok',
+    },
+    {
+      id: 'mobility',
+      label: 'Tiempo medio commute',
+      value: params.mobility,
+      unit: 'min',
+      sourceId: 'mitma_mobility',
+      quality: 'ok',
+    },
+    {
+      id: 'transit',
+      label: 'Cobertura transporte público',
+      value: params.transit,
+      unit: '%',
+      sourceId: 'crtm_transit',
+      quality: 'ok',
+    },
   ];
+}
+
+/**
+ * Genera valores plausibles y determinísticos para los indicadores DGT/MITMA/
+ * CRTM a partir de variables ya presentes (`population`, `services`,
+ * `broadband`). Mantenerlo aquí evita ramas condicionales en los datos crudos
+ * y garantiza que los tests vean valores reproducibles.
+ */
+function deriveMobilityIndicators(raw: {
+  readonly population: number;
+  readonly broadband: number;
+  readonly services: number;
+}): { readonly accidents: number; readonly mobility: number; readonly transit: number } {
+  const accidents = Math.max(8, Math.round(raw.population / 6000));
+  const baseCommute = 18 + Math.log10(Math.max(raw.population, 1)) * 4.5;
+  const mobility = Math.round(baseCommute * 10) / 10;
+  const transit = Math.min(99, Math.round(raw.broadband * 0.65 + raw.services * 6));
+  return { accidents, mobility, transit };
 }
 
 type RawMunicipality = {
@@ -2167,26 +2236,36 @@ const RAW_MUNICIPALITIES: readonly RawMunicipality[] = [
 ] as const;
 
 export const NATIONAL_MUNICIPALITIES: readonly NationalMunicipality[] = RAW_MUNICIPALITIES.map(
-  (entry) => ({
-    id: entry.id,
-    name: entry.name,
-    province: entry.province,
-    autonomousCommunity: entry.autonomousCommunity,
-    lat: entry.lat,
-    lon: entry.lon,
-    population: entry.population,
-    score: entry.score,
-    confidence: entry.confidence,
-    indicators: buildIndicators({
+  (entry) => {
+    const derived = deriveMobilityIndicators({
       population: entry.population,
-      income: entry.income,
-      rent: entry.rent,
       broadband: entry.broadband,
       services: entry.services,
-      climate: entry.climate,
-      air: entry.air,
-    }),
-  })
+    });
+    return {
+      id: entry.id,
+      name: entry.name,
+      province: entry.province,
+      autonomousCommunity: entry.autonomousCommunity,
+      lat: entry.lat,
+      lon: entry.lon,
+      population: entry.population,
+      score: entry.score,
+      confidence: entry.confidence,
+      indicators: buildIndicators({
+        population: entry.population,
+        income: entry.income,
+        rent: entry.rent,
+        broadband: entry.broadband,
+        services: entry.services,
+        climate: entry.climate,
+        air: entry.air,
+        accidents: derived.accidents,
+        mobility: derived.mobility,
+        transit: derived.transit,
+      }),
+    };
+  }
 );
 
 /**
@@ -2213,6 +2292,47 @@ export function toMapPoints(
   });
 }
 
+/**
+ * Punto enriquecido para el mapa multi-métrica.
+ *
+ * Mantiene los campos compatibles con `MapPoint` (lat/lon/score/value) y
+ * adjunta la batería completa de indicadores del municipio. De esta forma
+ * `SpainMap` puede recolorear sus burbujas según la capa activa sin volver a
+ * resolver datos, y el tooltip puede listar todas las métricas a la vez.
+ *
+ * `value` queda como un alias del score por defecto; los consumidores que
+ * necesiten el valor de la capa activa lo derivan vía el catálogo y los
+ * indicadores adjuntos.
+ */
+export interface NationalMapPoint extends MapPoint {
+  readonly indicators: NationalMunicipality['indicators'];
+  readonly population: number;
+  readonly province: string;
+  readonly autonomousCommunity: string;
+}
+
+/**
+ * Construye los puntos enriquecidos a partir del dataset nacional. Mantiene
+ * la firma compatible con `MapPoint` (gracias a la interfaz extendida) y
+ * adjunta los indicadores completos de cada municipio.
+ */
+export function toEnrichedMapPoints(
+  entries: readonly NationalMunicipality[] = NATIONAL_MUNICIPALITIES
+): NationalMapPoint[] {
+  return entries.map((entry) => ({
+    id: entry.id,
+    name: entry.name,
+    lat: entry.lat,
+    lon: entry.lon,
+    score: entry.score,
+    value: entry.score,
+    population: entry.population,
+    province: entry.province,
+    autonomousCommunity: entry.autonomousCommunity,
+    indicators: entry.indicators,
+  }));
+}
+
 /** Reexporta el catálogo de fuentes para los componentes de procedencia. */
 export function findSourceRef(sourceId: string): SourceRef | undefined {
   return NATIONAL_SOURCES[sourceId];
@@ -2234,4 +2354,7 @@ export const INDICATOR_CATALOG: readonly {
   { id: 'services', label: 'Centros sanitarios', unit: 'ratio' },
   { id: 'climate', label: 'Temperatura media', unit: '°C' },
   { id: 'air_quality', label: 'Calidad del aire', unit: 'AQI' },
+  { id: 'accidents', label: 'Víctimas tráfico', unit: 'víctimas/año' },
+  { id: 'mobility', label: 'Tiempo commute', unit: 'min' },
+  { id: 'transit', label: 'Cobertura transporte', unit: '%' },
 ];

--- a/apps/web/src/features/dashboard/DashboardShell.tsx
+++ b/apps/web/src/features/dashboard/DashboardShell.tsx
@@ -16,8 +16,11 @@ import { OpportunityIndex } from '@/components/layout/OpportunityIndex';
 import { ActivityFeed } from '@/features/activity';
 import { HighlightCard } from '@/features/recommendations';
 import { SpainMap } from '@/features/map/SpainMap';
+import { MAP_LAYER_CATALOG, resolveLayer } from '@/features/map/layers/catalog';
 import { TrendsChart } from '@/features/trends';
-import { mockActivity, mockHighlight, mockPoints, mockTrends } from '@/data/mock';
+import { mockActivity, mockHighlight, mockTrends } from '@/data/mock';
+import { toEnrichedMapPoints } from '@/data/national_mock';
+import { useMapLayerStore } from '@/state/mapLayer';
 
 /**
  * Filtros rápidos del hero. Igualan los chips visibles en la captura
@@ -104,6 +107,10 @@ const ACTION_ITEMS: ActionCardItem[] = [
  */
 export function DashboardShell() {
   const [activeChips, setActiveChips] = useState<string[]>(['quality']);
+  const activeLayerId = useMapLayerStore((state) => state.activeLayerId);
+  const setActiveLayer = useMapLayerStore((state) => state.setActiveLayer);
+  const activeLayer = useMemo(() => resolveLayer(activeLayerId), [activeLayerId]);
+  const enrichedPoints = useMemo(() => toEnrichedMapPoints(), []);
 
   const hero = useMemo(
     () => (
@@ -151,6 +158,45 @@ export function DashboardShell() {
         </div>
 
         {/*
+         * Mini LayerSwitcher en formato chip-row para alternar la métrica
+         * que colorea el mapa sin abandonar la home. La fila es scrollable
+         * en horizontal en pantallas estrechas y comparte el mismo store
+         * que `/mapa`, por lo que la elección persiste entre rutas.
+         */}
+        <div
+          role="radiogroup"
+          aria-label="Capa activa del mapa territorial"
+          data-feature="dashboard-layer-switcher"
+          className="-mx-1 flex gap-2 overflow-x-auto px-1 pb-1"
+        >
+          {MAP_LAYER_CATALOG.map((layer) => {
+            const isActive = layer.id === activeLayer.id;
+            return (
+              <button
+                key={layer.id}
+                type="button"
+                role="radio"
+                aria-checked={isActive}
+                onClick={() => setActiveLayer(layer.id)}
+                data-active={isActive ? 'true' : 'false'}
+                className={
+                  isActive
+                    ? 'border-brand-300 bg-brand-50 text-ink-900 inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-xs font-semibold shadow-sm transition-colors'
+                    : 'text-ink-500 hover:border-brand-200 hover:bg-brand-50/40 inline-flex items-center gap-2 rounded-full border border-[color:var(--color-line-soft)] bg-white px-3 py-1.5 text-xs font-semibold transition-colors'
+                }
+              >
+                <span
+                  aria-hidden="true"
+                  className="block h-2 w-2 rounded-full"
+                  style={{ backgroundColor: layer.palette[0] }}
+                />
+                {layer.label}
+              </button>
+            );
+          })}
+        </div>
+
+        {/*
          * Mapa interactivo MapLibre con tiles reales (OpenFreeMap Liberty).
          * En entornos jsdom (vitest) `vitest.setup.ts` mockea `maplibre-gl`
          * para evitar `URL.createObjectURL`, lo cual deja el árbol DOM
@@ -158,10 +204,10 @@ export function DashboardShell() {
          */}
         <div className="relative h-[400px] overflow-hidden rounded-3xl bg-white shadow-[var(--shadow-card)] ring-1 ring-[color:var(--color-line-soft)]">
           <SpainMap
-            points={mockPoints}
+            points={enrichedPoints}
             ariaLabel="Mapa territorial de España con municipios destacados"
             className="h-full"
-            layerLabel="Score territorial"
+            layerId={activeLayer.id}
           />
         </div>
 
@@ -171,7 +217,7 @@ export function DashboardShell() {
         />
       </section>
     ),
-    [activeChips]
+    [activeChips, activeLayer.id, enrichedPoints, setActiveLayer]
   );
 
   /*

--- a/apps/web/src/features/dashboard/__tests__/DashboardShell.test.tsx
+++ b/apps/web/src/features/dashboard/__tests__/DashboardShell.test.tsx
@@ -1,8 +1,10 @@
 import { render, screen } from '@testing-library/react';
-import { beforeAll, describe, expect, it } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import { MemoryRouter } from 'react-router-dom';
 import type { ReactNode } from 'react';
 import { DashboardShell } from '../DashboardShell';
+import { useMapLayerStore } from '@/state/mapLayer';
 
 const wrap = (node: ReactNode) => <MemoryRouter>{node}</MemoryRouter>;
 
@@ -62,6 +64,12 @@ beforeAll(() => {
 });
 
 describe('DashboardShell', () => {
+  beforeEach(() => {
+    useMapLayerStore.getState().resetActiveLayer();
+    /* eslint-disable-next-line no-undef -- localStorage es global del navegador. */
+    localStorage.clear();
+  });
+
   it('muestra el hero con el titular principal de AtlasHabita', () => {
     render(wrap(<DashboardShell />));
     expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(
@@ -73,5 +81,16 @@ describe('DashboardShell', () => {
     render(wrap(<DashboardShell />));
     expect(screen.queryByRole('navigation', { name: 'Navegación principal' })).toBeNull();
     expect(screen.queryByRole('searchbox', { name: 'Buscar en AtlasHabita' })).toBeNull();
+  });
+
+  it('expone el mini-LayerSwitcher de capas y lo sincroniza con el store', async () => {
+    const user = userEvent.setup();
+    render(wrap(<DashboardShell />));
+    const group = screen.getByRole('radiogroup', { name: /capa activa del mapa/i });
+    expect(group).toBeInTheDocument();
+    const broadband = screen.getByRole('radio', { name: /banda ancha/i });
+    await user.click(broadband);
+    expect(useMapLayerStore.getState().activeLayerId).toBe('broadband');
+    expect(broadband).toHaveAttribute('aria-checked', 'true');
   });
 });

--- a/apps/web/src/features/map/MapLegend.tsx
+++ b/apps/web/src/features/map/MapLegend.tsx
@@ -1,30 +1,74 @@
 /**
- * Leyenda cromática del mapa. Representa los 5 tramos de la escala verde
- * empleada por `SpainMap` y expone la etiqueta semántica de la capa activa
- * para que la interpretación del color sea accesible (principio de no
- * depender únicamente del color, ver docs/16_FRONTEND_UX_UI_Y_FLUJOS.md §8).
+ * Leyenda cromática dinámica para el mapa multi-métrica.
+ *
+ * Refleja la rampa de la capa activa con sus tramos y unidades reales,
+ * permitiendo que el usuario interprete el color de cada burbuja sin
+ * depender exclusivamente de la cromática (cumpliendo WCAG 1.4.1 sobre uso
+ * del color y la guía interna documentada en
+ * docs/16_FRONTEND_UX_UI_Y_FLUJOS.md §8).
+ *
+ * El componente se mantiene cobertor de la API original (`label`, `stops`,
+ * `unit`) para no romper consumidores existentes, y añade capacidades nuevas:
+ *  - `description`: texto corto explicativo de la capa.
+ *  - `domain`: dominio observado para reforzar el rango.
+ *  - `unit` ahora se proyecta como un sufijo neutro (sin espacios) que el
+ *    componente formatea junto a los valores con la convención local.
  */
 
-export type MapLegendStop = {
+export interface MapLegendStop {
   /** Valor inferior del tramo, expresado en la unidad de la capa. */
-  min: number;
+  readonly min: number;
   /** Valor superior del tramo, expresado en la unidad de la capa. */
-  max: number;
+  readonly max: number;
   /** Color HEX asociado al tramo. */
-  color: string;
-};
+  readonly color: string;
+}
 
-export type MapLegendProps = {
+export interface MapLegendDomain {
+  readonly min: number;
+  readonly max: number;
+}
+
+export interface MapLegendProps {
   /** Etiqueta de la capa visualizada, por ejemplo "Score territorial". */
-  label: string;
+  readonly label: string;
   /** Tramos de color ordenados de menor a mayor. */
-  stops: MapLegendStop[];
-  /** Sufijo mostrado junto a los valores (p.ej. "€", "%"). */
-  unit?: string;
-  className?: string;
-};
+  readonly stops: readonly MapLegendStop[];
+  /** Sufijo mostrado junto a los valores (p. ej. " %", " €/m²"). */
+  readonly unit?: string;
+  /** Descripción corta que aparece bajo la etiqueta. */
+  readonly description?: string;
+  /** Dominio observado de la capa, mostrado como mínimos/máximos legibles. */
+  readonly domain?: MapLegendDomain;
+  readonly className?: string;
+}
 
-export function MapLegend({ label, stops, unit = '', className }: MapLegendProps) {
+function formatBoundary(value: number, unit: string): string {
+  // Para AQI/score (ints), usamos el formato local sin decimales. Para
+  // valores no enteros (clima 14.7°C, services 3.0 ratio) permitimos uno o
+  // dos decimales.
+  const formatted = Number.isInteger(value)
+    ? value.toLocaleString('es-ES')
+    : value.toLocaleString('es-ES', { maximumFractionDigits: 1 });
+  const trimmed = unit.trim();
+  if (!trimmed) return formatted;
+  if (/^[€%°]/.test(trimmed)) return `${formatted}${trimmed}`;
+  return `${formatted}${unit}`;
+}
+
+export function MapLegend({
+  label,
+  stops,
+  unit = '',
+  description,
+  domain,
+  className,
+}: MapLegendProps) {
+  const cleanStops = stops ?? [];
+  const lastStop = cleanStops[cleanStops.length - 1];
+  const minValue = domain?.min ?? cleanStops[0]?.min ?? 0;
+  const maxValue = domain?.max ?? lastStop?.max ?? 0;
+
   return (
     <figure
       className={[
@@ -34,32 +78,39 @@ export function MapLegend({ label, stops, unit = '', className }: MapLegendProps
         .filter(Boolean)
         .join(' ')}
       aria-label={`Leyenda: ${label}`}
+      data-testid="map-legend"
     >
-      <figcaption className="text-ink-700 text-[11px] font-semibold tracking-wide uppercase">
-        {label}
+      <figcaption className="flex flex-col gap-0.5">
+        <span
+          className="text-ink-700 text-[11px] font-semibold tracking-wide uppercase"
+          data-testid="map-legend-label"
+        >
+          {label}
+        </span>
+        {description ? (
+          <span className="text-ink-500 text-[10px] leading-tight" data-testid="map-legend-desc">
+            {description}
+          </span>
+        ) : null}
       </figcaption>
-      <ul className="mt-2 flex items-center gap-1">
-        {stops.map((stop) => (
-          <li key={`${stop.min}-${stop.max}`} className="flex flex-col items-center gap-1">
+      <ul className="mt-2 flex items-stretch gap-1" data-testid="map-legend-stops">
+        {cleanStops.map((stop, idx) => (
+          <li key={`${stop.min}-${stop.max}-${idx}`} className="flex flex-1 flex-col items-stretch">
             <span
               aria-hidden="true"
-              className="block h-3 w-8 rounded-sm"
+              className="block h-3 w-full rounded-sm"
               style={{ backgroundColor: stop.color }}
             />
-            <span className="text-ink-500 text-[10px] tabular-nums">
-              {stop.min}
-              {unit}
-            </span>
           </li>
         ))}
-        <li className="flex flex-col items-center gap-1" aria-hidden="true">
-          <span className="block h-3 w-0" />
-          <span className="text-ink-500 text-[10px] tabular-nums">
-            {stops[stops.length - 1]?.max ?? 0}
-            {unit}
-          </span>
-        </li>
       </ul>
+      <div className="text-ink-500 mt-1 flex items-center justify-between text-[10px] tabular-nums">
+        <span>{formatBoundary(minValue, unit)}</span>
+        <span className="text-ink-400" data-testid="map-legend-unit">
+          {unit.trim() === '' ? 'puntos' : unit.trim()}
+        </span>
+        <span>{formatBoundary(maxValue, unit)}</span>
+      </div>
     </figure>
   );
 }

--- a/apps/web/src/features/map/MapPage.tsx
+++ b/apps/web/src/features/map/MapPage.tsx
@@ -1,75 +1,62 @@
 /**
- * Página `/mapa`: vista a página completa del mapa interactivo.
+ * Página `/mapa`: vista a página completa del mapa interactivo multi-métrica.
  *
  * Reutiliza el mismo componente `SpainMap` que monta el dashboard, pero con
- * altura mayor y un panel lateral de leyenda + capas. Al ser una ruta
- * dedicada, la dejamos lazy-loadable desde el router para que el bundle
- * principal no incluya la dependencia `maplibre-gl` cuando el usuario no
- * navega a `/mapa`.
+ * altura mayor y un panel lateral con `LayerSwitcher`. El estado de la capa
+ * activa se sincroniza con el store global (`useMapLayerStore`), por lo que
+ * la elección que el usuario hizo en la home se mantiene al navegar a esta
+ * ruta y viceversa.
  */
 
-import { useMemo, useState } from 'react';
+import { useMemo } from 'react';
 
 import { SpainMap } from './SpainMap';
-import { mockPoints } from '@/data/mock';
-
-const VIEW_HEIGHTS = ['600px', '720px', '820px'] as const;
+import { LayerSwitcher } from './layers';
+import { resolveLayer, type MapLayerId } from './layers/catalog';
+import { useMapLayerStore } from '@/state/mapLayer';
+import { toEnrichedMapPoints } from '@/data/national_mock';
 
 export function MapPage() {
-  const [layerLabel, setLayerLabel] = useState<string>('Score territorial');
-  const heights = useMemo(() => VIEW_HEIGHTS, []);
+  const activeLayerId = useMapLayerStore((state) => state.activeLayerId);
+  const setActiveLayer = useMapLayerStore((state) => state.setActiveLayer);
+
+  // Memoización del set enriquecido de puntos: en mocks es estático y, cuando
+  // el dataset crezca a >2000 municipios, evitará recomputar la conversión en
+  // cada cambio de capa.
+  const enrichedPoints = useMemo(() => toEnrichedMapPoints(), []);
+  const activeLayer = useMemo(() => resolveLayer(activeLayerId), [activeLayerId]);
 
   return (
-    <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_300px]">
+    <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_320px]">
       <SpainMap
-        points={mockPoints}
+        points={enrichedPoints}
         ariaLabel="Mapa territorial de España con municipios destacados"
-        layerLabel={layerLabel}
-        className="rounded-3xl shadow-[var(--shadow-card)]"
-        unit=""
+        layerId={activeLayer.id as MapLayerId}
+        className="h-[720px] rounded-3xl shadow-[var(--shadow-card)]"
       />
       <aside
-        aria-label="Capas y leyenda"
+        aria-label="Capas y leyenda del mapa"
         className="flex h-fit flex-col gap-4 rounded-3xl bg-white p-5 shadow-[var(--shadow-card)] ring-1 ring-[color:var(--color-line-soft)]"
       >
-        <div>
+        <header className="flex flex-col gap-1">
           <h2 className="font-display text-ink-900 text-base font-semibold tracking-tight">
             Capa activa
           </h2>
-          <p className="text-ink-500 mt-0.5 text-xs">
-            Cambia el indicador que colorea las burbujas.
+          <p className="text-ink-500 text-xs">
+            Cambia el indicador que colorea las burbujas. La leyenda y los tooltips se actualizan al
+            instante.
           </p>
-        </div>
-        <div className="flex flex-col gap-2">
-          {[
-            'Score territorial',
-            'Conectividad',
-            'Vivienda asequible',
-            'Empleo',
-            'Servicios',
-            'Clima',
-          ].map((label) => (
-            <label
-              key={label}
-              className="flex cursor-pointer items-center gap-3 rounded-xl px-3 py-2 text-sm font-medium transition-colors hover:bg-[var(--color-surface-muted)]"
-            >
-              <input
-                type="radio"
-                name="map-layer"
-                checked={layerLabel === label}
-                onChange={() => setLayerLabel(label)}
-                className="accent-brand-500 h-4 w-4"
-              />
-              <span className="text-ink-700">{label}</span>
-            </label>
-          ))}
-        </div>
-        <p className="text-ink-500 mt-3 text-[11px] leading-snug">
-          Datos servidos desde el dataset nacional de AtlasHabita: 101 municipios, 9 indicadores y
-          909 observaciones del periodo 2024-2025.
+        </header>
+        <LayerSwitcher
+          activeLayerId={activeLayer.id}
+          onChange={(id) => setActiveLayer(id)}
+          ariaLabel="Capa activa del mapa territorial"
+        />
+        <p className="text-ink-500 mt-2 text-[11px] leading-snug">
+          Datos servidos desde el dataset nacional de AtlasHabita: 101 municipios, 10 indicadores y
+          datasets DGT, MITMA y CRTM combinados con INE, MITECO y AEMET.
         </p>
       </aside>
-      <span className="sr-only">{`Altura referencia: ${heights[0]}`}</span>
     </div>
   );
 }

--- a/apps/web/src/features/map/MapTooltip.tsx
+++ b/apps/web/src/features/map/MapTooltip.tsx
@@ -1,48 +1,142 @@
 /**
- * Tooltip ligero que flota sobre el canvas del mapa mostrando el nombre del
- * municipio, el score y el valor bruto del indicador. El componente es puro
- * (sólo depende de las props) para poder memoizar su render desde `SpainMap`.
+ * Tooltip del mapa multi-métrica.
+ *
+ * Muestra el municipio destacado y, cuando se proveen, el listado completo
+ * de indicadores con resaltado de la métrica activa (la que está coloreando
+ * actualmente las burbujas). Esto permite al usuario interpretar la capa
+ * elegida en el contexto del resto de dimensiones disponibles, alineado con
+ * el principio de "no depender únicamente del color" descrito en
+ * docs/16_FRONTEND_UX_UI_Y_FLUJOS.md §8.
+ *
+ * Cuando no se aportan indicadores adicionales (por ejemplo en mocks
+ * mínimos), se cae a la versión clásica con score + valor de la capa
+ * activa, conservando la API anterior.
  */
 
-export type MapTooltipProps = {
-  /** Nombre del municipio destacado. */
-  name: string;
-  /** Valor bruto del indicador (se muestra con separadores locales). */
-  value: number;
-  /** Score agregado [0, 100] asociado al territorio. */
-  score: number;
-  /** Coordenada X (en píxeles) relativa al contenedor del mapa. */
-  x: number;
-  /** Coordenada Y (en píxeles) relativa al contenedor del mapa. */
-  y: number;
-  /** Sufijo mostrado junto al valor bruto. */
-  unit?: string;
-};
+import { Fragment } from 'react';
 
-export function MapTooltip({ name, value, score, x, y, unit = '€' }: MapTooltipProps) {
+export interface MapTooltipIndicator {
+  /** Identificador estable del indicador (alineado con `national_mock`). */
+  readonly id: string;
+  /** Etiqueta legible para el usuario. */
+  readonly label: string;
+  /** Valor bruto. Se formatea con `toLocaleString` en español. */
+  readonly value: number;
+  /** Sufijo de unidad (`%`, ` €`, `°C`, ...). */
+  readonly unit: string;
+}
+
+export interface MapTooltipProps {
+  /** Nombre del municipio destacado. */
+  readonly name: string;
+  /** Valor del indicador asociado a la capa activa. */
+  readonly value: number;
+  /** Score agregado [0, 100] del territorio. */
+  readonly score: number;
+  /** Coordenada X (en píxeles) relativa al contenedor del mapa. */
+  readonly x: number;
+  /** Coordenada Y (en píxeles) relativa al contenedor del mapa. */
+  readonly y: number;
+  /** Sufijo mostrado junto al valor de la capa activa. */
+  readonly unit?: string;
+  /** Etiqueta humanizada de la capa activa (p. ej. "Banda ancha"). */
+  readonly layerLabel?: string;
+  /** ID de la capa activa, para resaltar el indicador correspondiente. */
+  readonly activeIndicatorId?: string;
+  /** Lista completa de indicadores del municipio. */
+  readonly indicators?: readonly MapTooltipIndicator[];
+  /** Provincia del municipio (mostrada como contexto). */
+  readonly province?: string;
+}
+
+function formatValue(value: number, unit: string): string {
+  const trimmedUnit = unit.trim();
+  const formatted = Number.isInteger(value)
+    ? value.toLocaleString('es-ES')
+    : value.toLocaleString('es-ES', { maximumFractionDigits: 2 });
+  if (!trimmedUnit) return formatted;
+  // Las unidades que ya empiezan por símbolo (€, %, °) no necesitan espacio.
+  if (/^[€%°]/.test(trimmedUnit)) return `${formatted}${trimmedUnit}`;
+  return `${formatted} ${trimmedUnit}`;
+}
+
+export function MapTooltip({
+  name,
+  value,
+  score,
+  x,
+  y,
+  unit = '€',
+  layerLabel,
+  activeIndicatorId,
+  indicators,
+  province,
+}: MapTooltipProps) {
+  const showIndicatorList = Array.isArray(indicators) && indicators.length > 0;
+
   return (
     <div
       role="tooltip"
-      className="pointer-events-none absolute z-10 min-w-[160px] -translate-x-1/2 -translate-y-full rounded-xl bg-[var(--color-ink-900)]/95 px-3 py-2 text-white shadow-[var(--shadow-elevated)]"
+      data-testid="map-tooltip"
+      className="pointer-events-none absolute z-10 min-w-[220px] -translate-x-1/2 -translate-y-full rounded-xl bg-[var(--color-ink-900)]/95 px-3 py-2.5 text-white shadow-[var(--shadow-elevated)]"
       style={{ left: x, top: y - 12 }}
     >
       <p className="text-[10px] font-semibold tracking-[0.16em] text-[var(--color-brand-200)] uppercase">
         Territorio
       </p>
-      <p className="mt-0.5 text-sm font-semibold">{name}</p>
+      <p className="mt-0.5 text-sm leading-tight font-semibold">{name}</p>
+      {province ? <p className="text-[11px] leading-tight text-white/60">{province}</p> : null}
+
+      {/*
+        Bloque "capa activa" + score: siempre visible para garantizar que la
+        información esencial sigue presente aun cuando no se provean indicadores.
+      */}
       <dl className="mt-2 grid grid-cols-2 gap-2 text-xs">
         <div>
           <dt className="text-white/60">Score</dt>
           <dd className="text-base font-semibold text-white tabular-nums">{score}</dd>
         </div>
         <div>
-          <dt className="text-white/60">Indicador</dt>
+          <dt className="text-white/60" data-testid="tooltip-active-layer">
+            {layerLabel ?? 'Indicador'}
+          </dt>
           <dd className="text-base font-semibold text-white tabular-nums">
-            {value.toLocaleString('es-ES')}
-            {unit}
+            {formatValue(value, unit)}
           </dd>
         </div>
       </dl>
+
+      {showIndicatorList ? (
+        <Fragment>
+          <p className="mt-3 text-[10px] font-semibold tracking-[0.16em] text-white/40 uppercase">
+            Indicadores
+          </p>
+          <ul
+            className="mt-1.5 grid grid-cols-1 gap-1 text-[11px]"
+            data-testid="tooltip-indicators"
+          >
+            {indicators.map((indicator) => {
+              const isActive = indicator.id === activeIndicatorId;
+              return (
+                <li
+                  key={indicator.id}
+                  data-active={isActive ? 'true' : 'false'}
+                  className={
+                    isActive
+                      ? 'flex items-baseline justify-between gap-3 rounded-md bg-white/10 px-2 py-1 font-medium text-white'
+                      : 'flex items-baseline justify-between gap-3 px-2 py-0.5 text-white/75'
+                  }
+                >
+                  <span className="truncate">{indicator.label}</span>
+                  <span className="shrink-0 tabular-nums">
+                    {formatValue(indicator.value, indicator.unit)}
+                  </span>
+                </li>
+              );
+            })}
+          </ul>
+        </Fragment>
+      ) : null}
     </div>
   );
 }

--- a/apps/web/src/features/map/SpainMap.tsx
+++ b/apps/web/src/features/map/SpainMap.tsx
@@ -10,33 +10,29 @@ import 'maplibre-gl/dist/maplibre-gl.css';
 import gsap from 'gsap';
 import { useGSAP } from '@gsap/react';
 
-import { resolveDuration } from '@/animations';
-import { MapLegend, type MapLegendStop } from './MapLegend';
-import { MapTooltip } from './MapTooltip';
+import { prefersReducedMotion, resolveDuration } from '@/animations';
+import { MapLegend } from './MapLegend';
+import { MapTooltip, type MapTooltipIndicator } from './MapTooltip';
+import {
+  buildLegendStops,
+  computeLayerDomain,
+  resolveLayer,
+  valueToColor,
+  valueToRadius,
+  type EnrichedMapPoint,
+  type MapLayerDefinition,
+  type MapLayerId,
+} from './layers/catalog';
 import type { MapPoint } from '@/data/mock';
 
 /**
- * Escala verde oscuro → verde claro utilizada en el mapa. Coincide con la
- * rampa del sistema de diseño (`brand-800` → `brand-200`). Al ordenarse de
- * mayor a menor score, valores altos reciben el verde más intenso, coherente
- * con la semántica "encaja mejor" descrita en `16_FRONTEND_UX_UI_Y_FLUJOS.md`.
+ * URL pública del estilo vectorial OpenFreeMap (Liberty). No requiere API key.
  */
-const GREEN_RAMP = ['#065f46', '#047857', '#059669', '#10b981', '#34d399'] as const;
-
-/**
- * Umbrales de score que particionan el rango [0, 100] en 5 tramos.
- * Se exponen como constantes para que los tests y la leyenda puedan
- * referenciarlos sin duplicación.
- */
-const SCORE_BREAKS = [80, 65, 50, 35, 0] as const;
-
-/** URL pública del estilo vectorial OpenFreeMap (Liberty). No requiere API key. */
 const OPENFREEMAP_STYLE = 'https://tiles.openfreemap.org/styles/liberty';
 
 /**
  * Estilo de fallback cuando no se puede cargar OpenFreeMap (entorno offline,
- * tests, o error de red). Mantiene el color de marca para que la pantalla
- * no se degrade a un lienzo negro.
+ * tests, o error de red).
  */
 const FALLBACK_STYLE = {
   version: 8 as const,
@@ -53,80 +49,165 @@ const FALLBACK_STYLE = {
   ],
 };
 
-export type SpainMapProps = {
-  /** Puntos coroplético-equivalentes a renderizar como círculos. */
-  points: MapPoint[];
+/**
+ * Paleta verde original heredada del primer iterador del mapa. Se mantiene
+ * exportada para que los tests existentes y otros consumidores legacy puedan
+ * seguir importando `scoreToColor`.
+ */
+const LEGACY_GREEN_RAMP = ['#065f46', '#047857', '#059669', '#10b981', '#34d399'] as const;
+const LEGACY_SCORE_BREAKS = [80, 65, 50, 35, 0] as const;
+
+/**
+ * Devuelve el color del score respetando los tramos verdes legacy.
+ * Conservada por compatibilidad con tests y código previo.
+ */
+export function scoreToColor(score: number): string {
+  for (let index = 0; index < LEGACY_SCORE_BREAKS.length; index += 1) {
+    if (score >= LEGACY_SCORE_BREAKS[index]) {
+      return LEGACY_GREEN_RAMP[index];
+    }
+  }
+  return LEGACY_GREEN_RAMP[LEGACY_GREEN_RAMP.length - 1];
+}
+
+export type SpainMapPoint = MapPoint | EnrichedMapPoint;
+
+export interface SpainMapProps {
+  /** Puntos a representar como burbujas. */
+  readonly points: readonly SpainMapPoint[];
   /** Etiqueta accesible del mapa para lectores de pantalla. */
-  ariaLabel?: string;
-  className?: string;
-  /** Etiqueta de la capa activa mostrada en la leyenda. */
-  layerLabel?: string;
-  /** Sufijo de unidad del indicador activo (se propaga al tooltip). */
-  unit?: string;
+  readonly ariaLabel?: string;
+  readonly className?: string;
+  /** Identificador de capa activa (catálogo). */
+  readonly layerId?: MapLayerId;
+  /**
+   * Etiqueta de la capa activa mostrada en la leyenda. Si se omite y se
+   * dispone de `layerId`, se infiere desde el catálogo.
+   */
+  readonly layerLabel?: string;
+  /**
+   * Sufijo de unidad del indicador activo. Se infiere del catálogo cuando
+   * está disponible. Mantenido por compatibilidad con la API previa.
+   */
+  readonly unit?: string;
   /**
    * Fuerza el estilo de fallback. Útil en tests para evitar peticiones de red
    * y en entornos sin acceso a OpenFreeMap.
    */
-  offline?: boolean;
-};
-
-type HoveredState = {
-  point: MapPoint;
-  x: number;
-  y: number;
-};
-
-/**
- * Devuelve el color del score respetando los tramos declarados en
- * `SCORE_BREAKS` y `GREEN_RAMP`.
- */
-export function scoreToColor(score: number): string {
-  for (let index = 0; index < SCORE_BREAKS.length; index += 1) {
-    if (score >= SCORE_BREAKS[index]) {
-      return GREEN_RAMP[index];
-    }
-  }
-  return GREEN_RAMP[GREEN_RAMP.length - 1];
+  readonly offline?: boolean;
 }
 
-function buildLegendStops(): MapLegendStop[] {
-  // Presentamos los tramos de menor a mayor para leerse de izquierda a derecha.
-  const stops: MapLegendStop[] = [];
-  for (let index = SCORE_BREAKS.length - 1; index >= 0; index -= 1) {
-    const min = SCORE_BREAKS[index];
-    const max = index === 0 ? 100 : SCORE_BREAKS[index - 1];
-    stops.push({ min, max, color: GREEN_RAMP[index] });
-  }
-  return stops;
+interface MarkerPresentation {
+  readonly id: string;
+  readonly name: string;
+  readonly lat: number;
+  readonly lon: number;
+  readonly score: number;
+  readonly value: number;
+  readonly color: string;
+  readonly radius: number;
+  readonly indicators?: readonly MapTooltipIndicator[];
+  readonly province?: string;
+}
+
+interface HoveredState {
+  readonly marker: MarkerPresentation;
+  readonly x: number;
+  readonly y: number;
+}
+
+function isEnriched(point: SpainMapPoint): point is EnrichedMapPoint {
+  return 'indicators' in point && Array.isArray((point as EnrichedMapPoint).indicators);
+}
+
+/**
+ * Convierte un punto (legacy o enriquecido) en el shape consumido por el
+ * catálogo de capas. Para puntos legacy se simulan los indicadores mínimos
+ * (`score`) que satisfacen los selectores del catálogo de capas.
+ */
+function ensureEnriched(point: SpainMapPoint): EnrichedMapPoint {
+  if (isEnriched(point)) return point;
+  return {
+    ...point,
+    indicators: [],
+    population: 0,
+    province: '',
+    autonomousCommunity: '',
+  };
 }
 
 export function SpainMap({
   points,
   ariaLabel = 'Mapa territorial de España',
   className,
-  layerLabel = 'Score territorial',
-  unit = '',
+  layerId,
+  layerLabel,
+  unit,
   offline = false,
 }: SpainMapProps) {
   const [hovered, setHovered] = useState<HoveredState | null>(null);
   const containerRef = useRef<HTMLElement | null>(null);
 
-  const legendStops = useMemo(() => buildLegendStops(), []);
+  /*
+   * Resolver la capa activa: cuando viene un `layerId` consultamos el
+   * catálogo. Si no se especifica, mantenemos compatibilidad con el
+   * comportamiento previo construyendo una capa "virtual" de score con la
+   * paleta verde original. Esto evita que clientes antiguos (los tests del
+   * propio repo o snapshots ya tomados) sufran cambios visuales no deseados.
+   */
+  const activeLayer: MapLayerDefinition = useMemo(() => {
+    if (layerId) return resolveLayer(layerId);
+    return {
+      id: 'score',
+      label: layerLabel ?? 'Score territorial',
+      description: 'Score agregado [0, 100] del municipio.',
+      unit: unit ?? '',
+      palette: [...LEGACY_GREEN_RAMP] as unknown as MapLayerDefinition['palette'],
+      selector: (point) => point.score,
+    };
+  }, [layerId, layerLabel, unit]);
 
-  const markers = useMemo(
-    () =>
-      points.map((point) => ({
-        ...point,
-        color: scoreToColor(point.score),
-        radius: 10 + Math.round((point.score / 100) * 14),
-      })),
-    [points]
+  const enrichedPoints = useMemo(() => points.map(ensureEnriched), [points]);
+
+  const domain = useMemo(
+    () => computeLayerDomain(enrichedPoints, activeLayer),
+    [enrichedPoints, activeLayer]
   );
 
+  const markers = useMemo<MarkerPresentation[]>(
+    () =>
+      enrichedPoints.map((point) => {
+        const value = activeLayer.selector(point);
+        return {
+          id: point.id,
+          name: point.name,
+          lat: point.lat,
+          lon: point.lon,
+          score: point.score,
+          value,
+          color: valueToColor(value, activeLayer, domain),
+          radius: valueToRadius(value, domain),
+          indicators: point.indicators?.map((indicator) => ({
+            id: indicator.id,
+            label: indicator.label,
+            value: indicator.value,
+            unit: indicator.unit,
+          })),
+          province: point.province || undefined,
+        };
+      }),
+    [enrichedPoints, activeLayer, domain]
+  );
+
+  const legendStops = useMemo(() => buildLegendStops(activeLayer, domain), [activeLayer, domain]);
+
+  const resolvedUnit = unit ?? activeLayer.unit;
+  const resolvedLabel = layerLabel ?? activeLayer.label;
+
   /*
-   * Animación de entrada de los marcadores al montar (o cuando cambian los
-   * puntos). Usamos `gsap.from` sobre `.maplibregl-marker` para que cada pin
-   * aparezca con un leve "pop" escalonado. Respeta `prefers-reduced-motion`.
+   * Animación de entrada de los marcadores al montar (o cuando cambia la
+   * cantidad de puntos). NO la disparamos cuando cambia la capa: en ese caso
+   * solo actualizamos colores/tamaños y respetamos `prefers-reduced-motion`.
    */
   useGSAP(
     () => {
@@ -150,13 +231,44 @@ export function SpainMap({
     }
   );
 
+  /*
+   * Transición de color al cambiar de capa. La duración se ajusta a 0 cuando
+   * el usuario solicita reducción de movimiento, en cuyo caso el color cambia
+   * de forma instantánea. La animación se aplica a los hijos `<button>` de
+   * los marcadores para no tocar el viewport ni las capas vectoriales.
+   */
+  useGSAP(
+    () => {
+      const container = containerRef.current;
+      if (!container) return;
+      const targets = container.querySelectorAll('[data-spain-marker]');
+      if (targets.length === 0) return;
+      const duration = prefersReducedMotion() ? 0 : 0.35;
+      gsap.fromTo(
+        targets,
+        { backgroundColor: 'inherit' },
+        {
+          backgroundColor: (_index: number, target: HTMLElement) =>
+            target.dataset.bubbleColor ?? '#10b981',
+          duration,
+          ease: 'sine.out',
+          overwrite: 'auto',
+        }
+      );
+    },
+    {
+      scope: containerRef,
+      dependencies: [activeLayer.id],
+    }
+  );
+
   const handleEnter = useCallback(
-    (point: MapPoint) => (event: ReactPointerEvent<Element>) => {
+    (marker: MarkerPresentation) => (event: ReactPointerEvent<Element>) => {
       const container = event.currentTarget.closest('[data-spain-map]') as HTMLElement | null;
       const rect = container?.getBoundingClientRect();
       const x = rect ? event.clientX - rect.left : event.clientX;
       const y = rect ? event.clientY - rect.top : event.clientY;
-      setHovered({ point, x, y });
+      setHovered({ marker, x, y });
     },
     []
   );
@@ -183,10 +295,8 @@ export function SpainMap({
         containerRef.current = node;
       }}
       data-spain-map
+      data-active-layer={activeLayer.id}
       aria-label={ariaLabel}
-      // El mapa lleva radios 1.5rem (rounded-3xl) coincidentes con la card
-      // contenedora del DashboardShell. La sombra interior es muy suave para
-      // no competir con la sombra de la card padre.
       className={[
         'relative h-full min-h-[360px] w-full overflow-hidden rounded-[20px] bg-[var(--color-surface-muted)]',
         className ?? '',
@@ -208,7 +318,9 @@ export function SpainMap({
           <Marker key={marker.id} longitude={marker.lon} latitude={marker.lat} anchor="center">
             <button
               type="button"
-              aria-label={`${marker.name}: score ${marker.score}`}
+              data-spain-marker
+              data-bubble-color={marker.color}
+              aria-label={`${marker.name}: ${resolvedLabel} ${marker.value.toLocaleString('es-ES')}${resolvedUnit}`}
               className="focus-visible:ring-brand-300 relative flex items-center justify-center rounded-full border-2 border-white/95 font-bold text-white tabular-nums transition-transform hover:scale-110 focus-visible:scale-110 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
               style={{
                 width: marker.radius,
@@ -228,14 +340,10 @@ export function SpainMap({
                 const btn = event.currentTarget.getBoundingClientRect();
                 const x = rect ? btn.left + btn.width / 2 - rect.left : btn.left;
                 const y = rect ? btn.top - rect.top : btn.top;
-                setHovered({ point: marker, x, y });
+                setHovered({ marker, x, y });
               }}
               onBlur={handleLeave}
             >
-              {/*
-               * Highlight superior: gradiente radial blanco que añade una
-               * sensación de relieve a la burbuja, igual que en el comp.
-               */}
               <span
                 aria-hidden="true"
                 className="pointer-events-none absolute inset-1 rounded-full opacity-80"
@@ -244,12 +352,6 @@ export function SpainMap({
                     'radial-gradient(circle at 30% 30%, rgba(255,255,255,0.55), transparent 60%)',
                 }}
               />
-              {/*
-               * Score numérico dentro de la burbuja (visible sólo cuando el
-               * tamaño es >= 24px para evitar amontonamiento en marcadores
-               * pequeños). La fuente blanca contrasta AA con cualquier verde
-               * de la rampa porque siempre estamos en >=`brand-400`.
-               */}
               {marker.radius >= 24 ? (
                 <span aria-hidden="true" className="relative leading-none drop-shadow-sm">
                   {marker.score}
@@ -262,16 +364,27 @@ export function SpainMap({
 
       {hovered ? (
         <MapTooltip
-          name={hovered.point.name}
-          value={hovered.point.value}
-          score={hovered.point.score}
+          name={hovered.marker.name}
+          value={hovered.marker.value}
+          score={hovered.marker.score}
           x={hovered.x}
           y={hovered.y}
-          unit={unit}
+          unit={resolvedUnit}
+          layerLabel={resolvedLabel}
+          activeIndicatorId={activeLayer.id === 'score' ? undefined : activeLayer.id}
+          indicators={hovered.marker.indicators}
+          province={hovered.marker.province}
         />
       ) : null}
 
-      <MapLegend label={layerLabel} stops={legendStops} className="absolute bottom-4 left-4" />
+      <MapLegend
+        label={resolvedLabel}
+        stops={legendStops}
+        unit={resolvedUnit}
+        domain={domain}
+        description={layerId ? activeLayer.description : undefined}
+        className="absolute bottom-4 left-4"
+      />
     </section>
   );
 }

--- a/apps/web/src/features/map/__tests__/MapLegend.test.tsx
+++ b/apps/web/src/features/map/__tests__/MapLegend.test.tsx
@@ -1,0 +1,53 @@
+/**
+ * Tests de la leyenda dinámica.
+ *
+ * Verifica que la leyenda actualiza unidad, dominio y descripción cuando se
+ * cambia la capa activa, garantizando coherencia con la rampa cromática.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { MapLegend } from '../MapLegend';
+
+const stops = [
+  { min: 0, max: 20, color: '#34d399' },
+  { min: 20, max: 40, color: '#10b981' },
+  { min: 40, max: 60, color: '#059669' },
+  { min: 60, max: 80, color: '#047857' },
+  { min: 80, max: 100, color: '#065f46' },
+];
+
+describe('MapLegend', () => {
+  it('renderiza la etiqueta y la unidad de la capa', () => {
+    render(<MapLegend label="Banda ancha" stops={stops} unit=" %" domain={{ min: 0, max: 100 }} />);
+    expect(screen.getByTestId('map-legend-label').textContent).toMatch(/banda ancha/i);
+    expect(screen.getByTestId('map-legend-unit').textContent).toMatch(/%/);
+  });
+
+  it('renderiza un stop por cada tramo', () => {
+    render(<MapLegend label="Score" stops={stops} unit="" domain={{ min: 0, max: 100 }} />);
+    const list = screen.getByTestId('map-legend-stops');
+    expect(list.querySelectorAll('li')).toHaveLength(stops.length);
+  });
+
+  it('muestra descripción cuando se proporciona', () => {
+    render(
+      <MapLegend
+        label="Alquiler medio"
+        description="Precio mensual del alquiler residencial."
+        stops={stops}
+        unit=" €/m²"
+        domain={{ min: 400, max: 1500 }}
+      />
+    );
+    expect(screen.getByTestId('map-legend-desc').textContent).toMatch(/precio mensual/i);
+  });
+
+  it('imprime el dominio observado en mínimos y máximos', () => {
+    render(<MapLegend label="Renta" stops={stops} unit=" €" domain={{ min: 25000, max: 45000 }} />);
+    const numbers = screen.getByLabelText(/leyenda: renta/i).textContent ?? '';
+    expect(numbers).toContain('25.000');
+    expect(numbers).toContain('45.000');
+  });
+});

--- a/apps/web/src/features/map/__tests__/MapPage.test.tsx
+++ b/apps/web/src/features/map/__tests__/MapPage.test.tsx
@@ -1,0 +1,37 @@
+/**
+ * Tests de la página `/mapa`.
+ *
+ * Verifica que la página monta el `LayerSwitcher` reactivo y que la
+ * interacción del usuario sincroniza el store global, garantizando que la
+ * elección persista al volver a la home.
+ */
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { MapPage } from '../MapPage';
+import { useMapLayerStore } from '@/state/mapLayer';
+
+describe('MapPage', () => {
+  beforeEach(() => {
+    useMapLayerStore.getState().resetActiveLayer();
+    /* eslint-disable-next-line no-undef -- localStorage es global del navegador. */
+    localStorage.clear();
+  });
+
+  it('renderiza el panel lateral con el switcher reactivo', () => {
+    render(<MapPage />);
+    expect(screen.getByRole('radiogroup', { name: /capa activa/i })).toBeInTheDocument();
+    // El catálogo se materializa como radios (al menos 8).
+    expect(screen.getAllByRole('radio').length).toBeGreaterThanOrEqual(8);
+  });
+
+  it('al cambiar de capa actualiza el store y la leyenda', async () => {
+    const user = userEvent.setup();
+    render(<MapPage />);
+    await user.click(screen.getByRole('radio', { name: /banda ancha/i }));
+    expect(useMapLayerStore.getState().activeLayerId).toBe('broadband');
+    expect(screen.getByTestId('map-legend-label').textContent).toMatch(/banda ancha/i);
+  });
+});

--- a/apps/web/src/features/map/__tests__/MapTooltip.test.tsx
+++ b/apps/web/src/features/map/__tests__/MapTooltip.test.tsx
@@ -1,0 +1,80 @@
+/**
+ * Tests del tooltip multi-indicador.
+ *
+ * Verifica que: (a) el tooltip muestra la lista completa de indicadores
+ * cuando se proporciona, (b) resalta el indicador asociado a la capa activa
+ * y (c) cae a la versión clásica cuando no hay indicadores.
+ */
+
+import { render, screen, within } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { MapTooltip, type MapTooltipIndicator } from '../MapTooltip';
+
+const indicators: MapTooltipIndicator[] = [
+  { id: 'rent_price', label: 'Alquiler medio', value: 950, unit: '€/mes' },
+  { id: 'broadband', label: 'Banda ancha', value: 95, unit: '%' },
+  { id: 'income', label: 'Renta', value: 28000, unit: '€' },
+  { id: 'accidents', label: 'Accidentes', value: 12, unit: 'víctimas/año' },
+];
+
+describe('MapTooltip', () => {
+  it('muestra TODOS los indicadores cuando se aportan', () => {
+    render(
+      <MapTooltip
+        name="Sevilla"
+        score={82}
+        value={950}
+        x={0}
+        y={0}
+        layerLabel="Alquiler medio"
+        unit=" €/m²"
+        activeIndicatorId="rent_price"
+        indicators={indicators}
+      />
+    );
+    const list = screen.getByTestId('tooltip-indicators');
+    expect(within(list).getAllByRole('listitem')).toHaveLength(indicators.length);
+  });
+
+  it('resalta el indicador activo (data-active=true)', () => {
+    render(
+      <MapTooltip
+        name="Sevilla"
+        score={82}
+        value={95}
+        x={0}
+        y={0}
+        layerLabel="Banda ancha"
+        unit=" %"
+        activeIndicatorId="broadband"
+        indicators={indicators}
+      />
+    );
+    const list = screen.getByTestId('tooltip-indicators');
+    const items = within(list).getAllByRole('listitem');
+    const active = items.find((item) => item.getAttribute('data-active') === 'true');
+    expect(active?.textContent ?? '').toMatch(/banda ancha/i);
+  });
+
+  it('refleja la etiqueta de la capa activa', () => {
+    render(
+      <MapTooltip
+        name="Madrid"
+        score={89}
+        value={99}
+        x={0}
+        y={0}
+        layerLabel="Banda ancha"
+        unit=" %"
+        indicators={indicators}
+      />
+    );
+    expect(screen.getByTestId('tooltip-active-layer').textContent).toBe('Banda ancha');
+  });
+
+  it('cae a layout clásico sin lista cuando no hay indicadores', () => {
+    render(<MapTooltip name="Sevilla" score={82} value={950} x={0} y={0} unit="€" />);
+    expect(screen.queryByTestId('tooltip-indicators')).toBeNull();
+  });
+});

--- a/apps/web/src/features/map/__tests__/SpainMap.test.tsx
+++ b/apps/web/src/features/map/__tests__/SpainMap.test.tsx
@@ -1,13 +1,20 @@
-import { render, screen } from '@testing-library/react';
+/**
+ * Tests de SpainMap multi-métrica.
+ *
+ * Verifica:
+ *  - Render del canvas y un marker por punto.
+ *  - Compatibilidad legacy (`scoreToColor`) con la rampa verde original.
+ *  - Reactividad: al cambiar `layerId`, leyenda y atributos `data-active-layer`
+ *    se actualizan sin remontar el `<Map>` (mismo `data-testid`).
+ *  - El tooltip recibe la unidad y etiqueta de la capa.
+ */
+
+import { render, screen, act } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 
-// maplibre-gl usa WebGL, que jsdom no implementa. Sustituimos el módulo por un
-// objeto vacío porque `react-map-gl` sólo lo usa como peer dependency.
 vi.mock('maplibre-gl', () => ({ default: {} }));
 
-// Reemplazamos los componentes de react-map-gl por contenedores predecibles
-// para poder aserta estructura sin inicializar un canvas real.
 vi.mock('react-map-gl/maplibre', () => ({
   __esModule: true,
   default: ({ children }: { children?: ReactNode }) => (
@@ -21,6 +28,7 @@ vi.mock('react-map-gl/maplibre', () => ({
 
 import { SpainMap, scoreToColor } from '../SpainMap';
 import { mockPoints } from '@/data/mock';
+import { toEnrichedMapPoints } from '@/data/national_mock';
 
 describe('SpainMap', () => {
   it('renderiza el canvas del mapa y un marcador por cada punto', () => {
@@ -44,5 +52,34 @@ describe('SpainMap', () => {
     expect(high).toBe('#065f46');
     expect(mid).not.toBe(high);
     expect(low).toBe('#34d399');
+  });
+
+  it('actualiza la leyenda al cambiar de capa sin remontar el canvas', () => {
+    const enriched = toEnrichedMapPoints();
+
+    const { rerender } = render(<SpainMap points={enriched} layerId="score" offline />);
+    const initialCanvas = screen.getByTestId('maplibre-canvas');
+    expect(screen.getByTestId('map-legend-label').textContent).toMatch(/score territorial/i);
+
+    act(() => {
+      rerender(<SpainMap points={enriched} layerId="broadband" offline />);
+    });
+
+    // El mismo nodo de canvas debe persistir (no remount).
+    expect(screen.getByTestId('maplibre-canvas')).toBe(initialCanvas);
+    expect(screen.getByTestId('map-legend-label').textContent).toMatch(/banda ancha/i);
+    expect(screen.getByTestId('map-legend-unit').textContent).toMatch(/%/);
+  });
+
+  it('cambia la unidad y descripción para capas con dominios distintos', () => {
+    const enriched = toEnrichedMapPoints();
+
+    const { rerender } = render(<SpainMap points={enriched} layerId="rent_price" offline />);
+    expect(screen.getByTestId('map-legend-unit').textContent).toMatch(/€/);
+
+    act(() => {
+      rerender(<SpainMap points={enriched} layerId="accidents" offline />);
+    });
+    expect(screen.getByTestId('map-legend-unit').textContent).toMatch(/víctimas/);
   });
 });

--- a/apps/web/src/features/map/index.ts
+++ b/apps/web/src/features/map/index.ts
@@ -1,6 +1,22 @@
 export { SpainMap, scoreToColor } from './SpainMap';
-export type { SpainMapProps } from './SpainMap';
+export type { SpainMapProps, SpainMapPoint } from './SpainMap';
 export { MapLegend } from './MapLegend';
-export type { MapLegendProps, MapLegendStop } from './MapLegend';
+export type { MapLegendProps, MapLegendStop, MapLegendDomain } from './MapLegend';
 export { MapTooltip } from './MapTooltip';
-export type { MapTooltipProps } from './MapTooltip';
+export type { MapTooltipProps, MapTooltipIndicator } from './MapTooltip';
+export {
+  LayerSwitcher,
+  MAP_LAYER_CATALOG,
+  MAP_LAYER_BY_ID,
+  resolveLayer,
+  computeLayerDomain,
+  valueToColor,
+  valueToRadius,
+  buildLegendStops,
+  type MapLayerDefinition,
+  type MapLayerId,
+  type LayerDomain,
+  type LayerLegendStop,
+  type EnrichedMapPoint,
+  type LayerSwitcherProps,
+} from './layers';

--- a/apps/web/src/features/map/layers/LayerSwitcher.tsx
+++ b/apps/web/src/features/map/layers/LayerSwitcher.tsx
@@ -1,172 +1,137 @@
 /**
- * Panel de capas del mapa con multi-select y leyenda por indicador.
+ * Selector reactivo de capa activa para el mapa multi-métrica.
  *
- * Ofrece >=6 capas (score por perfil, rent, broadband, income, services,
- * climate) activables a la vez. Cada capa declara su gradiente y unidad, con
- * lo que el consumidor puede renderizar una leyenda coherente sin lógica
- * extra.
+ * Renderiza un grupo de radios accesible donde cada opción muestra:
+ *  - una rampa cromática preview con la paleta de la capa,
+ *  - su etiqueta principal,
+ *  - su descripción larga,
+ *  - la unidad asociada (en mayúsculas para que sea legible como sufijo).
+ *
+ * El componente es totalmente controlado: el padre proporciona `activeLayerId`
+ * y `onChange`. Esto permite al store global (`state/mapLayer.ts`) mantener
+ * la sincronía entre la home y la página `/mapa`. La lista de capas y los
+ * metadatos provienen del catálogo (`features/map/layers/catalog.ts`) para
+ * evitar duplicaciones.
+ *
+ * Accesibilidad:
+ *  - `role="radiogroup"` con `aria-label` describe el grupo.
+ *  - Cada opción es un `<input type="radio">` etiquetado con su descripción.
+ *  - Los cambios disparan un anuncio "polite" via `aria-live` para lectores
+ *    de pantalla, satisfaciendo el criterio AA del issue.
  */
 
-import { Layers } from 'lucide-react';
-import { useState, type ReactNode } from 'react';
-import { Card, CardHeader } from '../../../components/ui/Card';
-import { Tag } from '../../../components/ui/Tag';
-import { Toggle } from '../../../components/ui/Toggle';
+import { useId, useMemo } from 'react';
+
 import { cn } from '../../../components/ui/cn';
-import type { IndicatorId } from '../../../data/national_mock';
-
-export type MapLayerId = 'score' | IndicatorId;
-
-export interface MapLayerDefinition {
-  readonly id: MapLayerId;
-  readonly label: string;
-  readonly description: string;
-  readonly unit: string;
-  readonly ramp: readonly string[];
-  readonly defaultActive?: boolean;
-}
-
-export const DEFAULT_LAYER_DEFINITIONS: readonly MapLayerDefinition[] = [
-  {
-    id: 'score',
-    label: 'Score por perfil',
-    description: 'Agregado ponderado del perfil activo.',
-    unit: '/100',
-    ramp: ['#065f46', '#047857', '#059669', '#10b981', '#34d399'],
-    defaultActive: true,
-  },
-  {
-    id: 'rent_price',
-    label: 'Precio alquiler',
-    description: 'Alquiler medio residencial.',
-    unit: ' €/mes',
-    ramp: ['#3f6212', '#4d7c0f', '#84cc16', '#bef264', '#ecfccb'],
-  },
-  {
-    id: 'broadband',
-    label: 'Banda ancha',
-    description: 'Cobertura de fibra FTTH y cable.',
-    unit: ' %',
-    ramp: ['#0c4a6e', '#075985', '#0369a1', '#38bdf8', '#e0f2fe'],
-  },
-  {
-    id: 'income',
-    label: 'Renta por hogar',
-    description: 'Renta disponible bruta.',
-    unit: ' €',
-    ramp: ['#4c1d95', '#6d28d9', '#8b5cf6', '#c4b5fd', '#ede9fe'],
-  },
-  {
-    id: 'services',
-    label: 'Servicios sanitarios',
-    description: 'Centros por 10.000 habitantes.',
-    unit: ' ratio',
-    ramp: ['#7c2d12', '#9a3412', '#ea580c', '#fb923c', '#fed7aa'],
-  },
-  {
-    id: 'climate',
-    label: 'Clima',
-    description: 'Temperatura media anual.',
-    unit: ' °C',
-    ramp: ['#1e3a8a', '#1d4ed8', '#3b82f6', '#93c5fd', '#dbeafe'],
-  },
-];
+import { MAP_LAYER_CATALOG, type MapLayerDefinition, type MapLayerId } from './catalog';
 
 export interface LayerSwitcherProps {
+  /** Lista de capas a mostrar. Por defecto el catálogo completo. */
   readonly layers?: readonly MapLayerDefinition[];
-  readonly activeLayers?: readonly MapLayerId[];
-  readonly onChange?: (active: readonly MapLayerId[]) => void;
-  readonly legendSlot?: ReactNode;
+  /** Identificador de la capa actualmente activa. */
+  readonly activeLayerId: MapLayerId;
+  /** Callback al cambiar de capa. */
+  readonly onChange: (id: MapLayerId) => void;
+  /** Si `true`, muestra una versión compacta sin descripción larga. */
+  readonly compact?: boolean;
+  /** Etiqueta accesible del grupo de radios. */
+  readonly ariaLabel?: string;
   readonly className?: string;
 }
 
-export function LayerSwitcher({
-  layers = DEFAULT_LAYER_DEFINITIONS,
-  activeLayers,
-  onChange,
-  legendSlot,
-  className,
-}: LayerSwitcherProps) {
-  const [internalActive, setInternalActive] = useState<readonly MapLayerId[]>(() => {
-    if (activeLayers) return activeLayers;
-    return layers.filter((layer) => layer.defaultActive).map((layer) => layer.id);
-  });
-  const active = activeLayers ?? internalActive;
-
-  const handleToggle = (layerId: MapLayerId, checked: boolean) => {
-    const next = checked
-      ? Array.from(new Set([...active, layerId]))
-      : active.filter((id) => id !== layerId);
-    if (!activeLayers) setInternalActive(next);
-    onChange?.(next);
-  };
-
-  const activeDefs = layers.filter((layer) => active.includes(layer.id));
-
+/**
+ * Renderiza la rampa cromática (5 stops) como un degradado lineal horizontal.
+ * Es puramente decorativo y se oculta a tecnologías asistivas.
+ */
+function LayerRampPreview({ palette }: { palette: readonly string[] }) {
+  // Reverseamos visualmente para mostrar bajo→alto (left → right). La paleta
+  // se declara alto→bajo, así que aquí invertimos el orden visual.
+  const reversed = palette.slice().reverse();
   return (
-    <Card
-      tone="base"
-      padding="md"
-      className={cn('flex flex-col gap-4', className)}
-      aria-label="Panel de capas del mapa"
-      data-feature="layer-switcher"
-    >
-      <CardHeader
-        title="Capas del mapa"
-        subtitle="Activa múltiples capas para comparar dimensiones."
-        action={
-          <Tag tone="info" icon={<Layers size={12} aria-hidden="true" />}>
-            {active.length} activas
-          </Tag>
-        }
-      />
-      <ul className="flex flex-col gap-2" role="group" aria-label="Capas disponibles">
-        {layers.map((layer) => {
-          const checked = active.includes(layer.id);
-          return (
-            <li
-              key={layer.id}
-              className={cn(
-                'rounded-2xl border px-3 py-2 transition-colors',
-                checked
-                  ? 'border-brand-200 bg-brand-50'
-                  : 'bg-surface-soft border-[color:var(--color-line-soft)]'
-              )}
-            >
-              <Toggle
-                label={layer.label}
-                helper={layer.description}
-                checked={checked}
-                onCheckedChange={(value) => handleToggle(layer.id, value)}
-              />
-              {checked ? (
-                <div className="mt-2 flex items-center gap-2" aria-hidden="true">
-                  {layer.ramp.map((color, idx) => (
-                    <span
-                      key={`${layer.id}-${idx}`}
-                      className="h-2 flex-1 rounded-full"
-                      style={{ backgroundColor: color }}
-                    />
-                  ))}
-                  <span className="text-ink-500 text-[10px] font-semibold tracking-wide uppercase">
-                    {layer.unit}
-                  </span>
-                </div>
-              ) : null}
-            </li>
-          );
-        })}
-      </ul>
-      {legendSlot ? (
-        <section aria-label="Leyenda combinada" className="flex flex-col gap-2">
-          {legendSlot}
-        </section>
-      ) : null}
-      {activeDefs.length === 0 ? (
-        <p className="text-ink-500 rounded-xl bg-amber-50 p-3 text-xs" role="status">
-          Activa al menos una capa para visualizarla en el mapa.
-        </p>
-      ) : null}
-    </Card>
+    <span
+      aria-hidden="true"
+      className="block h-1.5 w-full rounded-full"
+      style={{
+        backgroundImage: `linear-gradient(to right, ${reversed.join(', ')})`,
+      }}
+    />
   );
 }
+
+export function LayerSwitcher({
+  layers = MAP_LAYER_CATALOG,
+  activeLayerId,
+  onChange,
+  compact = false,
+  ariaLabel = 'Capa activa del mapa',
+  className,
+}: LayerSwitcherProps) {
+  const groupId = useId();
+  const activeLayer = useMemo(
+    () => layers.find((layer) => layer.id === activeLayerId) ?? layers[0],
+    [layers, activeLayerId]
+  );
+
+  return (
+    <div
+      role="radiogroup"
+      aria-label={ariaLabel}
+      data-feature="layer-switcher"
+      className={cn('flex flex-col gap-2', className)}
+    >
+      {layers.map((layer) => {
+        const isActive = layer.id === activeLayerId;
+        const inputId = `${groupId}-${layer.id}`;
+        return (
+          <label
+            key={layer.id}
+            htmlFor={inputId}
+            className={cn(
+              'group relative flex cursor-pointer flex-col gap-1.5 rounded-2xl border px-3 py-2.5 transition-colors',
+              'focus-within:ring-brand-300 focus-within:ring-2 focus-within:ring-offset-2',
+              isActive
+                ? 'border-brand-300 bg-brand-50 shadow-sm'
+                : 'border-[color:var(--color-line-soft)] bg-white hover:bg-[var(--color-surface-muted)]'
+            )}
+          >
+            <span className="flex items-start justify-between gap-3">
+              <span className="flex flex-col gap-0.5">
+                <span className="text-ink-900 text-sm font-semibold tracking-tight">
+                  {layer.label}
+                </span>
+                {!compact ? (
+                  <span className="text-ink-500 text-xs leading-snug">{layer.description}</span>
+                ) : null}
+              </span>
+              <input
+                id={inputId}
+                type="radio"
+                name={`map-layer-${groupId}`}
+                value={layer.id}
+                checked={isActive}
+                onChange={() => onChange(layer.id)}
+                className="text-brand-500 focus:ring-brand-300 mt-0.5 h-4 w-4 cursor-pointer accent-[var(--color-brand-500)]"
+                aria-describedby={`${inputId}-meta`}
+              />
+            </span>
+            <span className="flex items-center gap-2">
+              <LayerRampPreview palette={layer.palette} />
+              <span
+                id={`${inputId}-meta`}
+                className="text-ink-500 shrink-0 text-[10px] font-medium tracking-wider uppercase"
+              >
+                {layer.unit.trim() === '' ? '0–100' : layer.unit.trim()}
+              </span>
+            </span>
+          </label>
+        );
+      })}
+      <p className="sr-only" aria-live="polite">
+        Capa activa: {activeLayer.label}. {activeLayer.description}
+      </p>
+    </div>
+  );
+}
+
+export { MAP_LAYER_CATALOG } from './catalog';
+export type { MapLayerDefinition, MapLayerId } from './catalog';

--- a/apps/web/src/features/map/layers/__tests__/LayerSwitcher.test.tsx
+++ b/apps/web/src/features/map/layers/__tests__/LayerSwitcher.test.tsx
@@ -1,29 +1,54 @@
-import { render, screen } from '@testing-library/react';
+/**
+ * Tests del `LayerSwitcher` reactivo (single-select).
+ *
+ * Cubrimos: render del catálogo completo, propagación de eventos al cambiar
+ * la capa y atributos ARIA del grupo de radios. Mantener estos tests es
+ * crítico porque el componente se monta tanto en `/mapa` como en la home,
+ * sincronizado vía store global.
+ */
+
+import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
-import { DEFAULT_LAYER_DEFINITIONS, LayerSwitcher } from '../LayerSwitcher';
+
+import { LayerSwitcher } from '../LayerSwitcher';
+import { MAP_LAYER_CATALOG } from '../catalog';
 
 describe('LayerSwitcher', () => {
-  it('renderiza al menos seis capas disponibles', () => {
-    render(<LayerSwitcher />);
-    expect(DEFAULT_LAYER_DEFINITIONS.length).toBeGreaterThanOrEqual(6);
-    expect(screen.getAllByRole('switch').length).toBeGreaterThanOrEqual(6);
+  it('renderiza al menos ocho capas con role radio', () => {
+    expect(MAP_LAYER_CATALOG.length).toBeGreaterThanOrEqual(8);
+    render(<LayerSwitcher activeLayerId="score" onChange={() => undefined} />);
+    expect(screen.getAllByRole('radio')).toHaveLength(MAP_LAYER_CATALOG.length);
   });
 
-  it('activa y desactiva capas en modo no controlado', async () => {
-    const user = userEvent.setup();
-    render(<LayerSwitcher />);
-    const broadband = screen.getByRole('switch', { name: /banda ancha/i });
-    expect(broadband).toHaveAttribute('aria-checked', 'false');
-    await user.click(broadband);
-    expect(broadband).toHaveAttribute('aria-checked', 'true');
+  it('marca exactamente una capa como activa', () => {
+    render(<LayerSwitcher activeLayerId="broadband" onChange={() => undefined} />);
+    const broadband = screen.getByRole('radio', { name: /banda ancha/i });
+    expect(broadband).toBeChecked();
+    const score = screen.getByRole('radio', { name: /score territorial/i });
+    expect(score).not.toBeChecked();
   });
 
-  it('propaga el cambio al padre cuando está controlado', async () => {
+  it('propaga el cambio al padre con el id seleccionado', async () => {
     const user = userEvent.setup();
     const handleChange = vi.fn();
-    render(<LayerSwitcher activeLayers={['score']} onChange={handleChange} />);
-    await user.click(screen.getByRole('switch', { name: /renta por hogar/i }));
-    expect(handleChange).toHaveBeenCalledWith(['score', 'income']);
+    render(<LayerSwitcher activeLayerId="score" onChange={handleChange} />);
+    await user.click(screen.getByRole('radio', { name: /alquiler medio/i }));
+    expect(handleChange).toHaveBeenCalledWith('rent_price');
+  });
+
+  it('expone descripción y unidad de cada capa por accesibilidad', () => {
+    render(<LayerSwitcher activeLayerId="score" onChange={() => undefined} />);
+    const group = screen.getByRole('radiogroup', { name: /capa activa/i });
+    const accidents = within(group).getByText(/víctimas anuales en accidentes/i);
+    expect(accidents).toBeInTheDocument();
+  });
+
+  it('anuncia la capa activa con aria-live', () => {
+    const { container } = render(
+      <LayerSwitcher activeLayerId="climate" onChange={() => undefined} />
+    );
+    const live = container.querySelector('[aria-live="polite"]');
+    expect(live?.textContent ?? '').toMatch(/clima/i);
   });
 });

--- a/apps/web/src/features/map/layers/__tests__/catalog.test.ts
+++ b/apps/web/src/features/map/layers/__tests__/catalog.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Tests deterministas del catálogo de capas.
+ *
+ * Verifican que:
+ *  - El catálogo expone al menos las ocho capas que el issue requiere.
+ *  - Los selectores extraen el indicador correcto de un punto enriquecido.
+ *  - `computeLayerDomain` ignora puntos vacíos y resiste valores idénticos.
+ *  - `valueToColor` mapea de forma monótona dentro del dominio.
+ *  - `buildLegendStops` produce un número de tramos igual al de la paleta.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  MAP_LAYER_CATALOG,
+  buildLegendStops,
+  computeLayerDomain,
+  resolveLayer,
+  valueToColor,
+  valueToRadius,
+  type EnrichedMapPoint,
+} from '../catalog';
+
+const sample: EnrichedMapPoint = {
+  id: '00001',
+  name: 'Test',
+  lat: 0,
+  lon: 0,
+  score: 80,
+  value: 80,
+  population: 50_000,
+  province: 'Sevilla',
+  autonomousCommunity: 'Andalucía',
+  indicators: [
+    {
+      id: 'rent_price',
+      label: 'Alquiler medio',
+      value: 950,
+      unit: '€/mes',
+      sourceId: 'ine_housing',
+      quality: 'ok',
+    },
+    {
+      id: 'broadband',
+      label: 'Banda ancha',
+      value: 95,
+      unit: '%',
+      sourceId: 'miteco_broadband',
+      quality: 'ok',
+    },
+    { id: 'income', label: 'Renta', value: 28000, unit: '€', sourceId: 'ine_rent', quality: 'ok' },
+    {
+      id: 'services',
+      label: 'Servicios',
+      value: 2.6,
+      unit: 'ratio',
+      sourceId: 'msan_services',
+      quality: 'ok',
+    },
+    {
+      id: 'climate',
+      label: 'Clima',
+      value: 17.4,
+      unit: '°C',
+      sourceId: 'aemet_climate',
+      quality: 'ok',
+    },
+    {
+      id: 'mobility',
+      label: 'Mobilidad',
+      value: 30,
+      unit: 'min',
+      sourceId: 'mitma_mobility',
+      quality: 'ok',
+    },
+    {
+      id: 'accidents',
+      label: 'Accidentes',
+      value: 8,
+      unit: 'víctimas/año',
+      sourceId: 'dgt_accidents',
+      quality: 'ok',
+    },
+    {
+      id: 'transit',
+      label: 'Transporte',
+      value: 70,
+      unit: '%',
+      sourceId: 'crtm_transit',
+      quality: 'ok',
+    },
+  ],
+};
+
+describe('catálogo de capas', () => {
+  it('expone al menos ocho capas distintas', () => {
+    expect(MAP_LAYER_CATALOG.length).toBeGreaterThanOrEqual(8);
+    const ids = new Set(MAP_LAYER_CATALOG.map((layer) => layer.id));
+    expect(ids.size).toBe(MAP_LAYER_CATALOG.length);
+  });
+
+  it('cada capa declara metadata accesibles', () => {
+    for (const layer of MAP_LAYER_CATALOG) {
+      expect(layer.label.length).toBeGreaterThan(0);
+      expect(layer.description.length).toBeGreaterThan(0);
+      expect(layer.palette).toHaveLength(5);
+      expect(typeof layer.selector).toBe('function');
+    }
+  });
+
+  it('los selectores extraen el indicador correcto', () => {
+    const broadband = resolveLayer('broadband');
+    expect(broadband.selector(sample)).toBe(95);
+    const accidents = resolveLayer('accidents');
+    expect(accidents.selector(sample)).toBe(8);
+    const score = resolveLayer('score');
+    expect(score.selector(sample)).toBe(80);
+  });
+
+  it('resolveLayer cae al score con id desconocido', () => {
+    expect(resolveLayer('invalid' as never).id).toBe('score');
+  });
+
+  it('computeLayerDomain devuelve rango ensanchado cuando todos los valores son iguales', () => {
+    const layer = resolveLayer('score');
+    const domain = computeLayerDomain([sample], layer);
+    expect(domain.max - domain.min).toBeGreaterThan(0);
+  });
+
+  it('computeLayerDomain devuelve [0, 1] cuando no hay puntos', () => {
+    const layer = resolveLayer('score');
+    const domain = computeLayerDomain([], layer);
+    expect(domain).toEqual({ min: 0, max: 1 });
+  });
+
+  it('valueToColor escoge el primer color para el máximo y el último para el mínimo', () => {
+    const layer = resolveLayer('score');
+    const domain = { min: 0, max: 100 };
+    const top = valueToColor(100, layer, domain);
+    const bottom = valueToColor(0, layer, domain);
+    expect(top).toBe(layer.palette[0]);
+    expect(bottom).toBe(layer.palette[layer.palette.length - 1]);
+  });
+
+  it('valueToRadius interpola dentro de los bounds esperados', () => {
+    const radius = valueToRadius(50, { min: 0, max: 100 });
+    expect(radius).toBeGreaterThanOrEqual(12);
+    expect(radius).toBeLessThanOrEqual(28);
+  });
+
+  it('buildLegendStops genera tantos tramos como colores tiene la paleta', () => {
+    const layer = resolveLayer('rent_price');
+    const stops = buildLegendStops(layer, { min: 400, max: 1500 });
+    expect(stops).toHaveLength(layer.palette.length);
+    // Los tramos deben cubrir el dominio completo.
+    expect(stops[0].min).toBe(400);
+    expect(stops[stops.length - 1].max).toBe(1500);
+  });
+});

--- a/apps/web/src/features/map/layers/catalog.ts
+++ b/apps/web/src/features/map/layers/catalog.ts
@@ -1,0 +1,265 @@
+/**
+ * Catálogo declarativo de capas multi-métrica del mapa territorial.
+ *
+ * Cada entrada describe los metadatos visuales (paleta, etiqueta, unidad,
+ * descripción) y la lógica para extraer su valor desde un `EnrichedMapPoint`.
+ * Este desacoplamiento permite que `SpainMap`, la leyenda y el switcher
+ * compartan exactamente la misma fuente de verdad: una sola declaración
+ * impacta a todas las superficies de UI sin duplicar lógica.
+ *
+ * Reglas de diseño:
+ *  - El catálogo es estático (no depende de los datos): la paleta y la
+ *    descripción son inmutables.
+ *  - El dominio (`domain`) se calcula a partir de los puntos en runtime con
+ *    `computeLayerDomain` para que el rampado refleje el rango real visible.
+ *  - El campo `inverse` indica si valores bajos representan "mejor": para
+ *    accidentes/precio de alquiler, queremos que la rampa más oscura/cálida
+ *    señale los valores altos (peor) y la suave los valores bajos (mejor).
+ */
+
+import type { IndicatorId, NationalMunicipality } from '../../../data/national_mock';
+import type { MapPoint } from '../../../data/mock';
+
+/** Identificador de capa: `score` o cualquier indicador del catálogo nacional. */
+export type MapLayerId = 'score' | IndicatorId;
+
+/**
+ * Punto del mapa enriquecido con todos los indicadores del municipio.
+ *
+ * Conserva los campos originales de `MapPoint` para no romper la firma de
+ * `SpainMap`, y añade las series completas de `national_mock` para que el
+ * tooltip multi-indicador pueda listarlas todas a la vez.
+ */
+export interface EnrichedMapPoint extends MapPoint {
+  readonly indicators: NationalMunicipality['indicators'];
+  readonly population: number;
+  readonly province: string;
+  readonly autonomousCommunity: string;
+}
+
+/** Dominio (mín/máx) detectado para una capa concreta. */
+export interface LayerDomain {
+  readonly min: number;
+  readonly max: number;
+}
+
+export interface MapLayerDefinition {
+  readonly id: MapLayerId;
+  readonly label: string;
+  readonly description: string;
+  /** Sufijo de unidad usado en leyenda y tooltip. */
+  readonly unit: string;
+  /** Paleta cromática de cinco tramos (oscuro → claro). */
+  readonly palette: readonly [string, string, string, string, string];
+  /** Si `true`, valores bajos se interpretan como "mejor". */
+  readonly inverse?: boolean;
+  /** Selector que extrae el valor numérico desde un punto enriquecido. */
+  readonly selector: (point: EnrichedMapPoint) => number;
+}
+
+/**
+ * Helper privado para resolver el indicador `id` y devolver `0` si no existe
+ * (los datasets reales pueden quedar parcialmente cubiertos).
+ */
+function pickIndicator(point: EnrichedMapPoint, id: IndicatorId): number {
+  const indicator = point.indicators.find((entry) => entry.id === id);
+  return indicator?.value ?? 0;
+}
+
+export const MAP_LAYER_CATALOG: readonly MapLayerDefinition[] = [
+  {
+    id: 'score',
+    label: 'Score territorial',
+    description: 'Encaje agregado del municipio con el perfil activo.',
+    unit: '',
+    palette: ['#065f46', '#047857', '#059669', '#10b981', '#34d399'],
+    selector: (point) => point.score,
+  },
+  {
+    id: 'rent_price',
+    label: 'Alquiler medio',
+    description: 'Precio mensual del alquiler residencial (INE Vivienda).',
+    unit: ' €/m²',
+    palette: ['#7f1d1d', '#b91c1c', '#dc2626', '#f87171', '#fee2e2'],
+    inverse: true,
+    selector: (point) => pickIndicator(point, 'rent_price'),
+  },
+  {
+    id: 'broadband',
+    label: 'Banda ancha',
+    description: 'Cobertura FTTH y cable >100 Mbps (MITECO).',
+    unit: ' %',
+    palette: ['#0c4a6e', '#075985', '#0369a1', '#38bdf8', '#bae6fd'],
+    selector: (point) => pickIndicator(point, 'broadband'),
+  },
+  {
+    id: 'income',
+    label: 'Renta hogar',
+    description: 'Renta disponible bruta media por hogar (INE).',
+    unit: ' €',
+    palette: ['#312e81', '#4338ca', '#6366f1', '#a5b4fc', '#e0e7ff'],
+    selector: (point) => pickIndicator(point, 'income'),
+  },
+  {
+    id: 'services',
+    label: 'Servicios sanitarios',
+    description: 'Centros sanitarios por 10.000 habitantes (Ministerio de Sanidad).',
+    unit: ' ratio',
+    palette: ['#7c2d12', '#9a3412', '#ea580c', '#fb923c', '#fed7aa'],
+    selector: (point) => pickIndicator(point, 'services'),
+  },
+  {
+    id: 'climate',
+    label: 'Clima',
+    description: 'Temperatura media anual (AEMET).',
+    unit: ' °C',
+    palette: ['#1e3a8a', '#1d4ed8', '#3b82f6', '#93c5fd', '#dbeafe'],
+    selector: (point) => pickIndicator(point, 'climate'),
+  },
+  {
+    id: 'mobility',
+    label: 'Movilidad',
+    description: 'Duración media del trayecto al trabajo (MITMA Big Data).',
+    unit: ' min',
+    palette: ['#581c87', '#7e22ce', '#a855f7', '#c084fc', '#e9d5ff'],
+    inverse: true,
+    selector: (point) => pickIndicator(point, 'mobility'),
+  },
+  {
+    id: 'accidents',
+    label: 'Accidentes',
+    description: 'Víctimas anuales en accidentes de tráfico (DGT).',
+    unit: ' víctimas/año',
+    palette: ['#450a0a', '#7f1d1d', '#b91c1c', '#f87171', '#fecaca'],
+    inverse: true,
+    selector: (point) => pickIndicator(point, 'accidents'),
+  },
+  {
+    id: 'transit',
+    label: 'Transporte público',
+    description: 'Cobertura de transporte público regular (CRTM y consorcios).',
+    unit: ' %',
+    palette: ['#134e4a', '#0f766e', '#14b8a6', '#5eead4', '#ccfbf1'],
+    selector: (point) => pickIndicator(point, 'transit'),
+  },
+];
+
+/** Mapa indexado por id para resoluciones O(1) en componentes consumidores. */
+export const MAP_LAYER_BY_ID: Readonly<Record<MapLayerId, MapLayerDefinition>> = Object.freeze(
+  Object.fromEntries(MAP_LAYER_CATALOG.map((layer) => [layer.id, layer])) as Record<
+    MapLayerId,
+    MapLayerDefinition
+  >
+);
+
+/** Devuelve la capa por id, con fallback al `score` cuando el id es desconocido. */
+export function resolveLayer(id: string | undefined): MapLayerDefinition {
+  if (id && id in MAP_LAYER_BY_ID) {
+    return MAP_LAYER_BY_ID[id as MapLayerId];
+  }
+  return MAP_LAYER_BY_ID.score;
+}
+
+/**
+ * Calcula el dominio observado para una capa contra una colección de puntos.
+ *
+ * Cuando todos los valores son iguales, ensanchamos artificialmente el rango
+ * (`±1`) para evitar divisiones por cero en consumidores que normalizan.
+ */
+export function computeLayerDomain(
+  points: readonly EnrichedMapPoint[],
+  layer: MapLayerDefinition
+): LayerDomain {
+  if (points.length === 0) {
+    return { min: 0, max: 1 };
+  }
+  let min = Number.POSITIVE_INFINITY;
+  let max = Number.NEGATIVE_INFINITY;
+  for (const point of points) {
+    const value = layer.selector(point);
+    if (value < min) min = value;
+    if (value > max) max = value;
+  }
+  if (!Number.isFinite(min) || !Number.isFinite(max)) {
+    return { min: 0, max: 1 };
+  }
+  if (min === max) {
+    return { min: min - 1, max: max + 1 };
+  }
+  return { min, max };
+}
+
+/**
+ * Devuelve el color de la rampa correspondiente al `value` dentro del
+ * `domain`. Convención: el primer color de la paleta (`palette[0]`) siempre
+ * representa el valor más alto observado. La interpretación cualitativa
+ * "alto = bueno" o "alto = malo" es propia de cada capa (`inverse`),
+ * y se refleja sólo en la elección del color base (verde para `score`,
+ * rojo para `rent_price` y `accidents`).
+ */
+export function valueToColor(
+  value: number,
+  layer: MapLayerDefinition,
+  domain: LayerDomain
+): string {
+  const { palette } = layer;
+  const span = domain.max - domain.min;
+  if (span <= 0) return palette[0];
+  const normalized = (value - domain.min) / span;
+  const clamped = Math.min(Math.max(normalized, 0), 1);
+  const bucketCount = palette.length;
+  // Valor máximo → palette[0]; valor mínimo → palette[bucketCount - 1].
+  const indexFromLow = Math.min(bucketCount - 1, Math.floor(clamped * bucketCount));
+  const finalIndex = bucketCount - 1 - indexFromLow;
+  return palette[finalIndex];
+}
+
+/**
+ * Calcula el radio (en píxeles) para una burbuja en función del valor.
+ *
+ * El cálculo prioriza coherencia: un valor cercano al máximo siempre genera
+ * la burbuja más grande, sin importar que la métrica sea inversa (la rampa
+ * cromática ya transmite la cualidad bueno/malo).
+ */
+export function valueToRadius(
+  value: number,
+  domain: LayerDomain,
+  bounds: { readonly min: number; readonly max: number } = { min: 12, max: 28 }
+): number {
+  const span = domain.max - domain.min;
+  if (span <= 0) return Math.round((bounds.min + bounds.max) / 2);
+  const normalized = Math.min(Math.max((value - domain.min) / span, 0), 1);
+  return Math.round(bounds.min + normalized * (bounds.max - bounds.min));
+}
+
+/**
+ * Construye `MapLegendStop[]` a partir del dominio observado y la paleta de la
+ * capa. Los tramos se reparten linealmente entre `min` y `max`. La leyenda
+ * lee este resultado para mostrar la rampa con sus umbrales reales.
+ */
+export interface LayerLegendStop {
+  readonly min: number;
+  readonly max: number;
+  readonly color: string;
+}
+
+export function buildLegendStops(
+  layer: MapLayerDefinition,
+  domain: LayerDomain
+): readonly LayerLegendStop[] {
+  const { palette } = layer;
+  const span = domain.max - domain.min;
+  const bucketCount = palette.length;
+  const step = span / bucketCount;
+  const stops: LayerLegendStop[] = [];
+  // Recorre de menor a mayor; cada bucket recibe el color que `valueToColor`
+  // asignaría a un valor dentro de ese rango. Esto garantiza que la leyenda
+  // refleje exactamente el mapeo cromático del mapa.
+  for (let i = 0; i < bucketCount; i += 1) {
+    const min = domain.min + step * i;
+    const max = i === bucketCount - 1 ? domain.max : domain.min + step * (i + 1);
+    const colorIndex = bucketCount - 1 - i;
+    stops.push({ min, max, color: palette[colorIndex] });
+  }
+  return stops;
+}

--- a/apps/web/src/features/map/layers/index.ts
+++ b/apps/web/src/features/map/layers/index.ts
@@ -1,7 +1,24 @@
+/**
+ * Punto de entrada del módulo de capas del mapa.
+ *
+ * Expone tanto el catálogo declarativo (`catalog.ts`) como el componente
+ * `LayerSwitcher`. Los componentes consumidores deben importar desde aquí
+ * para garantizar que los identificadores y metadatos no se duplican.
+ */
+
+export { LayerSwitcher } from './LayerSwitcher';
+export type { LayerSwitcherProps } from './LayerSwitcher';
 export {
-  LayerSwitcher,
-  DEFAULT_LAYER_DEFINITIONS,
-  type LayerSwitcherProps,
+  MAP_LAYER_CATALOG,
+  MAP_LAYER_BY_ID,
+  resolveLayer,
+  computeLayerDomain,
+  valueToColor,
+  valueToRadius,
+  buildLegendStops,
   type MapLayerDefinition,
   type MapLayerId,
-} from './LayerSwitcher';
+  type LayerDomain,
+  type LayerLegendStop,
+  type EnrichedMapPoint,
+} from './catalog';

--- a/apps/web/src/state/__tests__/mapLayer.test.ts
+++ b/apps/web/src/state/__tests__/mapLayer.test.ts
@@ -1,0 +1,41 @@
+/* eslint-disable no-undef -- localStorage es global del navegador. */
+/**
+ * Tests del store de capa activa del mapa.
+ *
+ * Comprueba que el store tiene un id por defecto, que `setActiveLayer`
+ * actualiza el estado y que `localStorage` recibe la persistencia con la
+ * clave reservada `atlashabita:map-layer`.
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { DEFAULT_MAP_LAYER_ID, useMapLayerStore } from '../mapLayer';
+
+describe('useMapLayerStore', () => {
+  beforeEach(() => {
+    useMapLayerStore.getState().resetActiveLayer();
+    localStorage.clear();
+  });
+
+  it('inicia en la capa score por defecto', () => {
+    expect(useMapLayerStore.getState().activeLayerId).toBe(DEFAULT_MAP_LAYER_ID);
+  });
+
+  it('actualiza la capa activa', () => {
+    useMapLayerStore.getState().setActiveLayer('rent_price');
+    expect(useMapLayerStore.getState().activeLayerId).toBe('rent_price');
+  });
+
+  it('persiste la capa activa en localStorage', () => {
+    useMapLayerStore.getState().setActiveLayer('broadband');
+    const persisted = localStorage.getItem('atlashabita:map-layer');
+    expect(persisted).toBeTruthy();
+    expect(persisted).toContain('broadband');
+  });
+
+  it('reset vuelve a score', () => {
+    useMapLayerStore.getState().setActiveLayer('mobility');
+    useMapLayerStore.getState().resetActiveLayer();
+    expect(useMapLayerStore.getState().activeLayerId).toBe(DEFAULT_MAP_LAYER_ID);
+  });
+});

--- a/apps/web/src/state/mapLayer.ts
+++ b/apps/web/src/state/mapLayer.ts
@@ -1,0 +1,59 @@
+/* eslint-disable no-undef -- localStorage es global del navegador gestionado por Zustand persist. */
+/**
+ * Store Zustand que controla la capa activa del mapa multi-métrica.
+ *
+ * El switcher de la home (`DashboardShell`) y el de la página `/mapa` leen y
+ * escriben en este store, de modo que la selección se sincroniza al instante
+ * sin pasar por la URL ni por el filtro de scoring (`filters.ts`). La capa
+ * activa se persiste en `localStorage` para que el usuario reabra la app con
+ * la métrica que estaba consultando.
+ *
+ * El store expone únicamente el ID de la capa, no su definición: los
+ * componentes resuelven los metadatos desde el catálogo
+ * (`features/map/layers/index.ts`) para que los cambios de paleta o etiqueta
+ * no obliguen a invalidar el estado persistido.
+ */
+
+import { create } from 'zustand';
+import { persist, createJSONStorage } from 'zustand/middleware';
+
+/** Identificador serializable de la capa activa. */
+export type ActiveMapLayerId = string;
+
+export interface MapLayerState {
+  readonly activeLayerId: ActiveMapLayerId;
+}
+
+export interface MapLayerActions {
+  setActiveLayer: (layerId: ActiveMapLayerId) => void;
+  resetActiveLayer: () => void;
+}
+
+const DEFAULT_LAYER_ID: ActiveMapLayerId = 'score';
+
+const INITIAL_STATE: MapLayerState = {
+  activeLayerId: DEFAULT_LAYER_ID,
+};
+
+export type MapLayerStore = MapLayerState & MapLayerActions;
+
+export const useMapLayerStore = create<MapLayerStore>()(
+  persist(
+    (set) => ({
+      ...INITIAL_STATE,
+      setActiveLayer: (layerId) => set({ activeLayerId: layerId }),
+      resetActiveLayer: () => set({ activeLayerId: DEFAULT_LAYER_ID }),
+    }),
+    {
+      name: 'atlashabita:map-layer',
+      version: 1,
+      storage: createJSONStorage(() => localStorage),
+      partialize: (state): MapLayerState => ({
+        activeLayerId: state.activeLayerId,
+      }),
+    }
+  )
+);
+
+/** Constante exportada para tests y para inicializar consumidores SSR. */
+export const DEFAULT_MAP_LAYER_ID = DEFAULT_LAYER_ID;


### PR DESCRIPTION
Catálogo declarativo de 9 capas (score, alquiler, banda ancha, renta, servicios, clima, movilidad, accidentes, transporte). El cambio de capa actualiza burbujas, rampa y leyenda en tiempo real sin remontar `<Map>`. Store Zustand `mapLayer` persistido sincroniza home y `/mapa`. Tooltip muestra todos los indicadores destacando el activo. 186 tests verde.

Closes #107