### PR TITLE
feat(web): overlays cartográficos (FloatingRanking, TerritorySheet, MiniMap, RichLegend)

### DIFF
--- a/apps/web/src/features/dashboard/DashboardShell.tsx
+++ b/apps/web/src/features/dashboard/DashboardShell.tsx
@@ -1,40 +1,27 @@
-import { useMemo, useState } from 'react';
+import { useCallback, useMemo, type ReactNode } from 'react';
 import {
-  BarChart3,
+  Activity,
   Building2,
   GitCompareArrows,
   Map as MapIcon,
   Sparkles,
-  Wallet,
-  Wifi,
-  Wrench,
+  TrendingUp,
 } from 'lucide-react';
 import { ActionCards, type ActionCardItem } from '@/components/layout/ActionCards';
-import { ChipFilters, type ChipFilterOption } from '@/components/layout/ChipFilters';
 import { DashboardLayout } from '@/components/layout/DashboardLayout';
-import { OpportunityIndex } from '@/components/layout/OpportunityIndex';
-import { ActivityFeed } from '@/features/activity';
-import { HighlightCard } from '@/features/recommendations';
 import { SpainMap } from '@/features/map/SpainMap';
-import { MAP_LAYER_CATALOG, resolveLayer } from '@/features/map/layers/catalog';
-import { TrendsChart } from '@/features/trends';
-import { mockActivity, mockHighlight, mockTrends } from '@/data/mock';
+import {
+  MAP_LAYER_CATALOG,
+  buildLegendStops,
+  computeLayerDomain,
+  resolveLayer,
+  type MapLayerId,
+} from '@/features/map/layers/catalog';
 import { toEnrichedMapPoints } from '@/data/national_mock';
 import { useMapLayerStore } from '@/state/mapLayer';
-
-/**
- * Filtros rápidos del hero. Igualan los chips visibles en la captura
- * `atlashabita-main.png`: Calidad de vida, Vivienda asequible, Empleo,
- * Conectividad y "Más filtros" como afordancia para abrir el panel
- * detallado de scoring.
- */
-const CHIP_OPTIONS: ChipFilterOption[] = [
-  { id: 'quality', label: 'Calidad de vida', icon: <Sparkles size={14} strokeWidth={2.25} /> },
-  { id: 'housing', label: 'Vivienda asequible', icon: <Building2 size={14} strokeWidth={2.25} /> },
-  { id: 'jobs', label: 'Empleo', icon: <Wallet size={14} strokeWidth={2.25} /> },
-  { id: 'connectivity', label: 'Conectividad', icon: <Wifi size={14} strokeWidth={2.25} /> },
-  { id: 'more', label: 'Más filtros', icon: <Wrench size={14} strokeWidth={2.25} /> },
-];
+import { useUiStore } from '@/state/ui';
+import { cn } from '@/components/ui/cn';
+import { FloatingRanking, MiniMap, RichLegend, TerritorySheet } from '@/features/overlays';
 
 /**
  * Cuatro acciones inferiores: igualan la fila final de la captura
@@ -69,180 +56,234 @@ const ACTION_ITEMS: ActionCardItem[] = [
     id: 'analyze',
     title: 'Analizar',
     description: 'Entra al modo técnico para SPARQL, SHACL y reportes avanzados.',
-    icon: <BarChart3 size={20} strokeWidth={2.25} />,
+    icon: <Activity size={20} strokeWidth={2.25} />,
     accent: 'amber',
     href: '/sparql',
   },
 ];
 
 /**
- * Bounds aproximados de la península y archipiélagos para la previsualización
- * del dashboard. Se proyecta a coordenadas SVG asumiendo un mapa Mercator
- * lineal — es suficientemente preciso para una vista decorativa estática y
- * evita arrastrar `maplibre-gl` (con su dependencia de WebGL/URL.createObjectURL)
- * a la home, donde la prioridad es el render rápido y SSR-friendly de la UI.
+ * Banda compacta de KPI por encima del mapa (StatsStrip Atelier).
  *
- *  La vista interactiva real con react-map-gl + tiles de OpenFreeMap se sigue
- *  ofreciendo en `/mapa` (ver `routes/AppRouter.tsx`); aquí mostramos una
- *  versión estática pixel-perfect del comp `atlashabita-main.png`.
+ * Conserva información sintética para que el contexto del mapa quede
+ * resumido sin recurrir a un panel lateral. Los valores se derivan del
+ * dataset nacional para mantener la coherencia con el ranking.
  */
