### PR TITLE
docs(review): segunda opinion cross-stack v0.5.1 (#134)

### DIFF
--- a/apps/api/src/atlashabita/interfaces/api/schemas.py
+++ b/apps/api/src/atlashabita/interfaces/api/schemas.py
@@ -264,7 +264,13 @@ class ErrorResponse(_ApiModel):
 
 
 class HealthResponse(_ApiModel):
-    """Eco del endpoint de salud (duplicado aquí para centralizar schemas)."""
+    """Contrato del endpoint de salud.
+
+    El router ``health`` mantiene su propio ``BaseModel`` por independencia
+    histórica; esta versión queda como fuente única para clientes que importan
+    desde ``schemas`` y deberá fusionarse con la del router cuando se haga la
+    revisión de schemas (ver ``docs/reviews/v0.5.1-review-cross.md`` #9).
+    """
 
     status: str
     name: str

--- a/apps/web/src/services/auth.ts
+++ b/apps/web/src/services/auth.ts
@@ -137,13 +137,13 @@ export function buildUserFromRegistration(input: {
  *
  * En el MVP no se hashea la contraseña: se guarda tal cual en `localStorage`.
  * Cuando exista backend real, esta función se sustituirá por una llamada a
- * `POST /auth/login` que devuelva el JWT correspondiente.
+ * `POST /auth/login` que devuelva el JWT correspondiente. El hash robusto
+ * (Argon2id en backend o PBKDF2 en cliente) se integra en ese mismo punto.
  *
  * Cadena de seguridad documentada:
  *   1. UI captura email + contraseña con `type="password"` y autocomplete adecuado.
  *   2. `validatePassword` exige longitud y diversidad de caracteres.
  *   3. `assertCredentials` compara contra el registro persistido.
- *   4. TODO: integrar PBKDF2 (o Argon2id en backend) en cuanto el endpoint exista.
  */
 export function assertCredentials(input: {
   email: string;

--- a/apps/web/src/state/auth.ts
+++ b/apps/web/src/state/auth.ts
@@ -50,12 +50,9 @@ export interface AuthUser {
  * Registro persistido de cuentas creadas en el dispositivo.
  *
  * Almacena la contraseña en claro porque el MVP no dispone aún de backend.
- *
- * TODO: integrar PBKDF2 antes de promocionar este store a producción real.
- * Cadena de seguridad:
- *   1. Validación de fortaleza en `services/auth.validatePassword`.
- *   2. Persistencia local únicamente (no se sincroniza con servidor).
- *   3. Sustituible por `POST /auth/{login,register}` cambiando este módulo.
+ * El refuerzo (hash + endpoint real) está documentado en
+ * `services/auth.assertCredentials`, que es el punto único a tocar cuando se
+ * integre `POST /auth/{login,register}`.
  */
 interface AccountRecord {
   readonly user: AuthUser;

--- a/docs/reviews/v0.5.1-review-cross.md
+++ b/docs/reviews/v0.5.1-review-cross.md
@@ -1,0 +1,148 @@
+# Review independiente cross-stack · v0.5.1
+
+> **Reviewer externo (sin contexto previo del proyecto)** | rama `fix/134-review-cross`
+> Foco: ergonomía de la API pública, _naming_, comentarios obsoletos y decisiones
+> cuestionables a lo ancho de los contratos backend (FastAPI/Pydantic) ↔ frontend
+> (Zustand + cliente HTTP). No incluye refactor masivo: sólo se aplican fixes
+> seguros y se documenta el resto como deuda.
+
+## Alcance auditado
+
+- `apps/api/src/atlashabita/interfaces/api/` (routers + `schemas.py` + `app.py`,
+  `middleware.py`, `cache.py`, `deps.py`).
+- `apps/web/src/state/` (7 stores Zustand: `auth`, `compareStore`,
+  `escenariosStore`, `filters`, `mapLayer`, `selection`, `ui`).
+- `apps/web/src/services/` (10 clientes HTTP + `types.ts` + `http.ts`).
+- `apps/web/src/hooks/` (9 hooks TanStack Query).
+
+Quedan deliberadamente fuera (restricción explícita del encargo): workflows CI,
+ontología RDF, los 10 ficheros huérfanos del trabajo paralelo de la issue #130.
+
+## Resumen ejecutivo
+
+El stack está **mucho mejor cuidado de lo que sugieren las cifras de issues
+abiertas**: separación dominio/aplicación/interfaz limpia, `_ApiModel` con
+`frozen=True` y `populate_by_name=True`, validación temprana en routers, Zustand
+con `persist` y `partialize` discplinado. Sin embargo, hay un grupo de
+**inconsistencias visibles desde fuera** que generarán fricción cuando alguien
+nuevo intente integrar:
+
+1. El **contrato `/profiles` divergente** entre backend (`label`, `weights:dict`)
+   y frontend (`name`, `default_weights:Array`).
+2. El **endpoint `/rdf/export` modelado como `GET` en el backend pero
+   consumido como `POST` con body** desde el frontend.
+3. El **endpoint `/sparql` espera `query_id` y el cliente envía `id`**.
+4. **14 schemas Pydantic definidos pero no usados** (`response_model` no
+   conectado en 9 de los 11 routers).
+5. **Persistencia en `localStorage` con dos convenciones**
+   (`atlashabita.<name>.v1` vs `atlashabita:<name>`).
+6. **Dos tópes `MAX_*` para "máximo de territorios a comparar"** y dos stores
+   con un `selectedTerritoryId` (`selection.ts` legacy + `ui.ts` actual).
+
+Ningún hallazgo es bloqueante para una v0.5.1, pero todos son los típicos
+puntos donde se acumula confusión y bugs en tiempo de demo.
+
+## Tabla de hallazgos (ordenados por severidad)
+
+| #   | Severidad   | Área              | Fichero(s)                                                                       | Hallazgo                                                                                                                                                  |
+| --- | ----------- | ----------------- | -------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | **alta**    | contrato API      | `apps/api/.../schemas.py:89-95` ↔ `apps/web/src/services/types.ts:25-30`         | `ProfileRead` devuelve `{label, weights:dict[str,float]}`; el cliente `Profile` espera `{name, default_weights:Array<{factor,weight}>}`. Tests del front mockean **el formato del front**, no el del back, así que el desajuste pasa desapercibido. |
+| 2   | **alta**    | contrato API      | `apps/api/.../routers/rdf_export.py:31-52` ↔ `apps/web/src/services/rdf_export.ts:40-52` | El backend expone `GET /rdf/export?format=…` (sin `territory_id`, sin paginación). El cliente envía `POST /rdf/export` con `{territory_id, chunk_bytes, page}`. Mensaje 405/422 garantizado al primer fetch real. |
+| 3   | **alta**    | contrato API      | `apps/web/src/services/sparql.ts:33-50`                                          | Frontend usa `id` como nombre de campo en `SparqlCatalogEntry` y `SparqlExecuteRequest`; el backend usa `query_id` (`SparqlQueryRequest.query_id`). El POST falla validación. |
+| 4   | **alta**    | dead code         | `apps/api/.../schemas.py` (l. 33-251)                                            | 14 modelos `…Read` están definidos y exportados pero **ningún router los referencia** (ni con `response_model`, ni para validar payload). Sólo `ProfileRead`, `SparqlCatalog*`, `SparqlQuery*` y `HealthResponse` (duplicado) están conectados. Mantenerlos sin uso da una falsa sensación de tipado fuerte. |
+| 5   | **media**   | naming            | `apps/web/src/state/{filters,mapLayer}.ts` vs `{auth,compareStore,escenariosStore}.ts` | Persist keys mezclan dos convenciones: `atlashabita:filters`, `atlashabita:map-layer` (kebab + colon, sin versión visible) frente a `atlashabita.auth.v1`, `atlashabita.compare.v1`, `atlashabita.escenarios.v1` (dot + versión). Versionar todo y unificar en `atlashabita.<name>.v1`. |
+| 6   | **media**   | naming            | `apps/api/.../routers/{rankings,sparql}.py:14,28`                                | Tags FastAPI están en español (`territorios`, `mapa`, `salud`, `accidentes`) salvo `rankings` y `sparql` en inglés. Romperá el agrupado del Swagger UI y la convención del propio proyecto. |
+| 7   | **media**   | duplicación       | `apps/web/src/state/selection.ts:14` y `compareStore.ts:22`                      | `MAX_COMPARISON_ITEMS = 4` y `MAX_COMPARE_ITEMS = 4` definen el mismo tope (RF-007) en dos sitios. Inevitable que diverjan al ajustar el límite. |
+| 8   | **media**   | dead code         | `apps/web/src/state/selection.ts:23-58`                                          | El array `comparison` y los métodos `addToComparison`/`removeFromComparison`/`toggleComparison`/`clearComparison` no tienen ningún consumidor en producción tras introducir `useCompareStore`. Sólo los tests siguen ejercitándolos. |
+| 9   | **media**   | duplicación       | `apps/api/.../schemas.py:266-273` y `apps/api/.../routers/health.py:18-25`       | `HealthResponse` definido dos veces. El comentario "_duplicado aquí para centralizar schemas_" reconoce el problema pero no lo resuelve. Sólo el del router está conectado. |
+| 10  | **media**   | endpoints         | `apps/api/.../routers/territories.py:53-75`                                      | El orden de las rutas es `/{territory_id:path}/indicators` antes que `/{territory_id:path}`, y ambas usan `path` para el ID. La barra final puede generar conflictos sutiles si un día se introduce un sub-recurso adicional. Documentar la convención. |
+| 11  | **baja**    | comentarios       | `apps/web/src/state/auth.ts:54` y `apps/web/src/services/auth.ts:146`            | Dos `TODO: integrar PBKDF2` redundantes para el mismo trabajo de seguridad. El issue tracker es el sitio correcto, no dos comentarios duplicados que envejecen sin enlace al ticket. |
+| 12  | **baja**    | naming            | `apps/web/src/services/rdf_export.ts:14-46`                                      | Mezcla camelCase (`territoryId`, `chunkBytes`) en la API pública del cliente con snake_case (`territory_id`, `chunk_bytes`) en el body que viaja por el cable. Aceptable como mapper, pero es la **única** capa que lo hace; el resto de servicios entrega snake_case del backend tal cual. Documentar la decisión o aplicarla a todos. |
+| 13  | **baja**    | API pública       | `apps/web/src/state/auth.ts:65-66`                                               | El tipo `AuthResult` es discriminado a mano (`{ok:true} \| {ok:false; error:string}`). El backend tiene `ErrorResponse` con `code` + `message` + `details`. Frontend no expone `code` y la UI no puede distinguir tipos de error de auth. |
+| 14  | **baja**    | comentarios       | `apps/api/.../routers/rdf_export.py:8-12`                                        | Comentario explica por qué se llama `rdf_export.py` (colisión con el package `infrastructure.rdf`) — útil al lector, pero ya está obsoleto desde que la app usa `from atlashabita.interfaces.api.routers import rdf_export`. Conservable; sólo trasladar a docstring de módulo. |
+| 15  | **baja**    | API pública       | `apps/api/.../routers/rdf_export.py:48-51`                                       | El parámetro de FastAPI se llama `export_format` con `alias="format"`. Es para evitar colisionar con la builtin `format` de Python — coherente, pero invisible a quien lee el binding `format=...` en el cliente. Una nota en el docstring evita la sorpresa. |
+| 16  | **baja**    | naming            | `apps/web/src/services/types.ts:38-42`                                           | `TerritoryScope` es un template literal type (`country:es \| autonomous_community:${string}`…). Útil, pero el código siempre usa el caso "country:es" como literal y los demás como interpolaciones. Vale la pena exponer un helper `scopeOf(kind, code)` para evitar concatenaciones manuales. |
+| 17  | **baja**    | API pública       | `apps/api/.../routers/sparql.py:53-72`                                           | El docstring de `run_query` expone como contrato `payload.query_id`, pero el cuerpo público lo rotula `SparqlQueryRequest.query_id`. La diferencia entre **id de consulta del catálogo** y **id de fila** (campo `id` ubicuo) confunde al lector. Renombrar a `catalog_id` o `query_name` aclararía. |
+| 18  | **baja**    | comentarios       | `apps/api/.../middleware.py:1-6`                                                 | Comentario "_para producción debe reemplazarse por un store compartido (Redis, etc.)_" sin enlazar a un issue ni a una ADR. Es deuda técnica invisible para un nuevo contribuidor. |
+| 19  | **baja**    | API pública       | `apps/web/src/services/http.ts:91-104`                                           | `toErrorResponse` cae a `code:'UNKNOWN'` y `message:'HTTP <status>'` cuando el payload no tiene la forma esperada. Aceptable, pero descarta `details` silenciosamente. Mejor preservar `payload` en `details.raw` para no perder información de depuración. |
+| 20  | **baja**    | API pública       | `apps/web/src/state/escenariosStore.ts:108-113`                                  | `generateScenarioId` usa `Math.random().toString(36)`. Suficiente para el MVP, pero cuando los escenarios sean compartidos entre dispositivos (sincronización futura) habrá colisiones triviales. Comentar como deuda explícita. |
+| 21  | **baja**    | naming            | `apps/api/.../routers/transit.py:17`                                             | El prefix es `/transit` y el tag `transporte`. El router maneja exclusivamente paradas (`/stops`); el nombre del tag y la URL distan del lenguaje del usuario español ("paradas/transporte público"). Coherencia mejorable. |
+| 22  | **baja**    | API pública       | `apps/api/.../routers/sources.py:43-55`                                          | `GET /sources/{source_id}` itera la lista completa para resolver el detalle (`for source in container.list_sources.execute(): if source.id == ...`). Para el dataset actual no importa; para 200+ fuentes obliga a un índice por ID. |
+| 23  | **baja**    | comentarios       | `apps/web/src/state/ui.ts:3-4`                                                   | Referencia a "milestone M12 — issue #118" en el header del módulo. El estado se compartirá con futuras issues; mejor citar la ADR (si existe) o eliminar la referencia y conservar la descripción funcional. |
+
+## Fixes aplicados en este commit
+
+Restricción del encargo: máximo 3 ficheros tocados, sólo cambios
+"alta-sin-riesgo" (eliminar comentarios obsoletos / duplicados, sin tocar API
+pública). Los tres ficheros tocados son:
+
+1. **#11 — TODO redundante en `apps/web/src/state/auth.ts`**: se elimina del
+   docstring de `AccountRecord` el bloque "_TODO: integrar PBKDF2 …_" + la
+   "_Cadena de seguridad_" que repetía punto a punto la documentación que ya
+   vive en `services/auth.ts:assertCredentials`. El docstring nuevo es de tres
+   líneas y apunta al **único** sitio donde habrá que tocar para integrar el
+   endpoint real, cumpliendo SRP también en la documentación.
+2. **#11 — TODO obsoleto en `apps/web/src/services/auth.ts`**: se reescribe el
+   docstring de `assertCredentials` para incorporar la nota del PBKDF2 dentro
+   de la frase descriptiva ("_El hash robusto … se integra en ese mismo
+   punto_"), y se elimina el ítem `4. TODO: …` que repetía la misma deuda
+   y rompía la numeración de la "_Cadena de seguridad_".
+3. **#9 — Comentario engañoso en `apps/api/.../schemas.py`**: se reemplaza
+   "_Eco del endpoint de salud (duplicado aquí para centralizar schemas)_"
+   por un docstring que reconoce que la duplicación es deuda y enlaza con
+   este propio review (`docs/reviews/v0.5.1-review-cross.md` #9). El comentario
+   anterior daba a entender una decisión deliberada cuando en realidad
+   `HealthResponse` está definido dos veces y sólo se conecta el del router.
+
+> Resto de hallazgos: pendientes de issues dedicadas. Los puntos #1, #2 y #3
+> requieren coordinación entre back y front (cambio de contrato + tests
+> bilaterales) y exceden el "sólo fixes obvios" del encargo.
+
+## Recomendaciones a corto plazo (sin código en esta PR)
+
+- **Issue dedicada** para alinear `/profiles`, `/rdf/export` y `/sparql` (puntos
+  #1-#3). Idealmente con un único PR que toque schemas backend + types frontend
+  + tests bilaterales.
+- **Borrar los 14 modelos `…Read` no usados** de `schemas.py` o, si se
+  conservan, conectarlos a su router con `response_model`. La opción intermedia
+  ("se quedan por si acaso") es la peor de las tres.
+- **Unificar persist keys** a `atlashabita.<name>.v1` y centralizar en un
+  módulo `state/persistKeys.ts` para que el grep sea trivial cuando llegue
+  v2 del esquema.
+- **Borrar el `comparison` legado** de `selection.ts` y migrar `RankingPanel`
+  al `useUiStore.openTerritorySheet` (que ya hace el mismo trabajo) o, si la
+  selección lateral es semánticamente distinta, renombrar a
+  `selectedRowId`/`focusedTerritoryId` para que no pisen al `selectedTerritoryId`
+  del `useUiStore`.
+- **Helper `scopeOf(kind, code)`** en `services/types.ts` para que los
+  consumidores no concatenen `'province:' + p.code` a mano (hallazgo #16).
+
+## Comentarios sobre decisiones de diseño
+
+- El uso de `frozen=True` en `_ApiModel` es la decisión correcta: forzar
+  inmutabilidad en la frontera HTTP cuesta cero y previene mutaciones
+  accidentales en los tests. Ojo: `tuple[..., ...]` en muchos campos
+  (`highlights`, `warnings`, `contributions`) es coherente con la inmutabilidad
+  pero genera serializaciones incómodas en JSON ("[..]"); FastAPI lo resuelve,
+  pero si algún consumidor inyecta los modelos en un `dict` ad-hoc tendrá que
+  re-castear.
+- El cliente `apiFetch` es minimalista y correcto. Puntos a vigilar: no
+  implementa retry con backoff (puede ser deliberado), no respeta `Retry-After`
+  cuando el back devuelve 429 con la cabecera. Hoy no es problema porque el
+  rate limit es en proceso y el front no satura.
+- El stack Zustand+TanStack Query está **bien dividido**: estado de UI en
+  Zustand (efímero o persistido en `localStorage`), estado de servidor en
+  TanStack. La única excepción extraña es `useEscenariosStore.scenarios`,
+  que persiste lo que efectivamente es estado de servidor (escenarios
+  guardados); con backend real conviene mover a TanStack + endpoint.
+
+## Conclusión
+
+La capa pública del producto es coherente y testeable, pero tiene un puñado de
+**desajustes back↔front que detonarán en cuanto un consumidor real haga la
+integración**. Ninguno bloquea la demo de v0.5.1; todos son resolubles con un
+PR pequeño y dirigido por issues nuevas. Este review se cierra aplicando
+únicamente la limpieza de comentarios obsoletos para mantener el alcance del
+encargo.
+
+— Reviewer externo (sin contexto previo) · `fix/134-review-cross`


### PR DESCRIPTION
Resuelve issue #134. Review cross-stack independiente.

## Hallazgos

23 hallazgos en `docs/reviews/v0.5.1-review-cross.md`. Tres desajustes alta documentados (no aplicados — requieren coordinación API/UI):
- `/profiles` schema mismatch (`label`/`weights` vs `name`/`default_weights`).
- `/rdf/export` verbo+payload mismatch (GET vs POST).
- `/sparql` field name (`query_id` vs `id`).

## Aplicado

- Eliminados 2 TODO redundantes de PBKDF2 en `state/auth.ts` y `services/auth.ts`.
- Reescrito comentario engañoso en `schemas.py` (`HealthResponse`).

Sin cambios funcionales — sólo limpieza de comentarios.

## Verificación

```
pnpm typecheck && pnpm lint   # OK
pnpm test                     # 75/75 (state+services)
pytest -k "schema"            # 24/24
```

Closes #134