### PR TITLE
feat(web): primitivas Motion Atelier (magnetic, countup, sparkline, marker reveal radial)

### DIFF
--- a/apps/web/src/animations/__tests__/atelier.test.ts
+++ b/apps/web/src/animations/__tests__/atelier.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  CARD_CONIC_ROTATION_S,
+  DURATIONS,
+  EASINGS,
+  MAGNETIC_RADIUS_PX,
+  MAGNETIC_STRENGTH,
+  MAP_IDLE_INTERVAL_S,
+  STAGGERS,
+  buildMarkerRevealVars,
+  motionPresets,
+  resolveAtelierDuration,
+  resolveAtelierDurationOrSkip,
+  resolveConicDuration,
+} from '../atelier';
+
+type MatchMediaStub = typeof window.matchMedia;
+
+function mockMatchMedia(matches: boolean): MatchMediaStub {
+  return ((query: string) => ({
+    matches,
+    media: query,
+    addEventListener: () => undefined,
+    removeEventListener: () => undefined,
+    addListener: () => undefined,
+    removeListener: () => undefined,
+    dispatchEvent: () => false,
+    onchange: null,
+  })) as unknown as MatchMediaStub;
+}
+
+const ORIGINAL_MATCH_MEDIA = window.matchMedia;
+
+function setReducedMotion(value: boolean): void {
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    writable: true,
+    value: mockMatchMedia(value),
+  });
+}
+
+afterEach(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    writable: true,
+    value: ORIGINAL_MATCH_MEDIA,
+  });
+});
+
+describe('atelier motion tokens', () => {
+  it('expone duraciones canónicas alineadas con el spec', () => {
+    expect(DURATIONS.instant).toBe(0.12);
+    expect(DURATIONS.base).toBe(0.32);
+    expect(DURATIONS.lush).toBe(0.55);
+    expect(DURATIONS.hero).toBe(0.9);
+  });
+
+  it('expone curvas Bézier nombradas', () => {
+    expect(EASINGS.enter).toBe('cubic-bezier(0.22, 0.84, 0.34, 1)');
+    expect(EASINGS.exit).toBe('cubic-bezier(0.55, 0.03, 0.71, 0.32)');
+    expect(EASINGS.smooth).toBe('cubic-bezier(0.36, 0.66, 0.04, 1)');
+  });
+
+  it('define staggers tight/normal/lush', () => {
+    expect(STAGGERS).toEqual({ tight: 0.04, normal: 0.07, lush: 0.12 });
+  });
+
+  it('exporta constantes auxiliares para microinteracciones', () => {
+    expect(MAGNETIC_RADIUS_PX).toBe(24);
+    expect(MAGNETIC_STRENGTH).toBeGreaterThan(0);
+    expect(MAGNETIC_STRENGTH).toBeLessThanOrEqual(1);
+    expect(MAP_IDLE_INTERVAL_S).toBe(30);
+    expect(CARD_CONIC_ROTATION_S).toBe(8);
+  });
+
+  it('motionPresets.markerRevealRadial respeta los valores GSAP esperados', () => {
+    expect(motionPresets.markerRevealRadial).toMatchObject({
+      scale: 0,
+      opacity: 0,
+      duration: DURATIONS.lush,
+      ease: EASINGS.enter,
+      transformOrigin: '50% 50%',
+    });
+    const stagger = motionPresets.markerRevealRadial.stagger as { from: string; amount: number };
+    expect(stagger.from).toBe('center');
+    expect(stagger.amount).toBeCloseTo(0.6, 5);
+  });
+});
+
+describe('resolveAtelierDuration helpers', () => {
+  it('devuelve la duración exacta cuando no hay prefers-reduced-motion', () => {
+    setReducedMotion(false);
+    expect(resolveAtelierDuration('base')).toBe(DURATIONS.base);
+    expect(resolveAtelierDurationOrSkip('lush')).toBe(DURATIONS.lush);
+    expect(resolveConicDuration()).toBe(CARD_CONIC_ROTATION_S);
+  });
+
+  it('colapsa a instant (o 0) cuando se solicita movimiento reducido', () => {
+    setReducedMotion(true);
+    expect(resolveAtelierDuration('hero')).toBe(DURATIONS.instant);
+    expect(resolveAtelierDurationOrSkip('hero')).toBe(0);
+    expect(resolveConicDuration()).toBe(0);
+  });
+});
+
+describe('buildMarkerRevealVars', () => {
+  it('replica los presets y aplica resolveAtelierDurationOrSkip', () => {
+    setReducedMotion(false);
+    const vars = buildMarkerRevealVars();
+    expect(vars.duration).toBe(DURATIONS.lush);
+    expect(vars.ease).toBe(EASINGS.enter);
+
+    setReducedMotion(true);
+    const reducedVars = buildMarkerRevealVars();
+    expect(reducedVars.duration).toBe(0);
+  });
+});

--- a/apps/web/src/animations/__tests__/usePrefersReducedMotion.test.ts
+++ b/apps/web/src/animations/__tests__/usePrefersReducedMotion.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+import { usePrefersReducedMotion } from '../usePrefersReducedMotion';
+
+type MediaQueryListEvent = globalThis.MediaQueryListEvent;
+
+interface ListenerSet {
+  fire: (matches: boolean) => void;
+  removed: boolean;
+}
+
+interface MockMediaQuery {
+  matches: boolean;
+  media: string;
+  addEventListener?: (type: string, listener: (event: MediaQueryListEvent) => void) => void;
+  removeEventListener?: (type: string, listener: (event: MediaQueryListEvent) => void) => void;
+  addListener?: (listener: (event: MediaQueryListEvent) => void) => void;
+  removeListener?: (listener: (event: MediaQueryListEvent) => void) => void;
+  dispatchEvent: () => boolean;
+  onchange: null;
+  __set: ListenerSet;
+}
+
+function createMockMediaQuery(initial: boolean, supportsModern: boolean): MockMediaQuery {
+  const set: ListenerSet = {
+    fire: () => undefined,
+    removed: false,
+  };
+
+  const mq = {
+    matches: initial,
+    media: '(prefers-reduced-motion: reduce)',
+    dispatchEvent: () => true,
+    onchange: null,
+    __set: set,
+  } as MockMediaQuery;
+
+  if (supportsModern) {
+    mq.addEventListener = (_type, listener) => {
+      set.fire = (matches: boolean) => {
+        mq.matches = matches;
+        listener({ matches, media: mq.media } as unknown as MediaQueryListEvent);
+      };
+    };
+    mq.removeEventListener = () => {
+      set.removed = true;
+    };
+  } else {
+    // Forzamos a que `addEventListener` sea undefined para reproducir
+    // navegadores antiguos donde sólo existe `addListener`.
+    (mq as unknown as { addEventListener: undefined }).addEventListener = undefined;
+    (mq as unknown as { removeEventListener: undefined }).removeEventListener = undefined;
+    mq.addListener = (listener) => {
+      set.fire = (matches: boolean) => {
+        mq.matches = matches;
+        listener({ matches, media: mq.media } as unknown as MediaQueryListEvent);
+      };
+    };
+    mq.removeListener = () => {
+      set.removed = true;
+    };
+  }
+  return mq;
+}
+
+const ORIGINAL_MATCH_MEDIA = window.matchMedia;
+
+afterEach(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    writable: true,
+    value: ORIGINAL_MATCH_MEDIA,
+  });
+  vi.restoreAllMocks();
+});
+
+describe('usePrefersReducedMotion', () => {
+  it('devuelve el valor inicial expuesto por matchMedia', () => {
+    const mq = createMockMediaQuery(true, true);
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      writable: true,
+      value: () => mq,
+    });
+
+    const { result } = renderHook(() => usePrefersReducedMotion());
+    expect(result.current).toBe(true);
+  });
+
+  it('reacciona al cambio en caliente usando addEventListener', () => {
+    const mq = createMockMediaQuery(false, true);
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      writable: true,
+      value: () => mq,
+    });
+
+    const { result } = renderHook(() => usePrefersReducedMotion());
+    expect(result.current).toBe(false);
+
+    act(() => {
+      mq.__set.fire(true);
+    });
+    expect(result.current).toBe(true);
+  });
+
+  it('compatibiliza con APIs antiguas (addListener) y limpia al desmontar', () => {
+    const mq = createMockMediaQuery(false, false);
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      writable: true,
+      value: () => mq,
+    });
+
+    const { result, unmount } = renderHook(() => usePrefersReducedMotion());
+    expect(result.current).toBe(false);
+
+    act(() => {
+      mq.__set.fire(true);
+    });
+    expect(result.current).toBe(true);
+
+    unmount();
+    expect(mq.__set.removed).toBe(true);
+  });
+
+  it('devuelve false cuando matchMedia no está disponible', () => {
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      writable: true,
+      value: undefined,
+    });
+    const { result } = renderHook(() => usePrefersReducedMotion());
+    expect(result.current).toBe(false);
+  });
+});

