### PR TITLE
fix(api): sustituir elipsis por docstrings en Protocol SPARQL (cierra CodeQL #10-#13)

### DIFF
--- a/apps/api/src/atlashabita/application/use_cases/run_sparql_query.py
+++ b/apps/api/src/atlashabita/application/use_cases/run_sparql_query.py
@@ -56,15 +56,19 @@ class SparqlRunnerProtocol(Protocol):
 
     def mobility_flow_between(
         self, origin_code: str, destination_code: str, period: str
-    ) -> list[dict[str, Any]]: ...
+    ) -> list[dict[str, Any]]:
+        """Flujos de movilidad entre dos municipios para un periodo concreto."""
 
     def accidents_in_radius(
         self, lat: float, lon: float, km: float, year: int | None = ...
-    ) -> list[dict[str, Any]]: ...
+    ) -> list[dict[str, Any]]:
+        """Accidentes con víctimas dentro de un radio en kilómetros."""
 
-    def transit_stops_in_municipality(self, municipality_code: str) -> list[dict[str, Any]]: ...
+    def transit_stops_in_municipality(self, municipality_code: str) -> list[dict[str, Any]]:
+        """Paradas de transporte público de un municipio dado."""
 
-    def risk_index(self, municipality_code: str) -> dict[str, Any]: ...
+    def risk_index(self, municipality_code: str) -> dict[str, Any]:
+        """Índice agregado de riesgo combinando accidentes y movilidad."""
 
 
 @dataclass(frozen=True, slots=True)


### PR DESCRIPTION
CodeQL marcaba 4 alertas "Statement has no effect" sobre `apps/api/src/atlashabita/application/use_cases/run_sparql_query.py:59-67` (cuerpos `...` en métodos de un `Protocol`). Aunque es un patrón válido en Python, el ruido se elimina sustituyendo cada elipsis por un docstring de una línea que documenta el contrato.

Backend 489 / 489 verde tras el cambio.