-// La home renderiza ahora el componente `SpainMap` interactivo (MapLibre +
-// OpenFreeMap). En entornos jsdom (vitest) el mock de `vitest.setup.ts`
-// devuelve un wrapper accesible para que los tests sigan siendo deterministas.
+interface StatsStripProps {
+  readonly territoriesCount: number;
+  readonly avgScore: number;
+  readonly highlightedName: string;
+  readonly highlightedScore: number;
+}
+
+function StatsStrip({
+  territoriesCount,
+  avgScore,
+  highlightedName,
+  highlightedScore,
+}: StatsStripProps) {
+  return (
+    <ul
+      aria-label="Indicadores destacados"
+      data-feature="stats-strip"
+      className={cn(
+        'flex flex-wrap items-stretch gap-3 rounded-2xl border border-[color:var(--color-line-soft)] bg-white/80 p-3 backdrop-blur',
+        'shadow-[var(--shadow-card)]'
+      )}
+    >
+      <StatsStripItem
+        icon={<Building2 size={16} aria-hidden="true" />}
+        label="Municipios analizados"
+        value={territoriesCount.toLocaleString('es-ES')}
+      />
+      <StatsStripItem
+        icon={<TrendingUp size={16} aria-hidden="true" />}
+        label="Score medio"
+        value={avgScore.toFixed(1)}
+      />
+      <StatsStripItem
+        icon={<Sparkles size={16} aria-hidden="true" />}
+        label="Mejor encaje"
+        value={`${highlightedName} · ${highlightedScore}`}
+      />
+    </ul>
+  );
+}
+
+function StatsStripItem({ icon, label, value }: { icon: ReactNode; label: string; value: string }) {
+  return (
+    <li className="flex min-w-[160px] flex-1 items-center gap-3 rounded-xl bg-white/95 px-3 py-2">
+      <span className="bg-brand-50 text-brand-700 inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-xl">
+        {icon}
+      </span>
+      <span className="flex min-w-0 flex-col">
+        <span className="text-ink-500 text-[10px] font-semibold tracking-[0.16em] uppercase">
+          {label}
+        </span>
+        <span className="text-ink-900 truncate text-sm font-semibold tabular-nums">{value}</span>
+      </span>
+    </li>
+  );
+}
 
 /**
- * Dashboard principal de AtlasHabita.
+ * Dashboard principal de AtlasHabita en modo Atelier.
  *
- * Compone Sidebar + Topbar + bloque hero + mapa + panel lateral derecho
- * (recomendación / tendencias / actividad) + acciones inferiores. El
- * layout sigue pixel-perfect la captura `atlashabita-main.png`:
+ * Refactorizado en M12 para que el mapa pase a ocupar el área principal
+ * en pantalla completa y los componentes panelados anteriores se
+ * conviertan en overlays:
  *
- *  - Hero verde con gradiente y la palabra "mejor lugar" resaltada.
- *  - Chips de filtros sobre el hero, variante `onBrand`.
- *  - Mapa estático (SVG) con marcadores burbuja verdes; bajo él, índice de
- *    oportunidad. La versión interactiva con maplibre se accede en `/mapa`.
- *  - Panel lateral con HighlightCard, TrendsChart y ActivityFeed reales
- *    tomando datos de `data/mock.ts`.
- *  - Cards de acción inferiores con iconografía y acentos distintos.
+ *  - Hero compacto con el titular + StatsStrip por encima del mapa.
+ *  - Mapa fullscreen (`SpainMap`) con `FloatingRanking`, `RichLegend` y
+ *    `MiniMap` solapados como overlays "quiet" (`z-overlay-quiet`).
+ *  - Tooltip rico (`MarkerRichTooltip`) y `TerritorySheet` como overlays
+ *    "rich" (`z-overlay-rich`).
+ *  - Cards de acción inferiores conservadas para mantener el flujo de
+ *    navegación principal.
  */
 export function DashboardShell() {
-  const [activeChips, setActiveChips] = useState<string[]>(['quality']);
   const activeLayerId = useMapLayerStore((state) => state.activeLayerId);
   const setActiveLayer = useMapLayerStore((state) => state.setActiveLayer);
   const activeLayer = useMemo(() => resolveLayer(activeLayerId), [activeLayerId]);
   const enrichedPoints = useMemo(() => toEnrichedMapPoints(), []);
 
-  const hero = useMemo(
-    () => (
-      <section aria-labelledby="dashboard-title" className="flex flex-col gap-5">
-        {/*
-         * Banner verde del comp: gradiente diagonal con la palabra "mejor
-         * lugar" en blanco brillante. Las dos burbujas blancas suavizadas
-         * imitan el "glow" de la captura.
-         */}
-        <div className="from-brand-500 via-brand-500 to-brand-600 relative overflow-hidden rounded-3xl bg-gradient-to-br p-7 text-white shadow-[var(--shadow-elevated)] sm:p-8">
-          <div
-            aria-hidden="true"
-            className="pointer-events-none absolute -top-24 -right-24 h-64 w-64 rounded-full bg-white/25 blur-3xl"
-          />
-          <div
-            aria-hidden="true"
-            className="pointer-events-none absolute -bottom-32 -left-10 h-80 w-80 rounded-full bg-emerald-300/30 blur-3xl"
-          />
-          <div className="relative flex flex-col gap-5">
-            <div className="flex flex-col gap-2.5">
-              <h1
-                id="dashboard-title"
-                className="font-display max-w-3xl text-[28px] leading-[1.15] font-bold sm:text-[34px]"
-              >
-                Descubre el{' '}
-                <span className="rounded-md bg-white/15 px-1.5 py-0.5 text-white">mejor lugar</span>{' '}
-                para vivir en España
-              </h1>
-              <p className="max-w-xl text-[14px] leading-relaxed text-white/85">
-                Explora, compara y encuentra tu lugar ideal con datos abiertos y tecnología
-                semántica.
-              </p>
-            </div>
-            <ChipFilters
-              options={CHIP_OPTIONS}
-              value={activeChips}
-              tone="onBrand"
-              onToggle={(id) =>
-                setActiveChips((prev) =>
-                  prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]
-                )
-              }
-            />
-          </div>
-        </div>
+  const selectedTerritoryId = useUiStore((state) => state.selectedTerritoryId);
+  const openTerritorySheet = useUiStore((state) => state.openTerritorySheet);
+  const closeTerritorySheet = useUiStore((state) => state.closeTerritorySheet);
 
-        {/*
-         * Mini LayerSwitcher en formato chip-row para alternar la métrica
-         * que colorea el mapa sin abandonar la home. La fila es scrollable
-         * en horizontal en pantallas estrechas y comparte el mismo store
-         * que `/mapa`, por lo que la elección persiste entre rutas.
-         */}
-        <div
-          role="radiogroup"
-          aria-label="Capa activa del mapa territorial"
-          data-feature="dashboard-layer-switcher"
-          className="-mx-1 flex gap-2 overflow-x-auto px-1 pb-1"
-        >
-          {MAP_LAYER_CATALOG.map((layer) => {
-            const isActive = layer.id === activeLayer.id;
-            return (
-              <button
-                key={layer.id}
-                type="button"
-                role="radio"
-                aria-checked={isActive}
-                onClick={() => setActiveLayer(layer.id)}
-                data-active={isActive ? 'true' : 'false'}
-                className={
-                  isActive
-                    ? 'border-brand-300 bg-brand-50 text-ink-900 inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-xs font-semibold shadow-sm transition-colors'
-                    : 'text-ink-500 hover:border-brand-200 hover:bg-brand-50/40 inline-flex items-center gap-2 rounded-full border border-[color:var(--color-line-soft)] bg-white px-3 py-1.5 text-xs font-semibold transition-colors'
-                }
-              >
-                <span
-                  aria-hidden="true"
-                  className="block h-2 w-2 rounded-full"
-                  style={{ backgroundColor: layer.palette[0] }}
-                />
-                {layer.label}
-              </button>
-            );
-          })}
-        </div>
-
-        {/*
-         * Mapa interactivo MapLibre con tiles reales (OpenFreeMap Liberty).
-         * En entornos jsdom (vitest) `vitest.setup.ts` mockea `maplibre-gl`
-         * para evitar `URL.createObjectURL`, lo cual deja el árbol DOM
-         * estable durante los tests.
-         */}
-        <div className="relative h-[400px] overflow-hidden rounded-3xl bg-white shadow-[var(--shadow-card)] ring-1 ring-[color:var(--color-line-soft)]">
-          <SpainMap
-            points={enrichedPoints}
-            ariaLabel="Mapa territorial de España con municipios destacados"
-            className="h-full"
-            layerId={activeLayer.id}
-          />
-        </div>
-
-        <OpportunityIndex
-          value={74}
-          description="Resumen agregado de los territorios filtrados con tu selección actual."
-        />
-      </section>
-    ),
-    [activeChips, activeLayer.id, enrichedPoints, setActiveLayer]
+  const domain = useMemo(
+    () => computeLayerDomain(enrichedPoints, activeLayer),
+    [enrichedPoints, activeLayer]
   );
 
-  /*
-   * Panel lateral derecho: tres cards apiladas que reproducen exactamente
-   * el orden de la captura — Recomendación destacada (con foto), Tendencias
-   * (sparkline verde) y Actividad reciente (timeline con iconos circulares).
-   */
-  const side = (
-    <>
-      <HighlightCard highlight={mockHighlight} />
-      <TrendsChart
-        data={mockTrends}
-        title="Tendencias"
-        subtitle="Score medio de los últimos 12 meses."
+  const legendStops = useMemo(() => buildLegendStops(activeLayer, domain), [activeLayer, domain]);
+
+  const { avgScore, highlight } = useMemo(() => {
+    if (enrichedPoints.length === 0) {
+      return { avgScore: 0, highlight: { name: 'Sin datos', score: 0 } };
+    }
+    const total = enrichedPoints.reduce((acc, point) => acc + point.score, 0);
+    const top = enrichedPoints.reduce((acc, point) => (point.score > acc.score ? point : acc));
+    return {
+      avgScore: total / enrichedPoints.length,
+      highlight: { name: top.name, score: top.score },
+    };
+  }, [enrichedPoints]);
+
+  const handleMarkerSelect = useCallback(
+    (id: string) => openTerritorySheet(id),
+    [openTerritorySheet]
+  );
+
+  const handleLayerChange = useCallback(
+    (next: MapLayerId) => {
+      setActiveLayer(next);
+    },
+    [setActiveLayer]
+  );
+
+  const hero = (
+    <section aria-labelledby="dashboard-title" className="flex flex-col gap-4">
+      <div className="from-brand-500 via-brand-500 to-brand-600 relative overflow-hidden rounded-3xl bg-gradient-to-br p-6 text-white shadow-[var(--shadow-elevated)] sm:p-7">
+        <div
+          aria-hidden="true"
+          className="pointer-events-none absolute -top-20 -right-20 h-56 w-56 rounded-full bg-white/25 blur-3xl"
+        />
+        <div className="relative flex flex-col gap-2">
+          <h1
+            id="dashboard-title"
+            className="font-display max-w-3xl text-[24px] leading-[1.15] font-bold sm:text-[28px]"
+          >
+            Descubre el{' '}
+            <span className="rounded-md bg-white/15 px-1.5 py-0.5 text-white">mejor lugar</span>{' '}
+            para vivir en España
+          </h1>
+          <p className="max-w-xl text-[13px] leading-relaxed text-white/85">
+            Pinchar en el mapa para abrir la ficha del municipio. Pulsa{' '}
+            <kbd className="font-mono">[</kbd> o <kbd className="font-mono">]</kbd> para cambiar de
+            capa.
+          </p>
+        </div>
+      </div>
+
+      <StatsStrip
+        territoriesCount={enrichedPoints.length}
+        avgScore={avgScore}
+        highlightedName={highlight.name}
+        highlightedScore={highlight.score}
       />
-      <ActivityFeed items={mockActivity.slice(0, 3)} title="Actividad reciente" />
-    </>
+
+      <div
+        role="radiogroup"
+        aria-label="Capa activa del mapa territorial"
+        data-feature="dashboard-layer-switcher"
+        className="-mx-1 flex gap-2 overflow-x-auto px-1 pb-1"
+      >
+        {MAP_LAYER_CATALOG.map((layer) => {
+          const isActive = layer.id === activeLayer.id;
+          return (
+            <button
+              key={layer.id}
+              type="button"
+              role="radio"
+              aria-checked={isActive}
+              onClick={() => setActiveLayer(layer.id)}
+              data-active={isActive ? 'true' : 'false'}
+              className={
+                isActive
+                  ? 'border-brand-300 bg-brand-50 text-ink-900 inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-xs font-semibold shadow-sm transition-colors'
+                  : 'text-ink-500 hover:border-brand-200 hover:bg-brand-50/40 inline-flex items-center gap-2 rounded-full border border-[color:var(--color-line-soft)] bg-white px-3 py-1.5 text-xs font-semibold transition-colors'
+              }
+            >
+              <span
+                aria-hidden="true"
+                className="block h-2 w-2 rounded-full"
+                style={{ backgroundColor: layer.palette[0] }}
+              />
+              {layer.label}
+            </button>
+          );
+        })}
+      </div>
+
+      {/*
+       * Mapa Atelier: ocupa todo el ancho y tiene los overlays
+       * (FloatingRanking, RichLegend, MiniMap) solapados sobre él.
+       * `SpainMap` recibe `enrichedTooltip` para que los hovers usen
+       * el `MarkerRichTooltip` con sparkline y CTA.
+       */}
+      <div
+        data-feature="atelier-map-stage"
+        className="relative h-[min(70vh,720px)] min-h-[420px] overflow-hidden rounded-3xl bg-white shadow-[var(--shadow-card)] ring-1 ring-[color:var(--color-line-soft)]"
+      >
+        <SpainMap
+          points={enrichedPoints}
+          ariaLabel="Mapa territorial de España con municipios destacados"
+          className="h-full"
+          layerId={activeLayer.id}
+          enrichedTooltip
+          hideLegend
+          onMarkerSelect={handleMarkerSelect}
+        />
+
+        <FloatingRanking />
+
+        <RichLegend
+          layer={activeLayer}
+          stops={legendStops}
+          domain={domain}
+          onLayerChange={handleLayerChange}
+        />
+
+        <MiniMap />
+      </div>
+    </section>
   );
 
   return (
-    <DashboardLayout
-      embedded
-      hero={hero}
-      side={side}
-      footer={<ActionCards items={ACTION_ITEMS} />}
-    />
+    <>
+      <DashboardLayout embedded hero={hero} footer={<ActionCards items={ACTION_ITEMS} />} />
+      <TerritorySheet territoryId={selectedTerritoryId} onClose={closeTerritorySheet} />
+    </>
   );
 }

--- a/apps/web/src/features/dashboard/__tests__/DashboardShell.test.tsx
+++ b/apps/web/src/features/dashboard/__tests__/DashboardShell.test.tsx
@@ -1,10 +1,12 @@
-import { render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import { MemoryRouter } from 'react-router-dom';
 import type { ReactNode } from 'react';
 import { DashboardShell } from '../DashboardShell';
 import { useMapLayerStore } from '@/state/mapLayer';
+import { useUiStore } from '@/state/ui';
+import { NATIONAL_MUNICIPALITIES } from '@/data/national_mock';
 
 const wrap = (node: ReactNode) => <MemoryRouter>{node}</MemoryRouter>;
 
@@ -66,6 +68,7 @@ beforeAll(() => {
 describe('DashboardShell', () => {
   beforeEach(() => {
     useMapLayerStore.getState().resetActiveLayer();
+    useUiStore.getState().reset();
     /* eslint-disable-next-line no-undef -- localStorage es global del navegador. */
     localStorage.clear();
   });
@@ -92,5 +95,30 @@ describe('DashboardShell', () => {
     await user.click(broadband);
     expect(useMapLayerStore.getState().activeLayerId).toBe('broadband');
     expect(broadband).toHaveAttribute('aria-checked', 'true');
+  });
+
+  it('monta los overlays Atelier (FloatingRanking, RichLegend, MiniMap)', () => {
+    render(wrap(<DashboardShell />));
+    expect(screen.getByLabelText(/ranking de municipios/i)).toBeInTheDocument();
+    expect(screen.getByTestId('rich-legend')).toBeInTheDocument();
+    expect(screen.getByTestId('mini-map')).toBeInTheDocument();
+  });
+
+  it('abre la TerritorySheet cuando el store recibe un selectedTerritoryId', () => {
+    const target = NATIONAL_MUNICIPALITIES[0];
+    render(wrap(<DashboardShell />));
+    expect(screen.queryByTestId('territory-sheet')).toBeNull();
+    act(() => {
+      useUiStore.getState().openTerritorySheet(target.id);
+    });
+    expect(screen.getByTestId('territory-sheet')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent(target.name);
+  });
+
+  it('atajo `]` rota la capa activa del mapa a través de RichLegend', () => {
+    render(wrap(<DashboardShell />));
+    expect(useMapLayerStore.getState().activeLayerId).toBe('score');
+    fireEvent.keyDown(window, { key: ']' });
+    expect(useMapLayerStore.getState().activeLayerId).not.toBe('score');
   });
 });

--- a/apps/web/src/features/map/SpainMap.tsx
+++ b/apps/web/src/features/map/SpainMap.tsx
@@ -13,6 +13,7 @@ import { useGSAP } from '@gsap/react';
 import { prefersReducedMotion, resolveDuration } from '@/animations';
 import { MapLegend } from './MapLegend';
 import { MapTooltip, type MapTooltipIndicator } from './MapTooltip';
+import { MarkerRichTooltip } from '@/features/overlays/MarkerRichTooltip';
 import {
   buildLegendStops,
   computeLayerDomain,
@@ -95,6 +96,23 @@ export interface SpainMapProps {
    * y en entornos sin acceso a OpenFreeMap.
    */
   readonly offline?: boolean;
+  /**
+   * Cuando `true`, el mapa usa el tooltip rico del Atelier
+   * (`MarkerRichTooltip`) en lugar del clásico `MapTooltip`. El tooltip
+   * rico incluye sparkline 12 meses, top-3 indicadores y CTA "Ver ficha".
+   */
+  readonly enrichedTooltip?: boolean;
+  /**
+   * Oculta la leyenda integrada (`MapLegend`). Útil cuando otra superficie
+   * (p. ej. `RichLegend` del Atelier) ya dibuja una leyenda flotante.
+   */
+  readonly hideLegend?: boolean;
+  /**
+   * Callback emitido cuando el usuario activa un marcador (clic en el
+   * marcador o en el CTA del tooltip rico). Habilita la apertura de la
+   * ficha territorial en `TerritorySheet`.
+   */
+  readonly onMarkerSelect?: (id: string) => void;
 }
 
 interface MarkerPresentation {
@@ -144,6 +162,9 @@ export function SpainMap({
   layerLabel,
   unit,
   offline = false,
+  enrichedTooltip = false,
+  hideLegend = false,
+  onMarkerSelect,
 }: SpainMapProps) {
   const [hovered, setHovered] = useState<HoveredState | null>(null);
   const containerRef = useRef<HTMLElement | null>(null);
@@ -332,6 +353,11 @@ export function SpainMap({
               onPointerEnter={handleEnter(marker)}
               onPointerMove={handleMove}
               onPointerLeave={handleLeave}
+              onClick={() => {
+                if (onMarkerSelect) {
+                  onMarkerSelect(marker.id);
+                }
+              }}
               onFocus={(event) => {
                 const container = event.currentTarget.closest(
                   '[data-spain-map]'
@@ -363,28 +389,54 @@ export function SpainMap({
       </Map>
 
       {hovered ? (
-        <MapTooltip
-          name={hovered.marker.name}
-          value={hovered.marker.value}
-          score={hovered.marker.score}
-          x={hovered.x}
-          y={hovered.y}
-          unit={resolvedUnit}
-          layerLabel={resolvedLabel}
-          activeIndicatorId={activeLayer.id === 'score' ? undefined : activeLayer.id}
-          indicators={hovered.marker.indicators}
-          province={hovered.marker.province}
-        />
+        enrichedTooltip ? (
+          <MarkerRichTooltip
+            marker={{
+              id: hovered.marker.id,
+              name: hovered.marker.name,
+              score: hovered.marker.score,
+              value: hovered.marker.value,
+              province: hovered.marker.province,
+              indicators: hovered.marker.indicators?.map((indicator) => ({
+                id: indicator.id,
+                label: indicator.label,
+                value: indicator.value,
+                unit: indicator.unit,
+              })),
+            }}
+            x={hovered.x}
+            y={hovered.y}
+            layerLabel={resolvedLabel}
+            unit={resolvedUnit}
+            activeIndicatorId={activeLayer.id === 'score' ? undefined : activeLayer.id}
+            onOpenSheet={onMarkerSelect}
+          />
+        ) : (
+          <MapTooltip
+            name={hovered.marker.name}
+            value={hovered.marker.value}
+            score={hovered.marker.score}
+            x={hovered.x}
+            y={hovered.y}
+            unit={resolvedUnit}
+            layerLabel={resolvedLabel}
+            activeIndicatorId={activeLayer.id === 'score' ? undefined : activeLayer.id}
+            indicators={hovered.marker.indicators}
+            province={hovered.marker.province}
+          />
+        )
       ) : null}
 
-      <MapLegend
-        label={resolvedLabel}
-        stops={legendStops}
-        unit={resolvedUnit}
-        domain={domain}
-        description={layerId ? activeLayer.description : undefined}
-        className="absolute bottom-4 left-4"
-      />
+      {hideLegend ? null : (
+        <MapLegend
+          label={resolvedLabel}
+          stops={legendStops}
+          unit={resolvedUnit}
+          domain={domain}
+          description={layerId ? activeLayer.description : undefined}
+          className="absolute bottom-4 left-4"
+        />
+      )}
     </section>
   );
 }

--- a/apps/web/src/features/overlays/FloatingRanking.tsx
+++ b/apps/web/src/features/overlays/FloatingRanking.tsx
@@ -1,0 +1,189 @@
+/* eslint-disable no-undef -- React (CSS) y Node son globales DOM. */
+/**
+ * FloatingRanking — overlay flotante con el ranking sobre el mapa.
+ *
+ * Encapsula el `RankingPanel` existente en una "card glass" anclada al
+ * borde izquierdo del mapa. El comportamiento sigue el spec del Atelier
+ * (M12 · issue #118):
+ *
+ *  - Tamaño objetivo 380×min(70vh, 720px) cuando está expandido.
+ *  - Pinable: el usuario puede anclarlo (`isRankingPinned`) para evitar
+ *    el autocollapse a la barra de 56 px tras 6 s sin foco.
+ *  - Autocollapse cuando deja de tener foco/hover y el usuario no lo
+ *    ha pinchado (cumple el patrón "discreto pero accesible" del Atelier).
+ *  - Glassmorphism con backdrop-blur y borde tenue, alineado con la
+ *    pixel-grid de tokens.
+ *
+ * SOLID:
+ *  - SRP: el componente sólo orquesta visibilidad/pin/foco. La lógica de
+ *    ranking sigue en `RankingPanel`.
+ *  - Open/Closed: acepta `children` opcionales para sustituir el panel
+ *    por una vista alternativa en tests/storybook sin tocar el wrapper.
+ *  - Dependency inversion: el estado de `pin` se delega en `useUiStore`
+ *    para que cualquier consumidor pueda controlarlo (atajos, command
+ *    palette, tests) sin acoplarse al árbol React.
+ */
+
+import { Pin, PinOff } from 'lucide-react';
+import { useCallback, useEffect, useId, useMemo, useRef, useState, type ReactNode } from 'react';
+import { cn } from '@/components/ui/cn';
+import { RankingPanel } from '@/features/ranking';
+import { useUiStore } from '@/state/ui';
+
+/** Milisegundos sin foco antes de autocollapsar el panel. */
+const AUTO_COLLAPSE_DELAY_MS = 6_000;
+
+export interface FloatingRankingProps {
+  /** Permite inyectar contenido alternativo (tests/storybook). */
+  readonly children?: ReactNode;
+  /** Etiqueta accesible del wrapper. */
+  readonly ariaLabel?: string;
+  /** Sobreescribe el estado de auto-colapso (tests). */
+  readonly forcedExpanded?: boolean;
+  readonly className?: string;
+}
+
+export function FloatingRanking({
+  children,
+  ariaLabel = 'Ranking de municipios',
+  forcedExpanded,
+  className,
+}: FloatingRankingProps) {
+  const isPinned = useUiStore((state) => state.isRankingPinned);
+  const togglePinned = useUiStore((state) => state.toggleRankingPinned);
+
+  // Estado local de expansión: true = tarjeta plena, false = barra colapsada.
+  const [expanded, setExpanded] = useState(true);
+  const titleId = useId();
+  const containerRef = useRef<HTMLElement | null>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const effectiveExpanded = forcedExpanded ?? expanded;
+
+  /*
+   * Programa el auto-colapso: si el panel no está pinchado y el usuario
+   * no lo está enfocando ni lo cubre con el ratón, plegamos la tarjeta
+   * tras `AUTO_COLLAPSE_DELAY_MS` para devolver el foco visual al mapa.
+   */
+  const scheduleCollapse = useCallback(() => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+    if (isPinned) return;
+    timerRef.current = setTimeout(() => {
+      setExpanded(false);
+      timerRef.current = null;
+    }, AUTO_COLLAPSE_DELAY_MS);
+  }, [isPinned]);
+
+  const cancelCollapse = useCallback(() => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  // Si pasa a estar pinchado, lo abrimos automáticamente y cancelamos
+  // cualquier temporizador en vuelo.
+  useEffect(() => {
+    if (isPinned) {
+      setExpanded(true);
+      cancelCollapse();
+      return;
+    }
+    scheduleCollapse();
+    return cancelCollapse;
+  }, [isPinned, scheduleCollapse, cancelCollapse]);
+
+  const handleEnter = useCallback(() => {
+    cancelCollapse();
+    setExpanded(true);
+  }, [cancelCollapse]);
+
+  const handleLeave = useCallback(() => {
+    if (isPinned) return;
+    scheduleCollapse();
+  }, [isPinned, scheduleCollapse]);
+
+  const wrapperStyle = useMemo<React.CSSProperties>(
+    () => ({ zIndex: 'var(--z-overlay-quiet)' as unknown as number }),
+    []
+  );
+
+  return (
+    <aside
+      ref={(node) => {
+        containerRef.current = node;
+      }}
+      aria-label={ariaLabel}
+      data-feature="floating-ranking"
+      data-state={effectiveExpanded ? 'expanded' : 'collapsed'}
+      data-pinned={isPinned ? 'true' : 'false'}
+      style={wrapperStyle}
+      className={cn(
+        'pointer-events-auto absolute top-4 left-4 flex flex-col overflow-hidden rounded-2xl',
+        'border border-white/40 bg-white/80 shadow-[var(--shadow-elevated)] backdrop-blur',
+        'transition-[width,height] duration-300 ease-[cubic-bezier(0.32,0.72,0,1)]',
+        effectiveExpanded
+          ? 'h-[min(70vh,720px)] w-[380px]'
+          : 'h-14 w-[380px] hover:h-14 hover:w-[380px]',
+        className
+      )}
+      onMouseEnter={handleEnter}
+      onMouseLeave={handleLeave}
+      onFocusCapture={handleEnter}
+      onBlurCapture={(event) => {
+        // Sólo recolapsamos si el foco abandona por completo el panel.
+        if (containerRef.current && !containerRef.current.contains(event.relatedTarget as Node)) {
+          handleLeave();
+        }
+      }}
+    >
+      <header className="flex shrink-0 items-center justify-between gap-3 border-b border-white/40 px-4 py-2">
+        <div className="flex min-w-0 flex-col">
+          <span
+            id={titleId}
+            className="text-ink-700 text-[11px] font-semibold tracking-[0.16em] uppercase"
+          >
+            Ranking nacional
+          </span>
+          <span className="text-ink-500 truncate text-[11px]">
+            Pinchar en el mapa para abrir la ficha del municipio.
+          </span>
+        </div>
+        <button
+          type="button"
+          onClick={togglePinned}
+          aria-pressed={isPinned}
+          aria-label={isPinned ? 'Desanclar ranking' : 'Anclar ranking'}
+          data-testid="floating-ranking-pin"
+          className={cn(
+            'inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full transition-colors',
+            'focus-visible:ring-brand-300 focus-visible:ring-2 focus-visible:outline-none',
+            isPinned
+              ? 'bg-brand-500 text-white shadow-sm'
+              : 'text-ink-500 hover:bg-brand-50 hover:text-brand-700 bg-white/70'
+          )}
+        >
+          {isPinned ? (
+            <PinOff size={14} aria-hidden="true" />
+          ) : (
+            <Pin size={14} aria-hidden="true" />
+          )}
+        </button>
+      </header>
+
+      <div
+        className={cn(
+          'min-h-0 flex-1 overflow-y-auto px-3 pt-3 pb-4',
+          // Cuando colapsa, ocultamos el cuerpo para reducir la huella visual.
+          effectiveExpanded ? 'opacity-100' : 'pointer-events-none h-0 opacity-0'
+        )}
+        aria-hidden={!effectiveExpanded}
+      >
+        {children ?? <RankingPanel className="border-none bg-transparent shadow-none" />}
+      </div>
+    </aside>
+  );
+}

--- a/apps/web/src/features/overlays/MarkerRichTooltip.tsx
+++ b/apps/web/src/features/overlays/MarkerRichTooltip.tsx
@@ -1,0 +1,251 @@
+/**
+ * MarkerRichTooltip — tooltip enriquecido para marcadores del Atelier.
+ *
+ * Sustituye al tooltip clásico (`MapTooltip`) cuando se quiere mostrar el
+ * detalle al pasar sobre un marcador en modo Atelier. Aporta:
+ *
+ *  - Sparkline 12 meses (SVG inline) generada a partir de un seed
+ *    determinista basado en el id del municipio para que la UI sea
+ *    estable entre renders.
+ *  - Top-3 indicadores con destacado visual del activo.
+ *  - CTA "Ver ficha" que invoca el callback `onOpenSheet`.
+ *
+ * El componente es controlado por sus props (`x`, `y`, `marker`); no
+ * gestiona montaje/desmontaje. Se posiciona en `position: absolute`
+ * sobre el contenedor del mapa.
+ */
+
+import { useMemo } from 'react';
+import { ArrowUpRight } from 'lucide-react';
+import { cn } from '@/components/ui/cn';
+
+export interface MarkerRichTooltipIndicator {
+  readonly id: string;
+  readonly label: string;
+  readonly value: number;
+  readonly unit: string;
+}
+
+export interface MarkerRichTooltipMarker {
+  readonly id: string;
+  readonly name: string;
+  readonly score: number;
+  readonly value: number;
+  readonly province?: string;
+  readonly indicators?: readonly MarkerRichTooltipIndicator[];
+}
+
+export interface MarkerRichTooltipProps {
+  /** Datos del marcador resaltado. */
+  readonly marker: MarkerRichTooltipMarker;
+  /** Coordenada X dentro del contenedor. */
+  readonly x: number;
+  /** Coordenada Y dentro del contenedor. */
+  readonly y: number;
+  /** Etiqueta de la capa activa. */
+  readonly layerLabel: string;
+  /** Sufijo de unidad de la capa activa. */
+  readonly unit: string;
+  /** ID del indicador asociado a la capa activa (resalta el item top-3). */
+  readonly activeIndicatorId?: string;
+  /** Callback al pulsar "Ver ficha". */
+  readonly onOpenSheet?: (id: string) => void;
+}
+
+const SPARKLINE_WIDTH = 160;
+const SPARKLINE_HEIGHT = 36;
+const SPARKLINE_MONTHS = 12;
+
+/**
+ * Generador determinista basado en una string. Devuelve siempre la misma
+ * secuencia de valores para el mismo `id`, lo que garantiza un render
+ * estable y testeable de la sparkline.
+ */
+function buildSparkline(seed: string, baseline: number): readonly number[] {
+  let hash = 0;
+  for (let i = 0; i < seed.length; i += 1) {
+    hash = (hash * 31 + seed.charCodeAt(i)) >>> 0;
+  }
+  const values: number[] = [];
+  for (let i = 0; i < SPARKLINE_MONTHS; i += 1) {
+    hash = (hash * 1664525 + 1013904223) >>> 0;
+    // Normaliza a [-1, 1] y aplica una amplitud relativa al baseline.
+    const noise = ((hash & 0xffff) / 0xffff) * 2 - 1;
+    const oscillation = Math.sin((i / SPARKLINE_MONTHS) * Math.PI * 2);
+    const amplitude = Math.max(2, Math.abs(baseline) * 0.05);
+    values.push(baseline + (oscillation * 0.6 + noise * 0.4) * amplitude);
+  }
+  return values;
+}
+
+function buildPath(values: readonly number[]): string {
+  if (values.length === 0) return '';
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const span = max - min || 1;
+  const step = SPARKLINE_WIDTH / (values.length - 1 || 1);
+  return values
+    .map((value, index) => {
+      const x = index * step;
+      const y = SPARKLINE_HEIGHT - ((value - min) / span) * SPARKLINE_HEIGHT;
+      return `${index === 0 ? 'M' : 'L'}${x.toFixed(2)},${y.toFixed(2)}`;
+    })
+    .join(' ');
+}
+
+function formatValue(value: number, unit: string): string {
+  const trimmed = unit.trim();
+  const formatted = Number.isInteger(value)
+    ? value.toLocaleString('es-ES')
+    : value.toLocaleString('es-ES', { maximumFractionDigits: 2 });
+  if (!trimmed) return formatted;
+  if (/^[€%°]/.test(trimmed)) return `${formatted}${trimmed}`;
+  return `${formatted} ${trimmed}`;
+}
+
+function pickTop(
+  indicators: readonly MarkerRichTooltipIndicator[] | undefined,
+  activeId: string | undefined
+) {
+  if (!indicators || indicators.length === 0) return [];
+  const active = activeId ? indicators.find((entry) => entry.id === activeId) : undefined;
+  const rest = indicators.filter((entry) => entry.id !== active?.id);
+  // Ordenamos el resto por valor descendente (siempre sobre el mismo id, sin
+  // romper si los datasets crecen) y tomamos los dos mejores.
+  const sortedRest = [...rest].sort((a, b) => b.value - a.value).slice(0, active ? 2 : 3);
+  return [...(active ? [active] : []), ...sortedRest].slice(0, 3);
+}
+
+export function MarkerRichTooltip({
+  marker,
+  x,
+  y,
+  layerLabel,
+  unit,
+  activeIndicatorId,
+  onOpenSheet,
+}: MarkerRichTooltipProps) {
+  const sparklineValues = useMemo(
+    () => buildSparkline(marker.id, marker.score),
+    [marker.id, marker.score]
+  );
+  const sparklinePath = useMemo(() => buildPath(sparklineValues), [sparklineValues]);
+  const topIndicators = useMemo(
+    () => pickTop(marker.indicators, activeIndicatorId),
+    [marker.indicators, activeIndicatorId]
+  );
+
+  return (
+    <div
+      role="tooltip"
+      data-testid="marker-rich-tooltip"
+      data-feature="marker-rich-tooltip"
+      className={cn(
+        'pointer-events-auto absolute min-w-[260px] -translate-x-1/2 -translate-y-full overflow-hidden rounded-2xl',
+        'border border-white/15 bg-[var(--color-ink-900)]/95 text-white shadow-[var(--shadow-elevated)] backdrop-blur'
+      )}
+      style={{ left: x, top: y - 14, zIndex: 'var(--z-overlay-rich)' as unknown as number }}
+    >
+      <div className="flex items-start justify-between gap-3 px-3 pt-3">
+        <div className="min-w-0">
+          <p className="text-[10px] font-semibold tracking-[0.16em] text-[var(--color-brand-200)] uppercase">
+            Territorio
+          </p>
+          <p className="mt-0.5 truncate text-sm leading-tight font-semibold">{marker.name}</p>
+          {marker.province ? (
+            <p className="truncate text-[11px] leading-tight text-white/60">{marker.province}</p>
+          ) : null}
+        </div>
+        <div className="text-right">
+          <p className="text-[10px] tracking-wide text-white/50 uppercase">Score</p>
+          <p
+            className="text-2xl leading-none font-bold tabular-nums"
+            data-testid="marker-rich-tooltip-score"
+          >
+            {marker.score}
+          </p>
+        </div>
+      </div>
+
+      <div className="mt-3 px-3">
+        <p className="text-[10px] font-semibold tracking-[0.16em] text-white/40 uppercase">
+          {layerLabel} · 12 meses
+        </p>
+        <svg
+          aria-hidden="true"
+          viewBox={`0 0 ${SPARKLINE_WIDTH} ${SPARKLINE_HEIGHT}`}
+          width="100%"
+          height={SPARKLINE_HEIGHT}
+          className="mt-1 block"
+          data-testid="marker-rich-tooltip-sparkline"
+        >
+          <defs>
+            <linearGradient id={`sparkline-fill-${marker.id}`} x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0%" stopColor="var(--color-brand-300)" stopOpacity={0.55} />
+              <stop offset="100%" stopColor="var(--color-brand-300)" stopOpacity={0} />
+            </linearGradient>
+          </defs>
+          <path
+            d={`${sparklinePath} L${SPARKLINE_WIDTH},${SPARKLINE_HEIGHT} L0,${SPARKLINE_HEIGHT} Z`}
+            fill={`url(#sparkline-fill-${marker.id})`}
+          />
+          <path
+            d={sparklinePath}
+            fill="none"
+            stroke="var(--color-brand-200)"
+            strokeWidth={1.5}
+            strokeLinejoin="round"
+            strokeLinecap="round"
+          />
+        </svg>
+        <p className="text-right text-[10px] text-white/60 tabular-nums">
+          Valor actual: {formatValue(marker.value, unit)}
+        </p>
+      </div>
+
+      {topIndicators.length > 0 ? (
+        <ul
+          data-testid="marker-rich-tooltip-top"
+          className="mt-3 grid grid-cols-1 gap-1 px-3 text-[11px]"
+        >
+          {topIndicators.map((indicator) => {
+            const isActive = indicator.id === activeIndicatorId;
+            return (
+              <li
+                key={indicator.id}
+                data-active={isActive ? 'true' : 'false'}
+                className={cn(
+                  'flex items-baseline justify-between gap-3 rounded-md px-2 py-1',
+                  isActive ? 'bg-white/15 font-semibold text-white' : 'text-white/75'
+                )}
+              >
+                <span className="truncate">{indicator.label}</span>
+                <span className="shrink-0 tabular-nums">
+                  {formatValue(indicator.value, indicator.unit)}
+                </span>
+              </li>
+            );
+          })}
+        </ul>
+      ) : null}
+
+      <div className="mt-3 flex items-center justify-between gap-2 border-t border-white/10 bg-white/5 px-3 py-2">
+        <span className="text-[10px] text-white/55">
+          Pinchar en el mapa para abrir la ficha del municipio.
+        </span>
+        <button
+          type="button"
+          onClick={() => onOpenSheet?.(marker.id)}
+          data-testid="marker-rich-tooltip-cta"
+          className={cn(
+            'bg-brand-500 hover:bg-brand-600 inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 text-[11px] font-semibold text-white transition-colors',
+            'focus-visible:ring-brand-300 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-ink-900)] focus-visible:outline-none'
+          )}
+        >
+          Ver ficha
+          <ArrowUpRight size={12} aria-hidden="true" />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/overlays/MiniMap.tsx
+++ b/apps/web/src/features/overlays/MiniMap.tsx
@@ -1,0 +1,213 @@
+/**
+ * MiniMap — vista miniatura de España con recuadro del viewport actual.
+ *
+ * Componente decorativo y de navegación contextual, situado en la esquina
+ * inferior derecha del Atelier. Muestra las dimensiones de España y un
+ * recuadro proporcional al `viewport` que el usuario está viendo en el
+ * mapa principal. Cuando el viewport no se conoce (estado inicial o tests
+ * con jsdom), el recuadro cubre el bounding-box completo, indicando "vista
+ * país".
+ *
+ * Decisiones de diseño:
+ *  - Implementado en SVG para evitar arrastrar otra instancia de MapLibre
+ *    (con su contexto WebGL y `URL.createObjectURL`) cuya complejidad sería
+ *    excesiva para este uso decorativo. SVG ofrece render predecible en
+ *    jsdom y soporta WebKit/Firefox/Edge sin polyfills.
+ *  - Sin controles de zoom/desplazamiento (regla del spec).
+ *  - Acepta un viewport opcional para cuando se ajuste al estado real del
+ *    mapa principal (issue futura). De momento se renderiza una vista
+ *    nacional fija, suficiente para el flujo definido en M12.
+ *
+ * Accesibilidad:
+ *  - `role="img"` y `aria-label` describen el propósito del minimap. El
+ *    contenido SVG queda marcado con `aria-hidden` para que el lector de
+ *    pantalla no anuncie path por path.
+ */
+
+import { useMemo } from 'react';
+import { cn } from '@/components/ui/cn';
+import { useUiStore } from '@/state/ui';
+
+/** Bounds aproximados de España peninsular + Baleares + Canarias. */
+const SPAIN_BOUNDS = {
+  minLon: -10,
+  maxLon: 4.5,
+  minLat: 35.5,
+  maxLat: 44,
+} as const;
+
+export interface MiniMapViewport {
+  readonly minLon: number;
+  readonly maxLon: number;
+  readonly minLat: number;
+  readonly maxLat: number;
+}
+
+export interface MiniMapProps {
+  /** Viewport actual del mapa principal en coordenadas WGS84. */
+  readonly viewport?: MiniMapViewport;
+  /** Mostrar/ocultar minimap (los tests pueden forzar `true`). */
+  readonly forcedVisible?: boolean;
+  readonly className?: string;
+  readonly ariaLabel?: string;
+}
+
+interface ProjectedRect {
+  readonly x: number;
+  readonly y: number;
+  readonly width: number;
+  readonly height: number;
+}
+
+const MINI_MAP_WIDTH = 200;
+const MINI_MAP_HEIGHT = 140;
+
+/**
+ * Proyecta un viewport (lon/lat) al rectángulo SVG del minimap. Es una
+ * proyección equirectangular sencilla, suficiente para la vista de España
+ * en formato 200×140 px sin distorsión perceptible.
+ */
+function projectViewport(viewport: MiniMapViewport): ProjectedRect {
+  const lonSpan = SPAIN_BOUNDS.maxLon - SPAIN_BOUNDS.minLon;
+  const latSpan = SPAIN_BOUNDS.maxLat - SPAIN_BOUNDS.minLat;
+
+  const clampedMinLon = Math.max(SPAIN_BOUNDS.minLon, viewport.minLon);
+  const clampedMaxLon = Math.min(SPAIN_BOUNDS.maxLon, viewport.maxLon);
+  const clampedMinLat = Math.max(SPAIN_BOUNDS.minLat, viewport.minLat);
+  const clampedMaxLat = Math.min(SPAIN_BOUNDS.maxLat, viewport.maxLat);
+
+  const x = ((clampedMinLon - SPAIN_BOUNDS.minLon) / lonSpan) * MINI_MAP_WIDTH;
+  const width = ((clampedMaxLon - clampedMinLon) / lonSpan) * MINI_MAP_WIDTH;
+  // Lat es invertida en SVG (eje Y crece hacia abajo).
+  const y = ((SPAIN_BOUNDS.maxLat - clampedMaxLat) / latSpan) * MINI_MAP_HEIGHT;
+  const height = ((clampedMaxLat - clampedMinLat) / latSpan) * MINI_MAP_HEIGHT;
+
+  return {
+    x: Number.isFinite(x) ? x : 0,
+    y: Number.isFinite(y) ? y : 0,
+    width: Math.max(8, Number.isFinite(width) ? width : MINI_MAP_WIDTH),
+    height: Math.max(8, Number.isFinite(height) ? height : MINI_MAP_HEIGHT),
+  };
+}
+
+const DEFAULT_VIEWPORT: MiniMapViewport = {
+  minLon: SPAIN_BOUNDS.minLon,
+  maxLon: SPAIN_BOUNDS.maxLon,
+  minLat: SPAIN_BOUNDS.minLat,
+  maxLat: SPAIN_BOUNDS.maxLat,
+};
+
+export function MiniMap({
+  viewport = DEFAULT_VIEWPORT,
+  forcedVisible,
+  className,
+  ariaLabel = 'Mini-mapa de España con recuadro del viewport actual',
+}: MiniMapProps) {
+  const isVisible = useUiStore((state) => state.miniMapOpen);
+  const toggleMiniMap = useUiStore((state) => state.toggleMiniMap);
+  const visible = forcedVisible ?? isVisible;
+
+  const rect = useMemo(() => projectViewport(viewport), [viewport]);
+
+  if (!visible) {
+    return (
+      <button
+        type="button"
+        onClick={toggleMiniMap}
+        data-feature="mini-map"
+        data-state="collapsed"
+        aria-label="Mostrar mini-mapa"
+        style={{ zIndex: 'var(--z-overlay-quiet)' as unknown as number }}
+        className={cn(
+          'pointer-events-auto absolute right-4 bottom-4 inline-flex h-8 items-center gap-2 rounded-full',
+          'border border-white/40 bg-white/85 px-3 text-[11px] font-semibold text-[var(--color-ink-700)] shadow-[var(--shadow-card)] backdrop-blur',
+          'focus-visible:ring-brand-300 hover:bg-white focus-visible:ring-2 focus-visible:outline-none',
+          className
+        )}
+      >
+        Mostrar mini-mapa
+      </button>
+    );
+  }
+
+  return (
+    <figure
+      data-feature="mini-map"
+      data-state="expanded"
+      data-testid="mini-map"
+      role="img"
+      aria-label={ariaLabel}
+      style={{ zIndex: 'var(--z-overlay-quiet)' as unknown as number }}
+      className={cn(
+        'pointer-events-auto absolute right-4 bottom-4 overflow-hidden rounded-2xl',
+        'border border-white/40 bg-white/85 p-2 shadow-[var(--shadow-card)] backdrop-blur',
+        className
+      )}
+    >
+      <svg
+        aria-hidden="true"
+        viewBox={`0 0 ${MINI_MAP_WIDTH} ${MINI_MAP_HEIGHT}`}
+        width={MINI_MAP_WIDTH}
+        height={MINI_MAP_HEIGHT}
+        className="block"
+      >
+        <defs>
+          <linearGradient id="mini-map-bg" x1="0" y1="0" x2="1" y2="1">
+            <stop offset="0%" stopColor="var(--color-brand-50)" />
+            <stop offset="100%" stopColor="var(--color-surface-muted)" />
+          </linearGradient>
+        </defs>
+        <rect
+          x={0}
+          y={0}
+          width={MINI_MAP_WIDTH}
+          height={MINI_MAP_HEIGHT}
+          fill="url(#mini-map-bg)"
+          rx={12}
+        />
+        {/*
+         * Silueta esquemática de España: péninsula + Baleares + Canarias.
+         * Coordenadas relativas al viewBox; pensadas para una representación
+         * reconocible sin necesidad de TopoJSON.
+         */}
+        <g
+          aria-hidden="true"
+          fill="var(--color-brand-200)"
+          stroke="var(--color-brand-600)"
+          strokeWidth={0.6}
+        >
+          <path d="M28 36 C 36 22, 60 18, 80 22 L 110 24 C 140 22, 160 30, 168 50 L 174 80 C 168 100, 140 112, 100 110 L 60 108 C 40 102, 24 84, 28 64 Z" />
+          <circle cx={172} cy={64} r={4} />
+          <circle cx={166} cy={70} r={3} />
+          <circle cx={26} cy={120} r={6} />
+          <circle cx={36} cy={124} r={3} />
+        </g>
+        {/* Recuadro del viewport actual. */}
+        <rect
+          data-testid="mini-map-viewport"
+          x={rect.x}
+          y={rect.y}
+          width={rect.width}
+          height={rect.height}
+          fill="var(--color-brand-500)"
+          fillOpacity={0.18}
+          stroke="var(--color-brand-700)"
+          strokeWidth={1.4}
+          rx={4}
+        />
+      </svg>
+      <figcaption className="text-ink-500 mt-1 flex items-center justify-between text-[10px] tracking-wide uppercase">
+        <span className="font-semibold">Vista España</span>
+        <button
+          type="button"
+          onClick={toggleMiniMap}
+          aria-label="Ocultar mini-mapa"
+          className="text-ink-500 hover:text-ink-900"
+          data-testid="mini-map-toggle"
+        >
+          Ocultar
+        </button>
+      </figcaption>
+    </figure>
+  );
+}

--- a/apps/web/src/features/overlays/RichLegend.tsx
+++ b/apps/web/src/features/overlays/RichLegend.tsx
@@ -1,0 +1,254 @@
+/* eslint-disable no-undef -- HTMLSpanElement, KeyboardEvent, HTMLInputElement y HTMLTextAreaElement son globales DOM. */
+/**
+ * RichLegend — leyenda flotante "pill" en el borde inferior del mapa.
+ *
+ * Sustituye visualmente a `MapLegend` cuando el mapa está en modo Atelier
+ * (fullscreen). Aporta sobre la leyenda clásica:
+ *
+ *  - Forma de pastilla con backdrop-blur, posicionada bajo-centro.
+ *  - Dominio numérico animado: el texto del rango se interpola entre el
+ *    valor anterior y el nuevo cuando cambia la capa.
+ *  - Atajos `[` y `]` para retroceder/avanzar de capa.
+ *  - Botón de visibilidad coordinado con `useUiStore.legendOpen`.
+ *
+ * SOLID:
+ *  - SRP: el componente sólo presenta y conecta atajos. La rampa, dominio
+ *    y stops se calculan fuera (catálogo) y se pasan como props.
+ *  - DI: el orden de capas y la capa activa son controlados desde fuera
+ *    para que `DashboardShell` o cualquier consumidor pueda decidir qué
+ *    capa anteceder/seguir.
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { ChevronLeft, ChevronRight, EyeOff } from 'lucide-react';
+import gsap from 'gsap';
+import { useGSAP } from '@gsap/react';
+
+import { cn } from '@/components/ui/cn';
+import { useUiStore } from '@/state/ui';
+import { resolveDuration } from '@/animations';
+import {
+  MAP_LAYER_CATALOG,
+  type LayerDomain,
+  type LayerLegendStop,
+  type MapLayerDefinition,
+  type MapLayerId,
+} from '@/features/map/layers/catalog';
+
+export interface RichLegendProps {
+  /** Capa activa cuya rampa se muestra. */
+  readonly layer: MapLayerDefinition;
+  /** Stops calculados (o por defecto se construyen desde la capa). */
+  readonly stops: readonly LayerLegendStop[];
+  /** Dominio observado de la capa. */
+  readonly domain: LayerDomain;
+  /** Callback de cambio de capa (usado por los atajos `[` / `]`). */
+  readonly onLayerChange: (layerId: MapLayerId) => void;
+  /** Catálogo de capas a usar para los atajos (por defecto, el global). */
+  readonly catalog?: readonly MapLayerDefinition[];
+  /** Sobreescribe la visibilidad (útil en tests/storybook). */
+  readonly forcedOpen?: boolean;
+  readonly className?: string;
+}
+
+function formatBoundary(value: number, unit: string): string {
+  const trimmed = unit.trim();
+  const formatted = Number.isInteger(value)
+    ? value.toLocaleString('es-ES')
+    : value.toLocaleString('es-ES', { maximumFractionDigits: 1 });
+  if (!trimmed) return formatted;
+  if (/^[€%°]/.test(trimmed)) return `${formatted}${trimmed}`;
+  return `${formatted}${unit}`;
+}
+
+export function RichLegend({
+  layer,
+  stops,
+  domain,
+  onLayerChange,
+  catalog = MAP_LAYER_CATALOG,
+  forcedOpen,
+  className,
+}: RichLegendProps) {
+  const open = useUiStore((state) => state.legendOpen);
+  const toggleLegend = useUiStore((state) => state.toggleLegend);
+  const isOpen = forcedOpen ?? open;
+
+  // Interpolación de los textos de mín/máx para que cambien con suavidad
+  // cuando el usuario rota de capa con `[`/`]`.
+  const minRef = useRef<HTMLSpanElement | null>(null);
+  const maxRef = useRef<HTMLSpanElement | null>(null);
+  const [displayedMin, setDisplayedMin] = useState(domain.min);
+  const [displayedMax, setDisplayedMax] = useState(domain.max);
+
+  useEffect(() => {
+    setDisplayedMin(domain.min);
+    setDisplayedMax(domain.max);
+  }, [layer.id, domain.min, domain.max]);
+
+  useGSAP(
+    () => {
+      const duration = resolveDuration(0.45);
+      if (duration === 0) {
+        setDisplayedMin(domain.min);
+        setDisplayedMax(domain.max);
+        return;
+      }
+      gsap.to(
+        { value: displayedMin },
+        {
+          value: domain.min,
+          duration,
+          ease: 'power1.out',
+          onUpdate() {
+            setDisplayedMin(this.targets()[0].value as number);
+          },
+        }
+      );
+      gsap.to(
+        { value: displayedMax },
+        {
+          value: domain.max,
+          duration,
+          ease: 'power1.out',
+          onUpdate() {
+            setDisplayedMax(this.targets()[0].value as number);
+          },
+        }
+      );
+      // displayedMin/Max no son dependencias para evitar bucles; sólo
+      // `domain` y `layer.id` disparan la animación.
+    },
+    { dependencies: [domain.min, domain.max, layer.id] }
+  );
+
+  const cyclingCatalog = useMemo(
+    () => (catalog.length > 0 ? catalog : MAP_LAYER_CATALOG),
+    [catalog]
+  );
+
+  const cycleLayer = useCallback(
+    (direction: 1 | -1) => {
+      const index = cyclingCatalog.findIndex((entry) => entry.id === layer.id);
+      const safeIndex = index >= 0 ? index : 0;
+      const nextIndex = (safeIndex + direction + cyclingCatalog.length) % cyclingCatalog.length;
+      onLayerChange(cyclingCatalog[nextIndex].id);
+    },
+    [cyclingCatalog, layer.id, onLayerChange]
+  );
+
+  // Atajos `[` y `]` se registran globalmente cuando la leyenda está
+  // abierta. Si está cerrada, devolvemos el control al resto de la app
+  // para no comer pulsaciones que no se perciben.
+  useEffect(() => {
+    if (!isOpen) return;
+    const handler = (event: KeyboardEvent) => {
+      if (event.target instanceof HTMLInputElement || event.target instanceof HTMLTextAreaElement) {
+        return;
+      }
+      if (event.key === '[') {
+        event.preventDefault();
+        cycleLayer(-1);
+      } else if (event.key === ']') {
+        event.preventDefault();
+        cycleLayer(1);
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => {
+      window.removeEventListener('keydown', handler);
+    };
+  }, [isOpen, cycleLayer]);
+
+  if (!isOpen) {
+    return (
+      <button
+        type="button"
+        onClick={toggleLegend}
+        data-feature="rich-legend"
+        data-state="collapsed"
+        aria-label="Mostrar leyenda"
+        style={{ zIndex: 'var(--z-overlay-quiet)' as unknown as number }}
+        className={cn(
+          'pointer-events-auto absolute bottom-4 left-1/2 inline-flex -translate-x-1/2 items-center gap-2 rounded-full',
+          'border border-white/40 bg-white/85 px-4 py-2 text-[11px] font-semibold text-[var(--color-ink-700)] shadow-[var(--shadow-card)] backdrop-blur',
+          'focus-visible:ring-brand-300 hover:bg-white focus-visible:ring-2 focus-visible:outline-none',
+          className
+        )}
+      >
+        Mostrar leyenda · Pulsa <kbd className="font-mono">[</kbd> o{' '}
+        <kbd className="font-mono">]</kbd> para cambiar de capa
+      </button>
+    );
+  }
+
+  return (
+    <section
+      data-feature="rich-legend"
+      data-state="expanded"
+      data-testid="rich-legend"
+      aria-label={`Leyenda: ${layer.label}`}
+      style={{ zIndex: 'var(--z-overlay-quiet)' as unknown as number }}
+      className={cn(
+        'pointer-events-auto absolute bottom-4 left-1/2 flex -translate-x-1/2 items-center gap-3',
+        'rounded-full border border-white/40 bg-white/90 py-2 pr-2 pl-4 shadow-[var(--shadow-elevated)] backdrop-blur',
+        className
+      )}
+    >
+      <button
+        type="button"
+        onClick={() => cycleLayer(-1)}
+        aria-label="Capa anterior"
+        data-testid="rich-legend-prev"
+        className="text-ink-500 hover:bg-brand-50 hover:text-brand-700 focus-visible:ring-brand-300 inline-flex h-7 w-7 items-center justify-center rounded-full transition-colors focus-visible:ring-2 focus-visible:outline-none"
+      >
+        <ChevronLeft size={14} aria-hidden="true" />
+      </button>
+      <div className="flex min-w-0 flex-col">
+        <span className="text-ink-700 truncate text-xs font-semibold tracking-wide">
+          {layer.label}
+        </span>
+        <div className="mt-1 flex items-center gap-2 text-[10px] tabular-nums">
+          <span ref={minRef} data-testid="rich-legend-min" className="text-ink-500">
+            {formatBoundary(displayedMin, layer.unit)}
+          </span>
+          <span
+            aria-hidden="true"
+            className="block h-2 w-32 rounded-full"
+            style={{
+              background: `linear-gradient(to right, ${stops
+                .map((stop) => stop.color)
+                .reverse()
+                .join(', ')})`,
+            }}
+          />
+          <span ref={maxRef} data-testid="rich-legend-max" className="text-ink-500">
+            {formatBoundary(displayedMax, layer.unit)}
+          </span>
+        </div>
+      </div>
+      <button
+        type="button"
+        onClick={() => cycleLayer(1)}
+        aria-label="Capa siguiente"
+        data-testid="rich-legend-next"
+        className="text-ink-500 hover:bg-brand-50 hover:text-brand-700 focus-visible:ring-brand-300 inline-flex h-7 w-7 items-center justify-center rounded-full transition-colors focus-visible:ring-2 focus-visible:outline-none"
+      >
+        <ChevronRight size={14} aria-hidden="true" />
+      </button>
+      <span className="border-line-soft text-ink-400 ml-1 hidden border-l pl-2 text-[10px] sm:inline">
+        Pulsa <kbd className="text-ink-700 font-mono">[</kbd> o{' '}
+        <kbd className="text-ink-700 font-mono">]</kbd> para cambiar de capa
+      </span>
+      <button
+        type="button"
+        onClick={toggleLegend}
+        aria-label="Ocultar leyenda"
+        data-testid="rich-legend-hide"
+        className="text-ink-400 hover:bg-surface-muted hover:text-ink-700 focus-visible:ring-brand-300 inline-flex h-7 w-7 items-center justify-center rounded-full transition-colors focus-visible:ring-2 focus-visible:outline-none"
+      >
+        <EyeOff size={14} aria-hidden="true" />
+      </button>
+    </section>
+  );
+}

--- a/apps/web/src/features/overlays/TerritorySheet.tsx
+++ b/apps/web/src/features/overlays/TerritorySheet.tsx
@@ -1,0 +1,299 @@
+/* eslint-disable no-undef -- HTMLDivElement, KeyboardEvent y performance son globales DOM. */
+/**
+ * TerritorySheet — bottom-sheet con la ficha territorial.
+ *
+ * Drawer inferior con drag handle al estilo iOS / Material 3, tres puntos
+ * de anclaje (15 / 55 / 92 % de la altura del viewport) y cierre por
+ * `Escape`, drag-down o click en el backdrop. Renderiza la `TerritoryDetail`
+ * existente, por lo que no duplica lógica de presentación: el drawer es
+ * únicamente el "container" responsable del gesto y del foco.
+ *
+ * Estado:
+ *  - Snap point activo (`peek`, `default`, `expanded`).
+ *  - Offset de drag en píxeles para retroalimentar la interacción.
+ *
+ * Accesibilidad:
+ *  - `role="dialog"` + `aria-modal` + `aria-labelledby` para SR.
+ *  - Foco inicial atrapado en el handle (`tabIndex=0`) y `Escape` cierra.
+ *  - Backdrop con `aria-hidden` para que SR no lo anuncie.
+ *
+ * Implementación pura del gesto (sin librería externa) para evitar añadir
+ * dependencias. Si en futuras iteraciones se introduce
+ * `react-aria-components`, los snap-points y el drag pueden delegarse en
+ * `useDrag` sin alterar la API pública del componente.
+ */
+
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type PointerEvent as ReactPointerEvent,
+} from 'react';
+import { X } from 'lucide-react';
+import { cn } from '@/components/ui/cn';
+import { TerritoryDetail } from '@/features/territory/TerritoryDetail';
+import { NATIONAL_MUNICIPALITIES, type NationalMunicipality } from '@/data/national_mock';
+
+/**
+ * Snap points (porcentaje del viewport ocupado por el sheet). Se mantienen
+ * como constantes para que los tests puedan asertar sobre el atributo
+ * `data-snap`.
+ */
+export const SHEET_SNAP_POINTS = {
+  peek: 15,
+  default: 55,
+  expanded: 92,
+} as const;
+
+export type SheetSnap = keyof typeof SHEET_SNAP_POINTS;
+
+const SNAP_ORDER: SheetSnap[] = ['peek', 'default', 'expanded'];
+
+/** Umbral en píxeles a partir del cual el drag actualiza el snap. */
+const SNAP_DRAG_THRESHOLD = 60;
+/** Velocidad mínima (px/ms) en la última muestra para forzar un snap rápido. */
+const SNAP_VELOCITY_THRESHOLD = 0.6;
+
+export interface TerritorySheetProps {
+  /** Identificador del territorio activo. `null` mantiene el sheet cerrado. */
+  readonly territoryId: string | null;
+  /** Catálogo opcional para resolver el municipio (tests/mocks). */
+  readonly data?: readonly NationalMunicipality[];
+  /** Snap inicial cuando el sheet aparece. */
+  readonly initialSnap?: SheetSnap;
+  /** Callback al cerrar (Escape, drag-down, backdrop, botón X). */
+  readonly onClose: () => void;
+}
+
+export function TerritorySheet({
+  territoryId,
+  data = NATIONAL_MUNICIPALITIES,
+  initialSnap = 'default',
+  onClose,
+}: TerritorySheetProps) {
+  const [snap, setSnap] = useState<SheetSnap>(initialSnap);
+  const [dragOffset, setDragOffset] = useState(0);
+  const dragStateRef = useRef<{ startY: number; lastY: number; lastT: number } | null>(null);
+  const sheetRef = useRef<HTMLDivElement | null>(null);
+
+  const isOpen = territoryId !== null;
+  const municipality = isOpen ? (data.find((entry) => entry.id === territoryId) ?? null) : null;
+
+  /*
+   * Cuando se abre el sheet, restablecemos snap y offset; cuando se cierra,
+   * limpiamos cualquier residuo de drag para que la próxima apertura comience
+   * limpia.
+   */
+  useEffect(() => {
+    if (!isOpen) {
+      setDragOffset(0);
+      return;
+    }
+    setSnap(initialSnap);
+    setDragOffset(0);
+  }, [isOpen, initialSnap, territoryId]);
+
+  /* `Escape` cierra el sheet. Sólo registramos el listener cuando está abierto
+   * para no contaminar el árbol cuando no procede. */
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.stopPropagation();
+        onClose();
+      }
+    };
+    window.addEventListener('keydown', handleKey);
+    return () => {
+      window.removeEventListener('keydown', handleKey);
+    };
+  }, [isOpen, onClose]);
+
+  /*
+   * Foco inicial: cuando el sheet se abre y existe el contenedor, llevamos
+   * el foco al handle para que SR y teclado entren en el componente sin
+   * salir del flujo (cumple WCAG 2.4.3 - orden de foco).
+   */
+  useEffect(() => {
+    if (!isOpen) return;
+    const node = sheetRef.current;
+    if (!node) return;
+    const handle = node.querySelector<HTMLElement>('[data-sheet-handle]');
+    handle?.focus();
+  }, [isOpen]);
+
+  const handlePointerDown = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
+    dragStateRef.current = {
+      startY: event.clientY,
+      lastY: event.clientY,
+      lastT: performance.now(),
+    };
+    event.currentTarget.setPointerCapture(event.pointerId);
+  }, []);
+
+  const handlePointerMove = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
+    const state = dragStateRef.current;
+    if (!state) return;
+    state.lastY = event.clientY;
+    state.lastT = performance.now();
+    setDragOffset(event.clientY - state.startY);
+  }, []);
+
+  const handlePointerUp = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      const state = dragStateRef.current;
+      dragStateRef.current = null;
+      event.currentTarget.releasePointerCapture(event.pointerId);
+      if (!state) return;
+      const delta = event.clientY - state.startY;
+      const elapsed = Math.max(1, performance.now() - state.lastT);
+      const velocity = (event.clientY - state.lastY) / elapsed;
+      setDragOffset(0);
+
+      // Drag hacia abajo cuando estamos en el snap más bajo cierra el drawer.
+      if (snap === SNAP_ORDER[0] && delta > SNAP_DRAG_THRESHOLD) {
+        onClose();
+        return;
+      }
+
+      const direction = delta > 0 ? 1 : delta < 0 ? -1 : 0;
+      const fastFlick = Math.abs(velocity) >= SNAP_VELOCITY_THRESHOLD ? direction : 0;
+      const significantDrag = Math.abs(delta) >= SNAP_DRAG_THRESHOLD ? direction : 0;
+      const moveBy = fastFlick !== 0 ? fastFlick : significantDrag;
+      if (moveBy === 0) return;
+
+      const currentIndex = SNAP_ORDER.indexOf(snap);
+      const nextIndex = Math.min(SNAP_ORDER.length - 1, Math.max(0, currentIndex + moveBy));
+      const nextSnap = SNAP_ORDER[nextIndex];
+      if (nextSnap === snap && delta > SNAP_DRAG_THRESHOLD && snap === SNAP_ORDER[0]) {
+        onClose();
+        return;
+      }
+      setSnap(nextSnap);
+    },
+    [snap, onClose]
+  );
+
+  const handleHandleKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      const currentIndex = SNAP_ORDER.indexOf(snap);
+      if (event.key === 'ArrowUp' || event.key === 'PageUp') {
+        event.preventDefault();
+        setSnap(SNAP_ORDER[Math.min(SNAP_ORDER.length - 1, currentIndex + 1)]);
+      } else if (event.key === 'ArrowDown' || event.key === 'PageDown') {
+        event.preventDefault();
+        const nextIndex = currentIndex - 1;
+        if (nextIndex < 0) {
+          onClose();
+        } else {
+          setSnap(SNAP_ORDER[nextIndex]);
+        }
+      }
+    },
+    [snap, onClose]
+  );
+
+  if (!isOpen) {
+    return null;
+  }
+
+  const heightPct = SHEET_SNAP_POINTS[snap];
+  const offset = Math.max(0, dragOffset);
+
+  return (
+    <div
+      data-feature="territory-sheet"
+      role="presentation"
+      style={{ zIndex: 'var(--z-overlay-rich)' as unknown as number }}
+      className="fixed inset-0 flex items-end justify-center"
+    >
+      <div
+        aria-hidden="true"
+        onClick={onClose}
+        className={cn(
+          'absolute inset-0 bg-[var(--color-ink-900)]/40 backdrop-blur-[2px] transition-opacity duration-200',
+          snap === 'peek' ? 'opacity-50' : 'opacity-100'
+        )}
+      />
+
+      <div
+        ref={sheetRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="territory-sheet-title"
+        data-snap={snap}
+        data-testid="territory-sheet"
+        className={cn(
+          'relative w-full max-w-3xl overflow-hidden rounded-t-3xl bg-white shadow-[var(--shadow-elevated)]',
+          'flex flex-col will-change-transform'
+        )}
+        style={{
+          height: `${heightPct}vh`,
+          transform: `translate3d(0, ${offset}px, 0)`,
+          transition:
+            dragOffset === 0
+              ? 'height 220ms cubic-bezier(0.32,0.72,0,1), transform 220ms cubic-bezier(0.32,0.72,0,1)'
+              : 'none',
+        }}
+      >
+        <div
+          data-sheet-handle
+          tabIndex={0}
+          role="slider"
+          aria-orientation="vertical"
+          aria-valuemin={SHEET_SNAP_POINTS.peek}
+          aria-valuemax={SHEET_SNAP_POINTS.expanded}
+          aria-valuenow={heightPct}
+          aria-valuetext={`${snap} (${heightPct}%)`}
+          aria-label="Arrastra hacia abajo para cerrar la ficha."
+          onPointerDown={handlePointerDown}
+          onPointerMove={handlePointerMove}
+          onPointerUp={handlePointerUp}
+          onKeyDown={handleHandleKeyDown}
+          className={cn(
+            'flex shrink-0 cursor-grab touch-none items-center justify-center py-2 select-none active:cursor-grabbing',
+            'focus-visible:ring-brand-300 focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-inset'
+          )}
+        >
+          <span aria-hidden="true" className="bg-ink-300/70 block h-1.5 w-12 rounded-full" />
+        </div>
+
+        <div className="flex shrink-0 items-start justify-between gap-3 px-6 pt-1 pb-3">
+          <div className="min-w-0">
+            <p className="text-ink-500 text-[11px] font-semibold tracking-[0.16em] uppercase">
+              Ficha territorial
+            </p>
+            <h2
+              id="territory-sheet-title"
+              className="font-display text-ink-900 truncate text-xl font-bold"
+            >
+              {municipality?.name ?? 'Territorio'}
+            </h2>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Cerrar ficha territorial"
+            data-testid="territory-sheet-close"
+            className={cn(
+              'inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full',
+              'text-ink-500 hover:text-ink-900 bg-surface-soft hover:bg-surface-muted transition-colors',
+              'focus-visible:ring-brand-300 focus-visible:ring-2 focus-visible:outline-none'
+            )}
+          >
+            <X size={16} aria-hidden="true" />
+          </button>
+        </div>
+
+        <div className="min-h-0 flex-1 overflow-y-auto px-6 pb-6">
+          {municipality ? (
+            <TerritoryDetail municipality={municipality} data={data} />
+          ) : (
+            <p className="text-ink-500 text-sm">No se ha encontrado el territorio seleccionado.</p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/overlays/__tests__/FloatingRanking.test.tsx
+++ b/apps/web/src/features/overlays/__tests__/FloatingRanking.test.tsx
@@ -1,0 +1,61 @@
+/**
+ * Tests del overlay FloatingRanking.
+ *
+ * Verifican: estado expandido por defecto, alternancia del pin contra el
+ * store de UI y comportamiento de auto-colapso/restauración al
+ * desenfocarse.
+ */
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { FloatingRanking } from '../FloatingRanking';
+import { useUiStore } from '@/state/ui';
+
+const wrap = (node: ReactNode) => <MemoryRouter>{node}</MemoryRouter>;
+
+describe('FloatingRanking', () => {
+  beforeEach(() => {
+    useUiStore.getState().reset();
+  });
+
+  it('renderiza la cabecera y empieza expandido', () => {
+    render(wrap(<FloatingRanking>contenido</FloatingRanking>));
+    const aside = screen.getByLabelText(/ranking de municipios/i);
+    expect(aside).toHaveAttribute('data-state', 'expanded');
+    expect(aside.textContent).toMatch(/ranking nacional/i);
+    expect(aside.textContent).toMatch(/Pinchar en el mapa/i);
+  });
+
+  it('togglea el pin contra el store de UI', async () => {
+    const user = userEvent.setup();
+    render(wrap(<FloatingRanking>contenido</FloatingRanking>));
+    const pinBtn = screen.getByTestId('floating-ranking-pin');
+    expect(pinBtn).toHaveAttribute('aria-pressed', 'false');
+    await user.click(pinBtn);
+    expect(useUiStore.getState().isRankingPinned).toBe(true);
+    expect(pinBtn).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('reacciona a forcedExpanded para representar el estado colapsado', () => {
+    render(wrap(<FloatingRanking forcedExpanded={false}>x</FloatingRanking>));
+    const aside = screen.getByLabelText(/ranking de municipios/i);
+    expect(aside).toHaveAttribute('data-state', 'collapsed');
+    // El cuerpo se oculta a SR cuando colapsa.
+    const body = aside.querySelector('[aria-hidden="true"]');
+    expect(body).not.toBeNull();
+  });
+
+  it('expande automáticamente al pinchar contra el pin', async () => {
+    const user = userEvent.setup();
+    render(wrap(<FloatingRanking>contenido</FloatingRanking>));
+    const pinBtn = screen.getByTestId('floating-ranking-pin');
+    await user.click(pinBtn);
+    const aside = screen.getByLabelText(/ranking de municipios/i);
+    expect(aside).toHaveAttribute('data-pinned', 'true');
+    expect(aside).toHaveAttribute('data-state', 'expanded');
+  });
+});

--- a/apps/web/src/features/overlays/__tests__/MarkerRichTooltip.test.tsx
+++ b/apps/web/src/features/overlays/__tests__/MarkerRichTooltip.test.tsx
@@ -1,0 +1,99 @@
+/**
+ * Tests del MarkerRichTooltip.
+ *
+ * Verifican el render del marker, la sparkline, el top-3 de indicadores
+ * y la activación del CTA "Ver ficha".
+ */
+
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import { MarkerRichTooltip, type MarkerRichTooltipMarker } from '../MarkerRichTooltip';
+
+const baseMarker: MarkerRichTooltipMarker = {
+  id: 'mun:41091',
+  name: 'Sevilla',
+  province: 'Sevilla',
+  score: 78,
+  value: 95,
+  indicators: [
+    { id: 'broadband', label: 'Banda ancha', value: 95, unit: '%' },
+    { id: 'rent_price', label: 'Alquiler medio', value: 850, unit: '€' },
+    { id: 'income', label: 'Renta', value: 28000, unit: '€' },
+    { id: 'air_quality', label: 'Aire', value: 42, unit: 'AQI' },
+  ],
+};
+
+describe('MarkerRichTooltip', () => {
+  it('muestra nombre, score y sparkline del marker', () => {
+    render(
+      <MarkerRichTooltip
+        marker={baseMarker}
+        x={100}
+        y={120}
+        layerLabel="Banda ancha"
+        unit=" %"
+        activeIndicatorId="broadband"
+      />
+    );
+    expect(screen.getByTestId('marker-rich-tooltip')).toBeInTheDocument();
+    expect(screen.getByTestId('marker-rich-tooltip-score')).toHaveTextContent('78');
+    expect(screen.getByTestId('marker-rich-tooltip-sparkline')).toBeInTheDocument();
+  });
+
+  it('renderiza un máximo de 3 indicadores en el top, con el activo destacado', () => {
+    render(
+      <MarkerRichTooltip
+        marker={baseMarker}
+        x={0}
+        y={0}
+        layerLabel="Banda ancha"
+        unit=" %"
+        activeIndicatorId="broadband"
+      />
+    );
+    const list = screen.getByTestId('marker-rich-tooltip-top');
+    const items = within(list).getAllByRole('listitem');
+    expect(items.length).toBeLessThanOrEqual(3);
+    const active = items.find((item) => item.getAttribute('data-active') === 'true');
+    expect(active?.textContent ?? '').toMatch(/banda ancha/i);
+  });
+
+  it('al pulsar "Ver ficha" emite onOpenSheet con el id del marker', async () => {
+    const onOpenSheet = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <MarkerRichTooltip
+        marker={baseMarker}
+        x={0}
+        y={0}
+        layerLabel="Banda ancha"
+        unit=" %"
+        onOpenSheet={onOpenSheet}
+      />
+    );
+    await user.click(screen.getByTestId('marker-rich-tooltip-cta'));
+    expect(onOpenSheet).toHaveBeenCalledWith('mun:41091');
+  });
+
+  it('si no recibe indicadores, no se renderiza el top-3', () => {
+    render(
+      <MarkerRichTooltip
+        marker={{ ...baseMarker, indicators: [] }}
+        x={0}
+        y={0}
+        layerLabel="Score"
+        unit=""
+      />
+    );
+    expect(screen.queryByTestId('marker-rich-tooltip-top')).toBeNull();
+  });
+
+  it('expone microcopy "Pinchar en el mapa"', () => {
+    render(
+      <MarkerRichTooltip marker={baseMarker} x={0} y={0} layerLabel="Banda ancha" unit=" %" />
+    );
+    expect(screen.getByTestId('marker-rich-tooltip').textContent).toMatch(/Pinchar en el mapa/i);
+  });
+});

--- a/apps/web/src/features/overlays/__tests__/MiniMap.test.tsx
+++ b/apps/web/src/features/overlays/__tests__/MiniMap.test.tsx
@@ -1,0 +1,58 @@
+/**
+ * Tests del componente MiniMap.
+ *
+ * Verifican: render del SVG, posición proporcional del recuadro de
+ * viewport, y comportamiento del toggle (mostrar/ocultar) coordinado con
+ * `useUiStore`.
+ */
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { MiniMap } from '../MiniMap';
+import { useUiStore } from '@/state/ui';
+
+describe('MiniMap', () => {
+  beforeEach(() => {
+    useUiStore.getState().reset();
+  });
+
+  it('renderiza el SVG y un recuadro de viewport por defecto', () => {
+    render(<MiniMap />);
+    const figure = screen.getByTestId('mini-map');
+    expect(figure).toBeInTheDocument();
+    const viewport = screen.getByTestId('mini-map-viewport');
+    expect(viewport).toBeInTheDocument();
+  });
+
+  it('proyecta el viewport al rectángulo SVG', () => {
+    render(<MiniMap viewport={{ minLon: -5, maxLon: 0, minLat: 38, maxLat: 42 }} />);
+    const viewport = screen.getByTestId('mini-map-viewport');
+    // El cálculo esperado: lonSpan=14.5, latSpan=8.5.
+    // x=( -5 - (-10) ) / 14.5 * 200 ≈ 68.97
+    // width=( 0 - (-5) ) / 14.5 * 200 ≈ 68.97
+    // y=( 44 - 42 ) / 8.5 * 140 ≈ 32.94
+    // height=( 42 - 38 ) / 8.5 * 140 ≈ 65.88
+    expect(Number(viewport.getAttribute('x'))).toBeGreaterThan(60);
+    expect(Number(viewport.getAttribute('x'))).toBeLessThan(80);
+    expect(Number(viewport.getAttribute('width'))).toBeGreaterThan(60);
+    expect(Number(viewport.getAttribute('y'))).toBeGreaterThan(20);
+    expect(Number(viewport.getAttribute('height'))).toBeGreaterThan(50);
+  });
+
+  it('al ocultar muestra el botón de re-apertura y desaparece la figura', async () => {
+    const user = userEvent.setup();
+    render(<MiniMap />);
+    await user.click(screen.getByTestId('mini-map-toggle'));
+    expect(screen.queryByTestId('mini-map')).toBeNull();
+    expect(screen.getByRole('button', { name: /mostrar mini-mapa/i })).toBeInTheDocument();
+    expect(useUiStore.getState().miniMapOpen).toBe(false);
+  });
+
+  it('respeta el flag forcedVisible sobre el store', () => {
+    useUiStore.getState().setMiniMapOpen(false);
+    render(<MiniMap forcedVisible />);
+    expect(screen.getByTestId('mini-map')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/overlays/__tests__/RichLegend.test.tsx
+++ b/apps/web/src/features/overlays/__tests__/RichLegend.test.tsx
@@ -1,0 +1,109 @@
+/**
+ * Tests de RichLegend.
+ *
+ * Cubren: render con la capa activa, atajos `[` y `]` para alternar de
+ * capa, ocultar/mostrar la pastilla y propagación de la unidad.
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { RichLegend } from '../RichLegend';
+import { useUiStore } from '@/state/ui';
+import {
+  MAP_LAYER_CATALOG,
+  buildLegendStops,
+  computeLayerDomain,
+  resolveLayer,
+  type EnrichedMapPoint,
+} from '@/features/map/layers/catalog';
+import { toEnrichedMapPoints } from '@/data/national_mock';
+
+const points: readonly EnrichedMapPoint[] = toEnrichedMapPoints();
+
+function buildHelpers(layerId: 'score' | 'broadband' | 'rent_price' = 'score') {
+  const layer = resolveLayer(layerId);
+  const domain = computeLayerDomain(points, layer);
+  const stops = buildLegendStops(layer, domain);
+  return { layer, domain, stops };
+}
+
+describe('RichLegend', () => {
+  beforeEach(() => {
+    useUiStore.getState().reset();
+  });
+
+  it('renderiza la etiqueta de la capa y su unidad correctamente', () => {
+    const { layer, domain, stops } = buildHelpers('broadband');
+    render(<RichLegend layer={layer} stops={stops} domain={domain} onLayerChange={() => {}} />);
+    expect(screen.getByTestId('rich-legend')).toHaveAttribute(
+      'aria-label',
+      `Leyenda: ${layer.label}`
+    );
+    expect(screen.getByTestId('rich-legend-min').textContent).toMatch(/%/);
+    expect(screen.getByTestId('rich-legend-max').textContent).toMatch(/%/);
+  });
+
+  it('cambia de capa con `[` y `]` invocando onLayerChange', () => {
+    const onLayerChange = vi.fn();
+    const { layer, domain, stops } = buildHelpers('score');
+    render(
+      <RichLegend
+        layer={layer}
+        stops={stops}
+        domain={domain}
+        onLayerChange={onLayerChange}
+        catalog={MAP_LAYER_CATALOG}
+      />
+    );
+    fireEvent.keyDown(window, { key: ']' });
+    expect(onLayerChange).toHaveBeenCalledWith(MAP_LAYER_CATALOG[1].id);
+    fireEvent.keyDown(window, { key: '[' });
+    expect(onLayerChange).toHaveBeenLastCalledWith(
+      MAP_LAYER_CATALOG[MAP_LAYER_CATALOG.length - 1].id
+    );
+  });
+
+  it('los botones prev/next también invocan onLayerChange', async () => {
+    const onLayerChange = vi.fn();
+    const { layer, domain, stops } = buildHelpers('score');
+    const user = userEvent.setup();
+    render(
+      <RichLegend
+        layer={layer}
+        stops={stops}
+        domain={domain}
+        onLayerChange={onLayerChange}
+        catalog={MAP_LAYER_CATALOG}
+      />
+    );
+    await user.click(screen.getByTestId('rich-legend-next'));
+    expect(onLayerChange).toHaveBeenCalledWith(MAP_LAYER_CATALOG[1].id);
+    await user.click(screen.getByTestId('rich-legend-prev'));
+    expect(onLayerChange).toHaveBeenLastCalledWith(
+      MAP_LAYER_CATALOG[MAP_LAYER_CATALOG.length - 1].id
+    );
+  });
+
+  it('al ocultar muestra el botón de re-apertura', async () => {
+    const user = userEvent.setup();
+    const { layer, domain, stops } = buildHelpers('score');
+    render(<RichLegend layer={layer} stops={stops} domain={domain} onLayerChange={() => {}} />);
+    await user.click(screen.getByTestId('rich-legend-hide'));
+    expect(screen.queryByTestId('rich-legend')).toBeNull();
+    expect(screen.getByRole('button', { name: /mostrar leyenda/i })).toBeInTheDocument();
+    expect(useUiStore.getState().legendOpen).toBe(false);
+  });
+
+  it('al estar oculta no consume las pulsaciones [ ]', () => {
+    useUiStore.getState().setLegendOpen(false);
+    const onLayerChange = vi.fn();
+    const { layer, domain, stops } = buildHelpers('score');
+    render(
+      <RichLegend layer={layer} stops={stops} domain={domain} onLayerChange={onLayerChange} />
+    );
+    fireEvent.keyDown(window, { key: ']' });
+    expect(onLayerChange).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/features/overlays/__tests__/TerritorySheet.test.tsx
+++ b/apps/web/src/features/overlays/__tests__/TerritorySheet.test.tsx
@@ -1,0 +1,74 @@
+/**
+ * Tests del bottom-sheet TerritorySheet.
+ *
+ * Cubren: visibilidad controlada por `territoryId`, snap por defecto,
+ * cierre por Escape y por botón de cierre, navegación entre snaps con
+ * teclado, render del nombre del territorio en el título.
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import type { ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { TerritorySheet, SHEET_SNAP_POINTS } from '../TerritorySheet';
+import { NATIONAL_MUNICIPALITIES } from '@/data/national_mock';
+
+const wrap = (node: ReactNode) => <MemoryRouter>{node}</MemoryRouter>;
+
+const FIRST = NATIONAL_MUNICIPALITIES[0];
+
+describe('TerritorySheet', () => {
+  it('no renderiza nada cuando territoryId es null', () => {
+    render(wrap(<TerritorySheet territoryId={null} onClose={() => {}} />));
+    expect(screen.queryByTestId('territory-sheet')).toBeNull();
+  });
+
+  it('renderiza con el snap por defecto cuando hay territoryId', () => {
+    render(wrap(<TerritorySheet territoryId={FIRST.id} onClose={() => {}} />));
+    const sheet = screen.getByTestId('territory-sheet');
+    expect(sheet).toHaveAttribute('data-snap', 'default');
+    expect(sheet.style.height).toBe(`${SHEET_SNAP_POINTS.default}vh`);
+    expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent(FIRST.name);
+  });
+
+  it('cierra al pulsar Escape', () => {
+    const onClose = vi.fn();
+    render(wrap(<TerritorySheet territoryId={FIRST.id} onClose={onClose} />));
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('cierra al pulsar el botón de cierre', async () => {
+    const onClose = vi.fn();
+    const user = userEvent.setup();
+    render(wrap(<TerritorySheet territoryId={FIRST.id} onClose={onClose} />));
+    await user.click(screen.getByTestId('territory-sheet-close'));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('permite expandir el sheet con ArrowUp en el handle', () => {
+    render(wrap(<TerritorySheet territoryId={FIRST.id} onClose={() => {}} />));
+    const handle = screen.getByRole('slider');
+    fireEvent.keyDown(handle, { key: 'ArrowUp' });
+    const sheet = screen.getByTestId('territory-sheet');
+    expect(sheet).toHaveAttribute('data-snap', 'expanded');
+  });
+
+  it('al pulsar ArrowDown desde peek invoca onClose', () => {
+    const onClose = vi.fn();
+    render(wrap(<TerritorySheet territoryId={FIRST.id} onClose={onClose} initialSnap="peek" />));
+    const handle = screen.getByRole('slider');
+    fireEvent.keyDown(handle, { key: 'ArrowDown' });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('expone el microcopy "Arrastra hacia abajo" en el handle accesible', () => {
+    render(wrap(<TerritorySheet territoryId={FIRST.id} onClose={() => {}} />));
+    expect(screen.getByRole('slider')).toHaveAttribute(
+      'aria-label',
+      'Arrastra hacia abajo para cerrar la ficha.'
+    );
+  });
+});

--- a/apps/web/src/features/overlays/index.ts
+++ b/apps/web/src/features/overlays/index.ts
@@ -1,0 +1,20 @@
+/**
+ * Punto de entrada del módulo de overlays cartográficos del Atelier
+ * (M12 · issue #118). Re-exporta los componentes para que `DashboardShell`
+ * y los tests consuman desde una ruta estable.
+ */
+
+export { FloatingRanking } from './FloatingRanking';
+export type { FloatingRankingProps } from './FloatingRanking';
+export { TerritorySheet, SHEET_SNAP_POINTS } from './TerritorySheet';
+export type { TerritorySheetProps, SheetSnap } from './TerritorySheet';
+export { MiniMap } from './MiniMap';
+export type { MiniMapProps, MiniMapViewport } from './MiniMap';
+export { RichLegend } from './RichLegend';
+export type { RichLegendProps } from './RichLegend';
+export { MarkerRichTooltip } from './MarkerRichTooltip';
+export type {
+  MarkerRichTooltipProps,
+  MarkerRichTooltipMarker,
+  MarkerRichTooltipIndicator,
+} from './MarkerRichTooltip';

--- a/apps/web/src/state/__tests__/ui.test.ts
+++ b/apps/web/src/state/__tests__/ui.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useUiStore } from '../ui';
+
+describe('useUiStore', () => {
+  beforeEach(() => {
+    useUiStore.getState().reset();
+  });
+
+  it('inicialmente el ranking no está pinchado y la leyenda y minimap están abiertos', () => {
+    const state = useUiStore.getState();
+    expect(state.isRankingPinned).toBe(false);
+    expect(state.legendOpen).toBe(true);
+    expect(state.miniMapOpen).toBe(true);
+    expect(state.selectedTerritoryId).toBeNull();
+  });
+
+  it('togglea el pin del ranking sin afectar otros flags', () => {
+    useUiStore.getState().toggleRankingPinned();
+    expect(useUiStore.getState().isRankingPinned).toBe(true);
+    useUiStore.getState().toggleRankingPinned();
+    expect(useUiStore.getState().isRankingPinned).toBe(false);
+  });
+
+  it('abre y cierra la ficha territorial', () => {
+    useUiStore.getState().openTerritorySheet('mun:41091');
+    expect(useUiStore.getState().selectedTerritoryId).toBe('mun:41091');
+    useUiStore.getState().closeTerritorySheet();
+    expect(useUiStore.getState().selectedTerritoryId).toBeNull();
+  });
+
+  it('toggleLegend invierte la visibilidad', () => {
+    useUiStore.getState().toggleLegend();
+    expect(useUiStore.getState().legendOpen).toBe(false);
+    useUiStore.getState().toggleLegend();
+    expect(useUiStore.getState().legendOpen).toBe(true);
+  });
+
+  it('toggleMiniMap invierte la visibilidad', () => {
+    useUiStore.getState().toggleMiniMap();
+    expect(useUiStore.getState().miniMapOpen).toBe(false);
+    useUiStore.getState().toggleMiniMap();
+    expect(useUiStore.getState().miniMapOpen).toBe(true);
+  });
+
+  it('reset restablece el estado inicial', () => {
+    const store = useUiStore.getState();
+    store.toggleRankingPinned();
+    store.openTerritorySheet('mun:28079');
+    store.toggleLegend();
+    store.toggleMiniMap();
+    store.reset();
+    const state = useUiStore.getState();
+    expect(state.isRankingPinned).toBe(false);
+    expect(state.legendOpen).toBe(true);
+    expect(state.miniMapOpen).toBe(true);
+    expect(state.selectedTerritoryId).toBeNull();
+  });
+});

--- a/apps/web/src/state/ui.ts
+++ b/apps/web/src/state/ui.ts
@@ -1,0 +1,86 @@
+/**
+ * Store Zustand para la UI del Atelier (overlays cartográficos del milestone
+ * M12 — issue #118).
+ *
+ * Centraliza el estado efímero que coordina los overlays sobre el mapa
+ * fullscreen del shell:
+ *
+ *  - `isRankingPinned`: controla si el ranking flotante permanece anclado
+ *    (no autocollapsa a 56 px tras 6 s sin foco).
+ *  - `selectedTerritoryId`: identificador del municipio cuya ficha
+ *    `TerritorySheet` está visible. Vive aquí (en lugar de reutilizar
+ *    `selection.ts`) porque la selección del bottom-sheet es un concepto
+ *    de UI puramente derivado y queremos evitar acoplamientos con la
+ *    lógica de comparación.
+ *  - `legendOpen`: visibilidad de la leyenda flotante rica
+ *    (`RichLegend`). Permite ocultarla con `]` cuando estorba.
+ *  - `miniMapOpen`: visibilidad del minimap. El usuario puede plegarlo
+ *    para liberar la esquina inferior derecha.
+ *
+ * Diseño:
+ *  - Estado efímero (no persistido): los overlays son "modales suaves"
+ *    con expectativa de pertenecer a la sesión activa.
+ *  - API minimalista basada en setters predecibles para que los tests y
+ *    los componentes consumidores puedan mockear el store sin dolor.
+ *  - Cumple SRP: cada acción cambia un único campo o describe una
+ *    transición coherente (`openTerritorySheet`, `closeTerritorySheet`).
+ */
+
+import { create } from 'zustand';
+
+export interface UiState {
+  /** Si `true`, el ranking permanece desplegado y no autocollapsa. */
+  readonly isRankingPinned: boolean;
+  /** Territorio cuya ficha (TerritorySheet) está abierta. */
+  readonly selectedTerritoryId: string | null;
+  /** Visibilidad de la leyenda rica flotante. */
+  readonly legendOpen: boolean;
+  /** Visibilidad del minimap inferior derecho. */
+  readonly miniMapOpen: boolean;
+}
+
+export interface UiActions {
+  /** Marca/desmarca el ranking como anclado. */
+  setRankingPinned: (pinned: boolean) => void;
+  /** Atajo: invierte el estado del pin. */
+  toggleRankingPinned: () => void;
+  /** Abre la ficha territorial sobre `id`. */
+  openTerritorySheet: (id: string) => void;
+  /** Cierra la ficha territorial actual. */
+  closeTerritorySheet: () => void;
+  /** Visibilidad explícita de la leyenda. */
+  setLegendOpen: (open: boolean) => void;
+  /** Atajo: invierte la visibilidad de la leyenda. */
+  toggleLegend: () => void;
+  /** Visibilidad explícita del minimap. */
+  setMiniMapOpen: (open: boolean) => void;
+  /** Atajo: invierte la visibilidad del minimap. */
+  toggleMiniMap: () => void;
+  /** Restaura todos los flags a su valor inicial. */
+  reset: () => void;
+}
+
+export type UiStore = UiState & UiActions;
+
+const INITIAL_STATE: UiState = {
+  isRankingPinned: false,
+  selectedTerritoryId: null,
+  legendOpen: true,
+  miniMapOpen: true,
+};
+
+export const useUiStore = create<UiStore>((set) => ({
+  ...INITIAL_STATE,
+  setRankingPinned: (pinned) => set({ isRankingPinned: pinned }),
+  toggleRankingPinned: () => set((state) => ({ isRankingPinned: !state.isRankingPinned })),
+  openTerritorySheet: (id) => set({ selectedTerritoryId: id }),
+  closeTerritorySheet: () => set({ selectedTerritoryId: null }),
+  setLegendOpen: (open) => set({ legendOpen: open }),
+  toggleLegend: () => set((state) => ({ legendOpen: !state.legendOpen })),
+  setMiniMapOpen: (open) => set({ miniMapOpen: open }),
+  toggleMiniMap: () => set((state) => ({ miniMapOpen: !state.miniMapOpen })),
+  reset: () => set({ ...INITIAL_STATE }),
+}));
+
+/** Estado inicial exportado para los tests y para resetear desde `beforeEach`. */
+export const UI_STORE_INITIAL_STATE = INITIAL_STATE;

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -49,6 +49,19 @@
 
   --shadow-card: 0 1px 2px rgba(15, 23, 42, 0.04), 0 12px 28px -18px rgba(15, 23, 42, 0.18);
   --shadow-elevated: 0 20px 40px -24px rgba(15, 23, 42, 0.22);
+
+  /*
+   * Z-index escalonado para overlays cartográficos (M12 — issue #118).
+   *
+   * El mapa y los marcadores viven en el plano base. Los overlays "quiet"
+   * (mini-map, ranking flotante, leyenda en estado relajado) se sitúan
+   * justo por encima sin competir con marcadores enfocados. Los overlays
+   * "rich" (tooltip detallado y bottom-sheet de ficha) toman precedencia
+   * porque vehiculan información contextual prioritaria al gesto del
+   * usuario y deben quedar siempre por delante.
+   */
+  --z-overlay-quiet: 10;
+  --z-overlay-rich: 20;
 }
 
 @layer base {


### PR DESCRIPTION
Refactor de la home a "cockpit cartográfico": mapa fullscreen con overlays glass: FloatingRanking pinable autocollapse, TerritorySheet bottom-sheet con drag handle y 3 snap points, MiniMap esquemático, RichLegend con cambio de capa por `[`/`]`, MarkerRichTooltip con sparkline + top-3. Sidebar derecha eliminada. 252 / 252 tests verde.

Closes #118