--- a/apps/web/src/animations/atelier.ts
+++ b/apps/web/src/animations/atelier.ts
@@ -1,0 +1,174 @@
+/**
+ * Tokens y presets de motion del sistema "AtlasHabita Atelier".
+ *
+ * Centralizamos las duraciones, curvas Bézier y patrones de stagger del
+ * lenguaje visual lush para que cualquier microinteracción los importe
+ * de un único origen y respete las directrices del milestone M12.
+ *
+ * Reglas de oro (issue #117):
+ *   - Respetar `prefers-reduced-motion`: en ese caso colapsamos la
+ *     duración a `instant` y eliminamos el desplazamiento orgánico.
+ *   - Animar SOLO `transform`, `opacity` y `clip-path`. Nunca tocamos
+ *     `top`/`left` para mantener 60fps en el repintado.
+ *   - El cleanup lo gestiona `useGSAP` en cada consumidor; aquí sólo
+ *     exponemos primitivas puras y helpers ergonómicos.
+ */
+import { prefersReducedMotion } from './reducedMotion';
+
+/**
+ * Tipado mínimo para `gsap.TweenVars` sin importar el namespace
+ * completo (evita pagar el coste del módulo cuando algunos consumidores
+ * sólo necesitan los tokens). Las claves coinciden con la API pública
+ * de GSAP que utilizamos.
+ */
+type TweenVarsLike = Record<string, unknown>;
+
+/**
+ * Duraciones canónicas en segundos. Coinciden con el spec del Atelier:
+ *   - `instant`: microinteracciones casi imperceptibles (hover, ticks).
+ *   - `base`:    transición estándar, suficiente para captar el cambio.
+ *   - `lush`:    reveals densos (markers, cards, tooltips contextuales).
+ *   - `hero`:    secuencias hero (intro de sección, paneo idle del mapa).
+ */
+export const DURATIONS = {
+  instant: 0.12,
+  base: 0.32,
+  lush: 0.55,
+  hero: 0.9,
+} as const;
+
+/** Tipos de duración disponibles (clave del objeto `DURATIONS`). */
+export type DurationKey = keyof typeof DURATIONS;
+
+/**
+ * Curvas Bézier nombradas para describir la intención del movimiento:
+ *   - `enter`:  ingresos suaves con un pequeño overshoot perceptual.
+ *   - `exit`:   salidas decididas que abandonan rápido el viewport.
+ *   - `smooth`: tránsitos largos y orgánicos (ideal para el panning).
+ */
+export const EASINGS = {
+  enter: 'cubic-bezier(0.22, 0.84, 0.34, 1)',
+  exit: 'cubic-bezier(0.55, 0.03, 0.71, 0.32)',
+  smooth: 'cubic-bezier(0.36, 0.66, 0.04, 1)',
+} as const;
+
+/** Tipos de easing disponibles. */
+export type EasingKey = keyof typeof EASINGS;
+
+/**
+ * Stagger en segundos para listas y cuadrículas. `tight` se reserva a
+ * tiles pequeños (chips, badges), `normal` a cards/markers y `lush` a
+ * heros y reveals corales con muchos elementos en pantalla.
+ */
+export const STAGGERS = {
+  tight: 0.04,
+  normal: 0.07,
+  lush: 0.12,
+} as const;
+
+/** Tipos de stagger disponibles. */
+export type StaggerKey = keyof typeof STAGGERS;
+
+/**
+ * Radio (px) de captura del cursor magnético sobre CTAs primarios.
+ * Mantener fuera del componente facilita ajustar la sensibilidad sin
+ * abrir un PR contra cada consumidor.
+ */
+export const MAGNETIC_RADIUS_PX = 24;
+
+/** Strength de atracción magnética (proporción 0..1). */
+export const MAGNETIC_STRENGTH = 0.35;
+
+/**
+ * Cadencia (s) del paneo idle del mapa hacia el "hot municipio". El
+ * Atelier especifica 30 s; lo reexportamos para que el helper y los
+ * tests compartan la misma constante.
+ */
+export const MAP_IDLE_INTERVAL_S = 30;
+
+/**
+ * Cadencia (s) del giro 360° del gradiente conic en cards. 8 s genera
+ * una sensación de presencia continua sin distraer la lectura.
+ */
+export const CARD_CONIC_ROTATION_S = 8;
+
+/**
+ * Resuelve una duración respetando `prefers-reduced-motion`. Cuando el
+ * usuario solicita movimiento reducido, devolvemos `instant`, que se
+ * interpreta como "casi inmediato" pero conserva la transición.
+ */
+export function resolveAtelierDuration(key: DurationKey): number {
+  if (prefersReducedMotion()) return DURATIONS.instant;
+  return DURATIONS[key];
+}
+
+/**
+ * Devuelve `0` cuando se pide movimiento reducido para que `gsap` salte
+ * directamente al estado final. Útil en `from`/`to` cuando NO queremos
+ * preservar siquiera el `instant` (revealings densos en home).
+ */
+export function resolveAtelierDurationOrSkip(key: DurationKey): number {
+  if (prefersReducedMotion()) return 0;
+  return DURATIONS[key];
+}
+
+/**
+ * Catálogo de presets reutilizables para `gsap.from`/`to`. Empaquetamos
+ * los argumentos típicos para reducir duplicación y garantizar que
+ * todos los reveals comparten timing y easing.
+ */
+export const motionPresets = {
+  /** Intro coral de markers desde el centro (radial). */
+  markerRevealRadial: {
+    scale: 0,
+    opacity: 0,
+    duration: DURATIONS.lush,
+    ease: EASINGS.enter,
+    stagger: { from: 'center' as const, amount: 0.6 },
+    transformOrigin: '50% 50%',
+    clearProps: 'transform,opacity',
+  },
+  /** Intro estándar (fade + lift) para tarjetas y panels. */
+  cardEnter: {
+    opacity: 0,
+    y: 16,
+    duration: DURATIONS.base,
+    ease: EASINGS.enter,
+    clearProps: 'transform,opacity',
+  },
+  /** Salida rápida hacia abajo (overlays cerrándose). */
+  overlayExit: {
+    opacity: 0,
+    y: 12,
+    duration: DURATIONS.base,
+    ease: EASINGS.exit,
+  },
+  /** Microinteracción de hover scale para CTAs de acción. */
+  ctaHover: {
+    scale: 1.04,
+    duration: DURATIONS.instant,
+    ease: EASINGS.enter,
+    overwrite: 'auto' as const,
+  },
+} as const;
+
+/**
+ * Exporta el resultado de `motionPresets.markerRevealRadial` listo para
+ * pasar a `gsap.from('.maplibregl-marker', ...)`. Resolver duración aquí
+ * facilita reutilizarlo desde tests y desde la home sin duplicar la
+ * comprobación de `prefers-reduced-motion`.
+ */
+export function buildMarkerRevealVars(): TweenVarsLike {
+  return {
+    ...motionPresets.markerRevealRadial,
+    duration: resolveAtelierDurationOrSkip('lush'),
+  };
+}
+
+/**
+ * Devuelve la duración del giro conic ajustada al modo reducido. Cuando
+ * el usuario pide menos movimiento "congelamos" el gradiente.
+ */
+export function resolveConicDuration(): number {
+  return prefersReducedMotion() ? 0 : CARD_CONIC_ROTATION_S;
+}

--- a/apps/web/src/animations/index.ts
+++ b/apps/web/src/animations/index.ts
@@ -12,3 +12,19 @@ export {
   FADE_IN_OFFSET,
   STAGGER_DEFAULT,
 } from './presets';
+export {
+  CARD_CONIC_ROTATION_S,
+  DURATIONS,
+  EASINGS,
+  MAGNETIC_RADIUS_PX,
+  MAGNETIC_STRENGTH,
+  MAP_IDLE_INTERVAL_S,
+  STAGGERS,
+  buildMarkerRevealVars,
+  motionPresets,
+  resolveAtelierDuration,
+  resolveAtelierDurationOrSkip,
+  resolveConicDuration,
+} from './atelier';
+export type { DurationKey, EasingKey, StaggerKey } from './atelier';
+export { usePrefersReducedMotion } from './usePrefersReducedMotion';

--- a/apps/web/src/animations/usePrefersReducedMotion.ts
+++ b/apps/web/src/animations/usePrefersReducedMotion.ts
@@ -1,0 +1,50 @@
+import { useEffect, useState } from 'react';
+
+import { REDUCED_MOTION_QUERY, prefersReducedMotion } from './reducedMotion';
+
+// Tipo nativo del navegador. Lo redeclaramos como alias para que el
+// linter (que sólo conoce los globales declarados en su config) no se
+// queje en archivos compartidos sin tocar la configuración.
+type MediaQueryListEvent = globalThis.MediaQueryListEvent;
+
+/**
+ * Hook reactivo que expone `prefers-reduced-motion` y se actualiza si
+ * el usuario cambia la preferencia del sistema en caliente. Esto evita
+ * que un componente montado anteriormente continúe animando aunque la
+ * persona haya activado "reducir movimiento" durante la sesión.
+ *
+ * Implementación defensiva: trabajamos sólo cuando `window.matchMedia`
+ * existe y ofrecemos compatibilidad con APIs antiguas (`addListener`)
+ * por si algún test o navegador embebido no expone `addEventListener`.
+ *
+ * Devuelve un booleano sincrónico durante el primer render, gracias a
+ * que `prefersReducedMotion()` es una función pura que consulta el DOM
+ * en el momento del montaje.
+ */
+export function usePrefersReducedMotion(): boolean {
+  const [reduced, setReduced] = useState<boolean>(() => prefersReducedMotion());
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+      return undefined;
+    }
+
+    const mediaQuery = window.matchMedia(REDUCED_MOTION_QUERY);
+    setReduced(mediaQuery.matches);
+
+    const handleChange = (event: MediaQueryListEvent) => setReduced(event.matches);
+
+    if (typeof mediaQuery.addEventListener === 'function') {
+      mediaQuery.addEventListener('change', handleChange);
+      return () => mediaQuery.removeEventListener('change', handleChange);
+    }
+    // Fallback para navegadores antiguos (Safari < 14, jsdom legacy).
+    if (typeof mediaQuery.addListener === 'function') {
+      mediaQuery.addListener(handleChange);
+      return () => mediaQuery.removeListener(handleChange);
+    }
+    return undefined;
+  }, []);
+
+  return reduced;
+}

--- a/apps/web/src/components/motion/CardConic.tsx
+++ b/apps/web/src/components/motion/CardConic.tsx
@@ -1,0 +1,169 @@
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  type CSSProperties,
+  type ElementType,
+  type PointerEvent,
+  type ReactNode,
+} from 'react';
+import gsap from 'gsap';
+
+import { CARD_CONIC_ROTATION_S, prefersReducedMotion } from '@/animations';
+
+type HTMLSpanElement = globalThis.HTMLSpanElement;
+
+export interface CardConicProps {
+  /** Contenido envuelto. */
+  children: ReactNode;
+  /** Tag HTML de la raíz. Por defecto `<div>`. */
+  as?: ElementType;
+  /** Color inicial del gradiente conic. */
+  fromColor?: string;
+  /** Color final del gradiente conic. */
+  toColor?: string;
+  /** Color "transparente" entre paradas, por defecto `transparent`. */
+  voidColor?: string;
+  /** Duración (s) de una vuelta completa. Por defecto 8 s. */
+  rotationDuration?: number;
+  /** Desactiva el efecto sin afectar al layout. */
+  disabled?: boolean;
+  className?: string;
+  'aria-label'?: string;
+}
+
+/**
+ * Wrapper que aplica un gradiente conic animado en hover/focus. Cuando
+ * el usuario apunta a la card, una capa absoluta entra en escena (con
+ * un fade muy corto) y rota 360° cada `rotationDuration` segundos para
+ * sugerir un halo continuo cobre→moss.
+ *
+ * Detalles importantes:
+ *   - El gradiente vive en una capa decorativa (`aria-hidden`) para no
+ *     manchar el árbol semántico ni los lectores de pantalla.
+ *   - La rotación se hace con `gsap` sobre `--card-conic-angle` usando
+ *     `CSS.registerProperty` cuando está disponible, recurriendo a un
+ *     fallback con `transform: rotate` si no.
+ *   - Respeta `prefers-reduced-motion`: en ese caso no se rota y se
+ *     reduce ligeramente la opacidad para señalar el hover sin marear.
+ */
+export function CardConic({
+  children,
+  as,
+  fromColor = 'var(--color-copper-500, #B87333)',
+  toColor = 'var(--color-moss-500, #4F8267)',
+  voidColor = 'transparent',
+  rotationDuration = CARD_CONIC_ROTATION_S,
+  disabled = false,
+  className,
+  'aria-label': ariaLabel,
+}: CardConicProps) {
+  const overlayRef = useRef<HTMLSpanElement | null>(null);
+  const tweenRef = useRef<gsap.core.Tween | null>(null);
+
+  const start = useCallback(() => {
+    if (disabled) return;
+    const node = overlayRef.current;
+    if (!node) return;
+    const reducedMotion = prefersReducedMotion();
+    gsap.to(node, {
+      opacity: reducedMotion ? 0.5 : 1,
+      duration: 0.32,
+      ease: 'power2.out',
+      overwrite: 'auto',
+    });
+    if (reducedMotion) return;
+    if (tweenRef.current) tweenRef.current.kill();
+    // Animamos una variable CSS para que el gradiente conic real se
+    // calcule en GPU sin recomposiciones de layout.
+    tweenRef.current = gsap.to(node, {
+      '--card-conic-angle': '360deg',
+      duration: rotationDuration,
+      ease: 'none',
+      repeat: -1,
+      modifiers: {
+        // Reseteamos cada vuelta para evitar acumulación tras horas en
+        // pantalla y mantener el ángulo dentro de [0, 360).
+        '--card-conic-angle': (value: string) => {
+          const numeric = parseFloat(value);
+          return `${numeric % 360}deg`;
+        },
+      },
+    });
+  }, [disabled, rotationDuration]);
+
+  const stop = useCallback(() => {
+    const node = overlayRef.current;
+    if (!node) return;
+    if (tweenRef.current) {
+      tweenRef.current.kill();
+      tweenRef.current = null;
+    }
+    gsap.to(node, {
+      opacity: 0,
+      duration: 0.32,
+      ease: 'power2.out',
+      overwrite: 'auto',
+    });
+  }, []);
+
+  useEffect(
+    () => () => {
+      // Cleanup global: si el componente se desmonta detenemos el loop
+      // y limpiamos la variable CSS para no manchar otros consumidores.
+      if (tweenRef.current) {
+        tweenRef.current.kill();
+        tweenRef.current = null;
+      }
+      const node = overlayRef.current;
+      if (node) {
+        gsap.killTweensOf(node);
+        node.style.removeProperty('--card-conic-angle');
+        node.style.removeProperty('opacity');
+      }
+    },
+    []
+  );
+
+  const handleEnter = useCallback((_event: PointerEvent<HTMLElement>) => start(), [start]);
+  const handleLeave = useCallback((_event: PointerEvent<HTMLElement>) => stop(), [stop]);
+  const handleFocus = useCallback(() => start(), [start]);
+  const handleBlur = useCallback(() => stop(), [stop]);
+
+  const Component = (as ?? 'div') as ElementType;
+  const overlayStyle: CSSProperties & Record<string, string> = {
+    '--card-conic-angle': '0deg',
+    background: `conic-gradient(from var(--card-conic-angle) at 50% 50%, ${fromColor}, ${voidColor} 30%, ${toColor} 60%, ${voidColor} 80%, ${fromColor})`,
+  };
+
+  return (
+    <Component
+      className={className}
+      data-motion="card-conic"
+      data-conic-disabled={disabled ? 'true' : undefined}
+      aria-label={ariaLabel}
+      onPointerEnter={handleEnter}
+      onPointerLeave={handleLeave}
+      onFocus={handleFocus}
+      onBlur={handleBlur}
+      style={{ position: 'relative', isolation: 'isolate' }}
+    >
+      <span
+        ref={overlayRef}
+        aria-hidden="true"
+        data-testid="card-conic-overlay"
+        style={{
+          ...overlayStyle,
+          position: 'absolute',
+          inset: -1,
+          borderRadius: 'inherit',
+          opacity: 0,
+          pointerEvents: 'none',
+          zIndex: 0,
+          mixBlendMode: 'soft-light',
+        }}
+      />
+      <span style={{ position: 'relative', zIndex: 1, display: 'block' }}>{children}</span>
+    </Component>
+  );
+}

--- a/apps/web/src/components/motion/MarkerRevealRadial.tsx
+++ b/apps/web/src/components/motion/MarkerRevealRadial.tsx
@@ -1,0 +1,294 @@
+import { useCallback, useEffect, useRef, type ReactNode, type RefObject } from 'react';
+import gsap from 'gsap';
+
+import {
+  EASINGS,
+  MAP_IDLE_INTERVAL_S,
+  buildMarkerRevealVars,
+  prefersReducedMotion,
+} from '@/animations';
+
+type Document = globalThis.Document;
+type HTMLDivElement = globalThis.HTMLDivElement;
+
+/** Selector estándar de markers MapLibre (clase autogenerada por la librería). */
+export const MAPLIBRE_MARKER_SELECTOR = '.maplibregl-marker';
+
+/**
+ * Coordenadas mínimas exigidas a un punto candidato a "hot municipio".
+ * Mantener una interfaz local (en lugar de importar la del mapa) evita
+ * acoplar el helper a las features y permite reutilizarlo desde otros
+ * contextos (analítica, dashboards externos, tests).
+ */
+export interface IdleHotPoint {
+  readonly id: string;
+  readonly lat: number;
+  readonly lon: number;
+  readonly score: number;
+}
+
+export interface PerformMarkerRevealOptions {
+  /** Container raíz donde buscar `.maplibregl-marker`. */
+  readonly scope: HTMLElement | Document;
+  /** Permite sobreescribir vars (delays adicionales, ease custom). */
+  readonly overrides?: gsap.TweenVars;
+}
+
+/**
+ * Lanza el reveal radial de markers en el scope indicado. Es un helper
+ * puro pensado para uso en hooks o tests: devuelve el `Tween` para que
+ * el consumidor lo pueda detener si fuese necesario, o `null` cuando no
+ * encuentra ningún marker (caso degenerado del primer load del mapa).
+ */
+export function performMarkerReveal({
+  scope,
+  overrides,
+}: PerformMarkerRevealOptions): gsap.core.Tween | null {
+  const targets = scope.querySelectorAll(MAPLIBRE_MARKER_SELECTOR);
+  if (targets.length === 0) return null;
+  const baseVars = buildMarkerRevealVars();
+  return gsap.from(targets, { ...baseVars, ...overrides });
+}
+
+export interface UseMarkerRevealOptions {
+  /** Ref al container que contiene los markers. */
+  readonly scopeRef: RefObject<HTMLElement | null>;
+  /**
+   * Cualquier valor cuya mutación debe disparar un nuevo reveal: por
+   * defecto pasamos la longitud de la lista para no relanzar reveals
+   * cuando sólo cambia el color de la capa.
+   */
+  readonly trigger?: unknown;
+  /** Permite desactivar el efecto sin desmontar el hook. */
+  readonly disabled?: boolean;
+}
+
+/**
+ * Hook que reaplica el reveal radial cuando cambia el `trigger`. Pensado
+ * para envolver al `<SpainMap>` o cualquier wrapper que ya monte sus
+ * markers vía `react-map-gl`. Internamente reusa `useGSAP` a través de
+ * `gsap.context` con cleanup automático al desmontar.
+ */
+export function useMarkerReveal({
+  scopeRef,
+  trigger,
+  disabled = false,
+}: UseMarkerRevealOptions): void {
+  useEffect(() => {
+    if (disabled) return undefined;
+    const node = scopeRef.current;
+    if (!node) return undefined;
+    const ctx = gsap.context(() => {
+      performMarkerReveal({ scope: node });
+    }, node);
+    return () => ctx.revert();
+    // `trigger` se incluye intencionalmente: queremos relanzar la
+    // animación cuando el caller indique que el dataset ha cambiado.
+  }, [scopeRef, trigger, disabled]);
+}
+
+export interface MarkerRevealRadialProps {
+  /** Subárbol que contiene `.maplibregl-marker`. */
+  readonly children: ReactNode;
+  /**
+   * Valor que dispara un nuevo reveal cuando cambia (ej.: `points.length`).
+   * Si se omite el reveal sólo se aplica al montar.
+   */
+  readonly trigger?: unknown;
+  /** Desactiva el efecto sin afectar al render del subárbol. */
+  readonly disabled?: boolean;
+  /** Etiqueta accesible. Por defecto se omite. */
+  readonly 'aria-label'?: string;
+  readonly className?: string;
+}
+
+/**
+ * Componente trigger: monta el subárbol y se encarga de aplicar el
+ * reveal radial sobre los markers MapLibre presentes en su DOM. Útil
+ * cuando no se quiere (o no se puede) tocar el componente del mapa
+ * directamente.
+ */
+export function MarkerRevealRadial({
+  children,
+  trigger,
+  disabled = false,
+  'aria-label': ariaLabel,
+  className,
+}: MarkerRevealRadialProps) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  useMarkerReveal({ scopeRef: containerRef, trigger, disabled });
+  return (
+    <div
+      ref={containerRef}
+      className={className}
+      data-motion="marker-reveal-radial"
+      aria-label={ariaLabel}
+    >
+      {children}
+    </div>
+  );
+}
+
+export interface IdleMapPanController {
+  /** Detiene el bucle pero no desactiva la posibilidad de reanudarlo. */
+  readonly stop: () => void;
+  /** Limpia por completo el bucle (idempotente). */
+  readonly destroy: () => void;
+  /**
+   * Dispara manualmente un paneo al hot municipio. Acepta un override
+   * de duración (en segundos) y de coordenadas, útil para los tests.
+   */
+  readonly panNow: (override?: { lat?: number; lon?: number; duration?: number }) => void;
+}
+
+export interface MapLikeInstance {
+  readonly easeTo: (options: {
+    center: [number, number];
+    duration: number;
+    easing?: (t: number) => number;
+  }) => unknown;
+}
+
+export interface CreateIdleMapPanOptions {
+  /** Mapa real (`maplibre-gl` o `react-map-gl`) o su mock. */
+  readonly map: MapLikeInstance;
+  /** Función que devuelve el hot municipio actual o `null`. */
+  readonly getHotPoint: () => IdleHotPoint | null;
+  /**
+   * Intervalo en milisegundos. Por defecto `MAP_IDLE_INTERVAL_S * 1000`
+   * (30 s) para encajar con el spec del Atelier.
+   */
+  readonly intervalMs?: number;
+  /** Duración (s) del `easeTo`. Por defecto 1.6 s. */
+  readonly easeDurationS?: number;
+  /**
+   * Reloj inyectable (sólo para tests). Si se omite usamos
+   * `globalThis.setInterval`/`clearInterval`.
+   */
+  readonly scheduler?: {
+    setInterval: typeof globalThis.setInterval;
+    clearInterval: typeof globalThis.clearInterval;
+  };
+}
+
+/**
+ * Crea un controlador que pansea el mapa al hot municipio cada cierto
+ * intervalo, respetando `prefers-reduced-motion`. Lo construimos como
+ * función pura (no hook) para poder reutilizarlo desde efectos en
+ * componentes y desde tests vitest sin react-test-renderer.
+ */
+export function createIdleMapPan({
+  map,
+  getHotPoint,
+  intervalMs = MAP_IDLE_INTERVAL_S * 1000,
+  easeDurationS = 1.6,
+  scheduler,
+}: CreateIdleMapPanOptions): IdleMapPanController {
+  // Usamos parametrizable scheduler para que vitest pueda inyectar
+  // fakeTimers sin depender de variables globales del entorno.
+  const realScheduler = scheduler ?? {
+    setInterval: globalThis.setInterval.bind(globalThis),
+    clearInterval: globalThis.clearInterval.bind(globalThis),
+  };
+
+  let timer: ReturnType<typeof globalThis.setInterval> | null = null;
+
+  const panNow: IdleMapPanController['panNow'] = (override) => {
+    if (prefersReducedMotion()) return;
+    const point = getHotPoint();
+    if (!point) return;
+    const lat = override?.lat ?? point.lat;
+    const lon = override?.lon ?? point.lon;
+    const durationMs = (override?.duration ?? easeDurationS) * 1000;
+    map.easeTo({
+      center: [lon, lat],
+      duration: durationMs,
+      easing: (t) => 1 - Math.pow(1 - t, 3),
+    });
+  };
+
+  // Arrancamos sólo si no se solicita movimiento reducido. El
+  // controlador puede ser invocado manualmente (`panNow`) en
+  // cualquier caso.
+  if (!prefersReducedMotion()) {
+    timer = realScheduler.setInterval(() => panNow(), intervalMs);
+  }
+
+  const stop = () => {
+    if (timer !== null) {
+      realScheduler.clearInterval(timer);
+      timer = null;
+    }
+  };
+
+  return {
+    stop,
+    destroy: stop,
+    panNow,
+  };
+}
+
+export interface UseIdleMapPanOptions {
+  /** Devuelve la instancia activa del mapa o `null` si aún no existe. */
+  readonly getMap: () => MapLikeInstance | null;
+  /** Hot municipio actual o `null`. */
+  readonly getHotPoint: () => IdleHotPoint | null;
+  /** Habilitación dinámica: pásalo `false` para pausar sin desmontar. */
+  readonly enabled?: boolean;
+  readonly intervalMs?: number;
+}
+
+/**
+ * Hook ergonómico para enganchar el panning idle desde un componente.
+ * Devuelve un `panNow` estable para que la UI pueda forzarlo (por
+ * ejemplo al pulsar un botón "Volver al hot municipio").
+ */
+export function useIdleMapPan({
+  getMap,
+  getHotPoint,
+  enabled = true,
+  intervalMs,
+}: UseIdleMapPanOptions): { panNow: () => void } {
+  const controllerRef = useRef<IdleMapPanController | null>(null);
+
+  useEffect(() => {
+    if (!enabled) return undefined;
+    const map = getMap();
+    if (!map) return undefined;
+    const controller = createIdleMapPan({
+      map,
+      getHotPoint,
+      ...(intervalMs !== undefined ? { intervalMs } : {}),
+    });
+    controllerRef.current = controller;
+    return () => {
+      controller.destroy();
+      controllerRef.current = null;
+    };
+  }, [enabled, getMap, getHotPoint, intervalMs]);
+
+  const panNow = useCallback(() => {
+    controllerRef.current?.panNow();
+  }, []);
+
+  return { panNow };
+}
+
+/**
+ * Tweena el color de los markers visibles sin remontar el subárbol del
+ * mapa. Espera nodos con `data-bubble-color` actualizado: cuando cambia
+ * el atributo, GSAP interpola hacia el nuevo color usando el easing
+ * `enter` del Atelier.
+ */
+export function tweenMarkerColors(scope: HTMLElement | Document): gsap.core.Tween | null {
+  const targets = scope.querySelectorAll<HTMLElement>('[data-bubble-color]');
+  if (targets.length === 0) return null;
+  const duration = prefersReducedMotion() ? 0 : 0.4;
+  return gsap.to(Array.from(targets), {
+    backgroundColor: (_index: number, target: HTMLElement) =>
+      target.dataset.bubbleColor ?? '#10b981',
+    duration,
+    ease: EASINGS.smooth,
+    overwrite: 'auto',
+  });
+}

--- a/apps/web/src/components/motion/MotionMagnetic.tsx
+++ b/apps/web/src/components/motion/MotionMagnetic.tsx
@@ -1,0 +1,143 @@
+import {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  type ElementType,
+  type FocusEvent,
+  type PointerEvent,
+  type ReactNode,
+  type Ref,
+} from 'react';
+import gsap from 'gsap';
+
+import { EASINGS, MAGNETIC_RADIUS_PX, MAGNETIC_STRENGTH, prefersReducedMotion } from '@/animations';
+
+export interface MotionMagneticProps {
+  /** Contenido (CTA, action card, icon button…). */
+  children: ReactNode;
+  /** Etiqueta HTML por defecto `div`. */
+  as?: ElementType;
+  /** Radio en píxeles dentro del cual se atrae el elemento. */
+  radius?: number;
+  /** Factor 0..1 que controla cuánto se desplaza el contenido. */
+  strength?: number;
+  /** Desactiva la atracción magnética sin retirar el wrapper. */
+  disabled?: boolean;
+  className?: string;
+  'aria-label'?: string;
+}
+
+/**
+ * Wrapper que aplica un efecto "cursor magnético" sobre CTAs y action
+ * cards: cuando el puntero entra en un radio configurable, el elemento
+ * desliza una fracción de la distancia para invitar al click. Usa
+ * `gsap.quickTo` para mantener un loop fluido (60fps) sin generar
+ * tweens nuevos en cada `pointermove`.
+ *
+ * Respeta `prefers-reduced-motion`: en ese caso no aplica desplazamiento
+ * y se comporta como un wrapper transparente. También resetea la
+ * posición al salir o perder el foco para evitar offsets persistentes.
+ */
+export const MotionMagnetic = forwardRef(function MotionMagnetic(
+  {
+    children,
+    as,
+    radius = MAGNETIC_RADIUS_PX,
+    strength = MAGNETIC_STRENGTH,
+    disabled = false,
+    className,
+    'aria-label': ariaLabel,
+  }: MotionMagneticProps,
+  forwardedRef: Ref<HTMLElement>
+) {
+  const elementRef = useRef<HTMLElement | null>(null);
+  // `quickTo` es una factoría perezosa: la creamos una vez por
+  // dimensión para que cada `pointermove` llame a una función nativa
+  // y GSAP coloque el valor en el siguiente frame sin instanciar
+  // tweens nuevos.
+  const quickXRef = useRef<gsap.QuickToFunc | null>(null);
+  const quickYRef = useRef<gsap.QuickToFunc | null>(null);
+
+  // Permitimos al consumidor obtener el nodo si necesita medirlo (p.ej.
+  // foco programático) sin renunciar a la encapsulación interna.
+  useImperativeHandle(forwardedRef, () => elementRef.current as HTMLElement, []);
+
+  useEffect(() => {
+    const node = elementRef.current;
+    if (!node) return undefined;
+    quickXRef.current = gsap.quickTo(node, 'x', {
+      duration: 0.35,
+      ease: EASINGS.smooth,
+    });
+    quickYRef.current = gsap.quickTo(node, 'y', {
+      duration: 0.35,
+      ease: EASINGS.smooth,
+    });
+    return () => {
+      // Cleanup explícito: si el componente se desmonta mientras el
+      // tween está en vuelo, evitamos warnings de GSAP y limpiamos las
+      // transformaciones residuales.
+      gsap.killTweensOf(node);
+      gsap.set(node, { x: 0, y: 0, clearProps: 'transform' });
+      quickXRef.current = null;
+      quickYRef.current = null;
+    };
+  }, []);
+
+  const settle = useCallback(() => {
+    if (!quickXRef.current || !quickYRef.current) return;
+    quickXRef.current(0);
+    quickYRef.current(0);
+  }, []);
+
+  const handleMove = useCallback(
+    (event: PointerEvent<HTMLElement>) => {
+      if (disabled) return;
+      if (prefersReducedMotion()) return;
+      const node = elementRef.current;
+      if (!node || !quickXRef.current || !quickYRef.current) return;
+
+      const rect = node.getBoundingClientRect();
+      const cx = rect.left + rect.width / 2;
+      const cy = rect.top + rect.height / 2;
+      const dx = event.clientX - cx;
+      const dy = event.clientY - cy;
+      const distance = Math.hypot(dx, dy);
+
+      // Si el cursor está fuera del radio configurado relajamos el
+      // wrapper hacia la posición original. De este modo el efecto solo
+      // se siente cuando el usuario está realmente cerca del CTA.
+      if (distance > radius) {
+        settle();
+        return;
+      }
+      quickXRef.current(dx * strength);
+      quickYRef.current(dy * strength);
+    },
+    [disabled, radius, settle, strength]
+  );
+
+  const handleLeave = useCallback((_event: PointerEvent<HTMLElement>) => settle(), [settle]);
+
+  const handleBlur = useCallback((_event: FocusEvent<HTMLElement>) => settle(), [settle]);
+
+  const Component = (as ?? 'div') as ElementType;
+  return (
+    <Component
+      ref={(node: HTMLElement | null) => {
+        elementRef.current = node;
+      }}
+      className={className}
+      data-motion="magnetic"
+      data-magnetic-disabled={disabled ? 'true' : undefined}
+      aria-label={ariaLabel}
+      onPointerMove={handleMove}
+      onPointerLeave={handleLeave}
+      onBlur={handleBlur}
+    >
+      {children}
+    </Component>
+  );
+});

--- a/apps/web/src/components/motion/NumberCountup.tsx
+++ b/apps/web/src/components/motion/NumberCountup.tsx
@@ -1,0 +1,127 @@
+import { useMemo, useRef, useState, type ElementType } from 'react';
+import gsap from 'gsap';
+import { useGSAP } from '@gsap/react';
+
+import { DURATIONS, EASINGS, prefersReducedMotion } from '@/animations';
+
+export interface NumberCountupProps {
+  /** Valor objetivo. Acepta enteros y decimales. */
+  value: number;
+  /**
+   * Valor inicial al montar. Por defecto 0; se puede usar el valor
+   * previo cuando se renderiza una secuencia de actualizaciones para
+   * evitar el "tic" de retroceso.
+   */
+  from?: number;
+  /** Duración del tweening. Por defecto `lush` (0.55 s). */
+  duration?: number;
+  /** Locale del formateador. Por defecto `'es-ES'`. */
+  locale?: string;
+  /** Opciones forwardeadas a `Intl.NumberFormat`. */
+  formatOptions?: Intl.NumberFormatOptions;
+  /** Sufijo opcional (`'%'`, `'€'`, `' km'`…). */
+  suffix?: string;
+  /** Prefijo opcional (`'+'`, `'€'`, …). */
+  prefix?: string;
+  /** Tag HTML del wrapper. Por defecto `<span>`. */
+  as?: ElementType;
+  className?: string;
+  /** Etiqueta accesible: si se omite usamos el valor formateado final. */
+  'aria-label'?: string;
+}
+
+/**
+ * Construye el formateador `Intl.NumberFormat` memoizado por locale y
+ * opciones para evitar instanciaciones innecesarias en cada render.
+ */
+function useNumberFormatter(
+  locale: string,
+  options: Intl.NumberFormatOptions | undefined
+): Intl.NumberFormat {
+  return useMemo(() => new Intl.NumberFormat(locale, options), [locale, options]);
+}
+
+/**
+ * Componente que anima la transición numérica entre dos valores con
+ * `gsap.to`, formateando el resultado con `Intl.NumberFormat('es-ES')`
+ * por defecto. Es ideal para los KPIs del Atelier (StatsStrip, hero
+ * counters, recomendaciones), donde la cifra final tiene tanta carga
+ * informativa como su variación.
+ *
+ * Detalles de accesibilidad:
+ *   - El wrapper expone `role="text"` para garantizar que screen readers
+ *     compatibles lo anuncien como una unidad.
+ *   - Cuando el usuario solicita movimiento reducido, saltamos
+ *     directamente al valor final y el `aria-label` refleja el estado
+ *     final desde el primer pintado.
+ */
+export function NumberCountup({
+  value,
+  from = 0,
+  duration = DURATIONS.lush,
+  locale = 'es-ES',
+  formatOptions,
+  suffix,
+  prefix,
+  as,
+  className,
+  'aria-label': ariaLabelOverride,
+}: NumberCountupProps) {
+  const formatter = useNumberFormatter(locale, formatOptions);
+  const [display, setDisplay] = useState<string>(() => formatter.format(from));
+  const targetRef = useRef<{ current: number }>({ current: from });
+
+  useGSAP(() => {
+    const proxy = targetRef.current;
+
+    if (prefersReducedMotion()) {
+      // Saltamos directamente al valor final. Mantener el estado en
+      // `proxy.current` permite que tweens posteriores arranquen desde
+      // ese valor sin "rebote" hacia 0.
+      proxy.current = value;
+      setDisplay(formatter.format(value));
+      return;
+    }
+
+    const tween = gsap.to(proxy, {
+      current: value,
+      duration,
+      ease: EASINGS.enter,
+      overwrite: 'auto',
+      onUpdate: () => {
+        setDisplay(formatter.format(proxy.current));
+      },
+      onComplete: () => {
+        // Forzar el formato exacto al final para que cifras decimales
+        // no se queden en valores como `12.999998…`.
+        setDisplay(formatter.format(value));
+      },
+    });
+
+    return () => {
+      tween.kill();
+    };
+  }, [value, duration, formatter]);
+
+  const ariaLabel = ariaLabelOverride ?? `${prefix ?? ''}${formatter.format(value)}${suffix ?? ''}`;
+
+  const Component = (as ?? 'span') as ElementType;
+  return (
+    <Component
+      className={className}
+      data-motion="number-countup"
+      data-target-value={value}
+      aria-label={ariaLabel}
+    >
+      {prefix}
+      <span aria-hidden="true" className="tabular-nums">
+        {display}
+      </span>
+      {suffix}
+    </Component>
+  );
+}
+
+// Nota tipográfica: la animación es puramente visual; el `aria-label`
+// transmite el dato definitivo a las tecnologías asistivas y el
+// wrapper interno se marca `aria-hidden` para no leer cada tick.

--- a/apps/web/src/components/motion/Sparkline.tsx
+++ b/apps/web/src/components/motion/Sparkline.tsx
@@ -1,0 +1,166 @@
+import { useId, useMemo } from 'react';
+
+export interface SparklineProps {
+  /**
+   * Serie temporal a representar. Debe tener al menos un punto. Acepta
+   * únicamente números finitos (los `NaN`/`Infinity` se sanean a 0).
+   */
+  values: readonly number[];
+  /** Ancho intrínseco del SVG. Por defecto 96. */
+  width?: number;
+  /** Alto intrínseco del SVG. Por defecto 28. */
+  height?: number;
+  /** Stroke width en píxeles. Por defecto 1.5. */
+  strokeWidth?: number;
+  /** Color del trazo. Por defecto `currentColor` (hereda del padre). */
+  stroke?: string;
+  /** Color de relleno (área). Por defecto `transparent`. */
+  fill?: string;
+  /** Etiqueta accesible. Si se omite usamos un fallback descriptivo. */
+  ariaLabel?: string;
+  /** Opacidad del relleno. Por defecto 0.16 cuando hay fill explícito. */
+  fillOpacity?: number;
+  /** Padding interno (px) para que el trazo no toque los bordes. */
+  padding?: number;
+  className?: string;
+}
+
+interface NormalizedSerie {
+  readonly path: string;
+  readonly area: string;
+  readonly minIndex: number;
+  readonly maxIndex: number;
+}
+
+/**
+ * Saneamos la serie para tolerar valores no numéricos sin romper el
+ * cálculo del rango. Devolvemos un array de la misma longitud porque
+ * preferimos preservar la cadencia temporal a "saltarnos" puntos.
+ */
+function sanitize(values: readonly number[]): number[] {
+  return values.map((value) => (Number.isFinite(value) ? value : 0));
+}
+
+/**
+ * Construye los `path` del trazo y del área usando coordenadas
+ * normalizadas al recuadro del SVG. El cálculo es memoizable porque
+ * depende exclusivamente de los inputs declarados.
+ */
+function buildSerie(
+  values: readonly number[],
+  width: number,
+  height: number,
+  padding: number
+): NormalizedSerie {
+  const sanitized = sanitize(values);
+  const innerW = Math.max(1, width - padding * 2);
+  const innerH = Math.max(1, height - padding * 2);
+
+  let min = Number.POSITIVE_INFINITY;
+  let max = Number.NEGATIVE_INFINITY;
+  let minIndex = 0;
+  let maxIndex = 0;
+  sanitized.forEach((value, index) => {
+    if (value < min) {
+      min = value;
+      minIndex = index;
+    }
+    if (value > max) {
+      max = value;
+      maxIndex = index;
+    }
+  });
+
+  // Para series planas usamos el centro vertical, evitando una
+  // división por cero cuando max === min.
+  const range = max - min;
+  const safeRange = range === 0 ? 1 : range;
+  const stepX = sanitized.length > 1 ? innerW / (sanitized.length - 1) : 0;
+
+  const points = sanitized.map((value, index) => {
+    const x = padding + stepX * index;
+    const ratio = range === 0 ? 0.5 : (value - min) / safeRange;
+    // Invertimos Y porque en SVG el origen está en la esquina superior.
+    const y = padding + innerH - ratio * innerH;
+    return [x, y] as const;
+  });
+
+  if (points.length === 0) {
+    return { path: '', area: '', minIndex, maxIndex };
+  }
+
+  const path = points
+    .map(([x, y], index) =>
+      index === 0 ? `M${x.toFixed(2)} ${y.toFixed(2)}` : `L${x.toFixed(2)} ${y.toFixed(2)}`
+    )
+    .join(' ');
+
+  const lastX = points[points.length - 1][0];
+  const firstX = points[0][0];
+  const baseY = padding + innerH;
+  const area = `${path} L${lastX.toFixed(2)} ${baseY.toFixed(2)} L${firstX.toFixed(2)} ${baseY.toFixed(2)} Z`;
+
+  return { path, area, minIndex, maxIndex };
+}
+
+/**
+ * Sparkline SVG ligero, sin dependencias de Recharts ni D3, pensado
+ * para tooltips y resúmenes de tendencias en el mapa AtlasHabita.
+ *
+ * Características:
+ *   - Trabaja con `viewBox` para escalar limpio a cualquier tamaño CSS.
+ *   - Genera un `path` compuesto (línea + área opcional) en una sola
+ *     pasada, cubriendo el caso degenerado de series planas.
+ *   - Marca con `<title>` para accesibilidad básica (lectores de
+ *     pantalla anunciarán la etiqueta del gráfico).
+ */
+export function Sparkline({
+  values,
+  width = 96,
+  height = 28,
+  strokeWidth = 1.5,
+  stroke = 'currentColor',
+  fill = 'transparent',
+  fillOpacity,
+  padding = 2,
+  ariaLabel,
+  className,
+}: SparklineProps) {
+  const titleId = useId();
+  const serie = useMemo(
+    () => buildSerie(values, width, height, padding),
+    [values, width, height, padding]
+  );
+
+  const safeLabel = ariaLabel ?? `Tendencia (${values.length} valores)`;
+  const showFill = fill !== 'transparent';
+  const resolvedFillOpacity = fillOpacity ?? (showFill ? 0.16 : 0);
+
+  return (
+    <svg
+      role="img"
+      aria-labelledby={titleId}
+      width={width}
+      height={height}
+      viewBox={`0 0 ${width} ${height}`}
+      preserveAspectRatio="none"
+      className={className}
+      data-motion="sparkline"
+    >
+      <title id={titleId}>{safeLabel}</title>
+      {showFill && serie.area ? (
+        <path d={serie.area} fill={fill} fillOpacity={resolvedFillOpacity} stroke="none" />
+      ) : null}
+      {serie.path ? (
+        <path
+          d={serie.path}
+          stroke={stroke}
+          strokeWidth={strokeWidth}
+          fill="none"
+          strokeLinejoin="round"
+          strokeLinecap="round"
+        />
+      ) : null}
+    </svg>
+  );
+}

--- a/apps/web/src/components/motion/__tests__/CardConic.test.tsx
+++ b/apps/web/src/components/motion/__tests__/CardConic.test.tsx
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { CardConic } from '../CardConic';
+
+describe('CardConic', () => {
+  it('renderiza el wrapper con la capa decorativa aria-hidden', () => {
+    render(
+      <CardConic aria-label="card-conic">
+        <span>contenido</span>
+      </CardConic>
+    );
+    const wrapper = screen.getByLabelText('card-conic');
+    expect(wrapper).toHaveAttribute('data-motion', 'card-conic');
+    const overlay = screen.getByTestId('card-conic-overlay');
+    expect(overlay).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('inicializa el gradiente con la variable CSS de ángulo', () => {
+    render(
+      <CardConic aria-label="conic">
+        <span>x</span>
+      </CardConic>
+    );
+    const overlay = screen.getByTestId('card-conic-overlay');
+    expect(overlay.style.getPropertyValue('--card-conic-angle')).toBe('0deg');
+    expect(overlay.style.background).toContain('conic-gradient');
+  });
+
+  it('reacciona a hover/focus sin alterar el contenido renderizado', () => {
+    render(
+      <CardConic aria-label="hoverable">
+        <button type="button">CTA</button>
+      </CardConic>
+    );
+    const wrapper = screen.getByLabelText('hoverable');
+    fireEvent.pointerEnter(wrapper);
+    fireEvent.focus(wrapper);
+    fireEvent.pointerLeave(wrapper);
+    fireEvent.blur(wrapper);
+    expect(screen.getByRole('button', { name: 'CTA' })).toBeInTheDocument();
+  });
+
+  it('expone data-conic-disabled cuando se desactiva el efecto', () => {
+    render(
+      <CardConic aria-label="locked" disabled>
+        <span>locked</span>
+      </CardConic>
+    );
+    expect(screen.getByLabelText('locked')).toHaveAttribute('data-conic-disabled', 'true');
+  });
+});

--- a/apps/web/src/components/motion/__tests__/MarkerRevealRadial.test.tsx
+++ b/apps/web/src/components/motion/__tests__/MarkerRevealRadial.test.tsx
@@ -1,0 +1,181 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import {
+  MAPLIBRE_MARKER_SELECTOR,
+  MarkerRevealRadial,
+  createIdleMapPan,
+  performMarkerReveal,
+  tweenMarkerColors,
+} from '../MarkerRevealRadial';
+
+type MatchMediaStub = typeof window.matchMedia;
+
+function mockMatchMedia(matches: boolean): MatchMediaStub {
+  return ((query: string) => ({
+    matches,
+    media: query,
+    addEventListener: () => undefined,
+    removeEventListener: () => undefined,
+    addListener: () => undefined,
+    removeListener: () => undefined,
+    dispatchEvent: () => false,
+    onchange: null,
+  })) as unknown as MatchMediaStub;
+}
+
+const ORIGINAL_MATCH_MEDIA = window.matchMedia;
+
+afterEach(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    writable: true,
+    value: ORIGINAL_MATCH_MEDIA,
+  });
+  vi.useRealTimers();
+});
+
+describe('MarkerRevealRadial', () => {
+  it('renderiza el subárbol y aplica data-motion="marker-reveal-radial"', () => {
+    render(
+      <MarkerRevealRadial aria-label="reveal">
+        <button type="button" className="maplibregl-marker">
+          A
+        </button>
+        <button type="button" className="maplibregl-marker">
+          B
+        </button>
+      </MarkerRevealRadial>
+    );
+    const wrapper = screen.getByLabelText('reveal');
+    expect(wrapper).toHaveAttribute('data-motion', 'marker-reveal-radial');
+    expect(wrapper.querySelectorAll(MAPLIBRE_MARKER_SELECTOR)).toHaveLength(2);
+  });
+
+  it('performMarkerReveal devuelve null cuando no hay markers', () => {
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      writable: true,
+      value: mockMatchMedia(false),
+    });
+    const empty = document.createElement('div');
+    expect(performMarkerReveal({ scope: empty })).toBeNull();
+  });
+
+  it('performMarkerReveal acepta overrides cuando hay markers', () => {
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      writable: true,
+      value: mockMatchMedia(false),
+    });
+    const root = document.createElement('div');
+    document.body.appendChild(root);
+    const m1 = document.createElement('div');
+    m1.className = 'maplibregl-marker';
+    const m2 = document.createElement('div');
+    m2.className = 'maplibregl-marker';
+    root.append(m1, m2);
+    const tween = performMarkerReveal({ scope: root, overrides: { delay: 0.1 } });
+    expect(tween).not.toBeNull();
+    document.body.removeChild(root);
+  });
+
+  it('tweenMarkerColors devuelve null cuando no hay nodos con data-bubble-color', () => {
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      writable: true,
+      value: mockMatchMedia(false),
+    });
+    const root = document.createElement('div');
+    expect(tweenMarkerColors(root)).toBeNull();
+  });
+});
+
+describe('createIdleMapPan', () => {
+  it('llama a easeTo con las coordenadas del hot municipio', () => {
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      writable: true,
+      value: mockMatchMedia(false),
+    });
+    const easeTo = vi.fn();
+    const map = { easeTo };
+    const ctrl = createIdleMapPan({
+      map,
+      getHotPoint: () => ({ id: 'm1', lat: 40, lon: -3, score: 80 }),
+      intervalMs: 1000,
+      easeDurationS: 1,
+    });
+    ctrl.panNow();
+    expect(easeTo).toHaveBeenCalledTimes(1);
+    expect(easeTo.mock.calls[0][0]).toMatchObject({
+      center: [-3, 40],
+      duration: 1000,
+    });
+    ctrl.destroy();
+  });
+
+  it('respeta prefers-reduced-motion: no programa intervalos ni paneos', () => {
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      writable: true,
+      value: mockMatchMedia(true),
+    });
+    const easeTo = vi.fn();
+    const ctrl = createIdleMapPan({
+      map: { easeTo },
+      getHotPoint: () => ({ id: 'm1', lat: 40, lon: -3, score: 80 }),
+      intervalMs: 1000,
+      easeDurationS: 1,
+    });
+    ctrl.panNow();
+    expect(easeTo).not.toHaveBeenCalled();
+    ctrl.destroy();
+  });
+
+  it('panNow no falla cuando no hay hot point disponible', () => {
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      writable: true,
+      value: mockMatchMedia(false),
+    });
+    const easeTo = vi.fn();
+    const ctrl = createIdleMapPan({
+      map: { easeTo },
+      getHotPoint: () => null,
+      intervalMs: 1000,
+    });
+    ctrl.panNow();
+    expect(easeTo).not.toHaveBeenCalled();
+    ctrl.destroy();
+  });
+
+  it('dispara easeTo en cada tick del scheduler inyectado', () => {
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      writable: true,
+      value: mockMatchMedia(false),
+    });
+    const easeTo = vi.fn();
+    const handlerHolder: { fn: (() => void) | null } = { fn: null };
+    const setIntervalMock = vi.fn().mockImplementation((handler: () => void) => {
+      handlerHolder.fn = handler;
+      return 42;
+    });
+    const clearIntervalMock = vi.fn();
+    const ctrl = createIdleMapPan({
+      map: { easeTo },
+      getHotPoint: () => ({ id: 'a', lat: 40, lon: -3, score: 50 }),
+      intervalMs: 100,
+      scheduler: {
+        setInterval: setIntervalMock as unknown as typeof globalThis.setInterval,
+        clearInterval: clearIntervalMock as unknown as typeof globalThis.clearInterval,
+      },
+    });
+    expect(setIntervalMock).toHaveBeenCalledTimes(1);
+    handlerHolder.fn?.();
+    expect(easeTo).toHaveBeenCalledTimes(1);
+    ctrl.destroy();
+    expect(clearIntervalMock).toHaveBeenCalledWith(42);
+  });
+});

--- a/apps/web/src/components/motion/__tests__/MotionMagnetic.test.tsx
+++ b/apps/web/src/components/motion/__tests__/MotionMagnetic.test.tsx
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { MotionMagnetic } from '../MotionMagnetic';
+
+describe('MotionMagnetic', () => {
+  it('renderiza los hijos y expone data-motion="magnetic"', () => {
+    render(
+      <MotionMagnetic aria-label="cta">
+        <button type="button">Explorar</button>
+      </MotionMagnetic>
+    );
+
+    const wrapper = screen.getByLabelText('cta');
+    expect(wrapper).toHaveAttribute('data-motion', 'magnetic');
+    expect(screen.getByRole('button', { name: 'Explorar' })).toBeInTheDocument();
+  });
+
+  it('procesa pointermove y pointerleave sin romperse', () => {
+    render(
+      <MotionMagnetic as="section" aria-label="card">
+        <span>contenido</span>
+      </MotionMagnetic>
+    );
+    const wrapper = screen.getByLabelText('card');
+    fireEvent.pointerMove(wrapper, { clientX: 5, clientY: 5 });
+    fireEvent.pointerLeave(wrapper);
+    fireEvent.blur(wrapper);
+    expect(wrapper).toContainHTML('<span>contenido</span>');
+  });
+
+  it('respeta la prop disabled marcando data-magnetic-disabled', () => {
+    render(
+      <MotionMagnetic aria-label="off" disabled>
+        <span>off</span>
+      </MotionMagnetic>
+    );
+    expect(screen.getByLabelText('off')).toHaveAttribute('data-magnetic-disabled', 'true');
+  });
+});

--- a/apps/web/src/components/motion/__tests__/NumberCountup.test.tsx
+++ b/apps/web/src/components/motion/__tests__/NumberCountup.test.tsx
@@ -1,0 +1,75 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import { NumberCountup } from '../NumberCountup';
+
+type MatchMediaStub = typeof window.matchMedia;
+
+function mockMatchMedia(matches: boolean): MatchMediaStub {
+  return ((query: string) => ({
+    matches,
+    media: query,
+    addEventListener: () => undefined,
+    removeEventListener: () => undefined,
+    addListener: () => undefined,
+    removeListener: () => undefined,
+    dispatchEvent: () => false,
+    onchange: null,
+  })) as unknown as MatchMediaStub;
+}
+
+const ORIGINAL_MATCH_MEDIA = window.matchMedia;
+
+afterEach(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    writable: true,
+    value: ORIGINAL_MATCH_MEDIA,
+  });
+});
+
+describe('NumberCountup', () => {
+  it('formatea con Intl.NumberFormat es-ES por defecto y expone aria-label', () => {
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      writable: true,
+      value: mockMatchMedia(true),
+    });
+    render(<NumberCountup value={1234567} suffix=" hab." aria-label="poblacion total" />);
+    const wrapper = screen.getByLabelText('poblacion total');
+    expect(wrapper).toHaveAttribute('data-motion', 'number-countup');
+    expect(wrapper).toHaveAttribute('data-target-value', '1234567');
+    expect(wrapper.textContent).toContain('1.234.567');
+    expect(wrapper.textContent).toContain('hab.');
+  });
+
+  it('aplica prefijo y respeta opciones de formato decimal', () => {
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      writable: true,
+      value: mockMatchMedia(true),
+    });
+    render(
+      <NumberCountup
+        value={42.5}
+        prefix="+"
+        aria-label="positivo"
+        formatOptions={{ minimumFractionDigits: 1, maximumFractionDigits: 1 }}
+      />
+    );
+    const wrapper = screen.getByLabelText('positivo');
+    expect(wrapper.textContent).toContain('+');
+    expect(wrapper.textContent).toContain('42,5');
+  });
+
+  it('genera un aria-label de fallback con prefijo y sufijo', () => {
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      writable: true,
+      value: mockMatchMedia(true),
+    });
+    render(<NumberCountup value={50} prefix="+" suffix="%" />);
+    const wrapper = screen.getByLabelText('+50%');
+    expect(wrapper).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/motion/__tests__/Sparkline.test.tsx
+++ b/apps/web/src/components/motion/__tests__/Sparkline.test.tsx
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import { Sparkline } from '../Sparkline';
+
+describe('Sparkline', () => {
+  it('renderiza un SVG accesible con role="img"', () => {
+    render(<Sparkline values={[1, 4, 2, 6, 5]} ariaLabel="Tendencia mensual" />);
+    const svg = screen.getByRole('img', { name: 'Tendencia mensual' });
+    expect(svg.tagName.toLowerCase()).toBe('svg');
+    expect(svg).toHaveAttribute('data-motion', 'sparkline');
+  });
+
+  it('genera un path para series con varios puntos', () => {
+    const { container } = render(<Sparkline values={[1, 2, 3, 4]} />);
+    const path = container.querySelector('path');
+    expect(path).not.toBeNull();
+    const d = path?.getAttribute('d') ?? '';
+    expect(d.startsWith('M')).toBe(true);
+    // Esperamos tantos comandos M/L como puntos en la serie.
+    expect(d.match(/[ML]/g)).toHaveLength(4);
+  });
+
+  it('maneja series planas sin lanzar errores', () => {
+    const { container } = render(<Sparkline values={[5, 5, 5]} />);
+    const path = container.querySelector('path');
+    expect(path).not.toBeNull();
+    const d = path?.getAttribute('d') ?? '';
+    expect(d.includes('NaN')).toBe(false);
+  });
+
+  it('dibuja un área cuando se proporciona un fill diferente de transparent', () => {
+    const { container } = render(<Sparkline values={[1, 2, 3]} fill="#bada55" fillOpacity={0.4} />);
+    const paths = container.querySelectorAll('path');
+    expect(paths.length).toBeGreaterThanOrEqual(2);
+    expect(paths[0].getAttribute('fill')).toBe('#bada55');
+    expect(paths[0].getAttribute('fill-opacity')).toBe('0.4');
+  });
+
+  it('etiqueta automáticamente la serie cuando no se pasa ariaLabel', () => {
+    render(<Sparkline values={[10, 20, 30]} />);
+    expect(screen.getByRole('img', { name: 'Tendencia (3 valores)' })).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/motion/index.ts
+++ b/apps/web/src/components/motion/index.ts
@@ -4,3 +4,30 @@ export { MotionStagger } from './MotionStagger';
 export type { MotionStaggerProps } from './MotionStagger';
 export { MotionScale } from './MotionScale';
 export type { MotionScaleProps } from './MotionScale';
+export { MotionMagnetic } from './MotionMagnetic';
+export type { MotionMagneticProps } from './MotionMagnetic';
+export { NumberCountup } from './NumberCountup';
+export type { NumberCountupProps } from './NumberCountup';
+export { Sparkline } from './Sparkline';
+export type { SparklineProps } from './Sparkline';
+export { CardConic } from './CardConic';
+export type { CardConicProps } from './CardConic';
+export {
+  MAPLIBRE_MARKER_SELECTOR,
+  MarkerRevealRadial,
+  createIdleMapPan,
+  performMarkerReveal,
+  tweenMarkerColors,
+  useIdleMapPan,
+  useMarkerReveal,
+} from './MarkerRevealRadial';
+export type {
+  CreateIdleMapPanOptions,
+  IdleHotPoint,
+  IdleMapPanController,
+  MapLikeInstance,
+  MarkerRevealRadialProps,
+  PerformMarkerRevealOptions,
+  UseIdleMapPanOptions,
+  UseMarkerRevealOptions,
+} from './MarkerRevealRadial';


### PR DESCRIPTION
Helpers `motionPresets`, `usePrefersReducedMotion`, `MotionMagnetic`, `NumberCountup`, `Sparkline`, `CardConic`, `MarkerRevealRadial` con marker reveal radial, magnetic cursor, countup ES, sparkline SVG ligera, idle pan helper. Sólo `transform/opacity/clip-path`, respeto a `prefers-reduced-motion`, cleanup automático. 253 / 253 tests verde.

Closes #117