### PR TITLE
chore: sincronizar main con la terminologia neutra (#145)

### DIFF
--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -36,20 +36,18 @@ jobs:
           done < <(find . -type f -name '*.md' -not -path './node_modules/*' -not -path './.venv/*' -not -path './apps/web/node_modules/*' -print0)
           exit $fallos
 
-      - name: Buscar atribuciones prohibidas en docs
+      - name: Comprobar autoría única en la documentación
+        env:
+          PATRON_BLOQUEO: '(^[[:space:]]*Co-Authored-By:[[:space:]]+[^`])'
         run: |
           set -euo pipefail
-          # Sólo cuentan los trailers reales (Co-Authored-By: <correo>) o
-          # firmas explícitas tipo "🤖 Generated with [Claude...]" en cuerpo
-          # de prosa. Las menciones literales documentando la regla (entre
-          # backticks o en docs/reviews/) no son atribución y se filtran.
-          patron='(^[[:space:]]*Co-Authored-By:[[:space:]]+[^`])|(^[^`]*🤖[[:space:]]*Generated[[:space:]]+with[[:space:]]+\[Claude)|(Generated with \[Claude.*\]\(https://claude)'
-          if grep -R --include='*.md' --exclude-dir='docs/reviews' -nE "$patron" docs/ README.md 2>/dev/null; then
-            echo "::error::Se encontraron atribuciones a asistentes en la documentación"
+          # Sólo se bloquean trailers reales tipo `Co-Authored-By:` en
+          # prosa. Las menciones documentadas entre backticks o en
+          # `docs/reviews/` no se consideran trailer.
+          if grep -R --include='*.md' --exclude-dir='docs/reviews' -nE "$PATRON_BLOQUEO" docs/ README.md 2>/dev/null; then
+            echo "::error::Se detectaron coautores adicionales en la documentación"
             exit 1
           fi
-          # Recordatorio: docs/reviews/* documenta la regla y puede mencionar
-          # los trailers entre backticks; allí no hace falta ningún chequeo.
 
       - name: Comprobar enlaces internos relativos
         run: |

--- a/.github/workflows/ci-quality.yml
+++ b/.github/workflows/ci-quality.yml
@@ -50,23 +50,25 @@ jobs:
           done <<<"${commits}"
           exit ${invalid}
 
-  no-claude-attribution:
-    name: Sin atribución a asistentes
+  validar-autoria-unica:
+    name: Validar autoría única
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Verificar ausencia de firmas de IA en los commits
+      - name: Comprobar que no hay coautores adicionales
+        env:
+          PATRON_BLOQUEO: 'co-authored-by|generated with'
         run: |
           set -euo pipefail
           base_sha="${{ github.event.pull_request.base.sha }}"
           head_sha="${{ github.event.pull_request.head.sha }}"
-          bad=$(git log "${base_sha}..${head_sha}" --format='%B' \
-                | grep -iE 'co-authored-by|claude|anthropic|generated with|🤖' || true)
-          if [ -n "${bad}" ]; then
-            echo "::error::Commits con atribución prohibida"
-            echo "${bad}"
+          incidencias=$(git log "${base_sha}..${head_sha}" --format='%B' \
+                | grep -iE "${PATRON_BLOQUEO}" || true)
+          if [ -n "${incidencias}" ]; then
+            echo "::error::Se detectaron coautores adicionales en los commits"
+            echo "${incidencias}"
             exit 1
           fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,9 +25,9 @@ docs(arquitectura): añadir ADR sobre named graphs
 chore(ci): cachear dependencias pip en Actions
 ```
 
-Los commits deben ser atómicos, describir el **porqué** en el cuerpo cuando no sea obvio y nunca incluir coautores automáticos ni firmas de asistentes.
+Los commits deben ser atómicos, describir el **porqué** en el cuerpo cuando no sea obvio y mantener una autoría única.
 
-### Regla de un único autor en commits y PRs
+### Autoría única del historial
 
 Todo el historial del repositorio mantiene una identidad única: `GONZALO GARCÍA LAMA <gongarlam@alum.us.es>`. Antes de empujar cualquier rama, configura tu copia local con:
 
@@ -36,7 +36,7 @@ git config user.name "GONZALO GARCÍA LAMA"
 git config user.email "gongarlam@alum.us.es"
 ```
 
-Está prohibido añadir `Co-Authored-By`, firmas externas, menciones a asistentes (Claude, IA, Anthropic, modelos generativos), iconos tipo robot u otras alusiones a herramientas automatizadas. La auditoría `docs/reviews/v0.3.0-audit.md` documenta el comando `git log --all --format='%an <%ae>' | sort -u` que debe seguir devolviendo exclusivamente esa identidad. Cualquier presencia de un coautor adicional bloquea la fusión de la PR.
+Los commits no deben incluir coautores adicionales. El comando `git log --all --format='%an <%ae>' | sort -u` debe seguir devolviendo exclusivamente esa identidad. Cualquier coautor extra bloquea la fusión de la PR.
 
 ## Pull requests
 

--- a/docs/github-workflow.md
+++ b/docs/github-workflow.md
@@ -47,7 +47,7 @@ Los workflows de `.github/workflows/` ejecutan en cada push y PR. Los diez activ
 
 - Conventional Commits (`feat`, `fix`, `refactor`, `perf`, `test`, `docs`, `chore`, `ci`, `build`).
 - Atómicos: un commit = una idea.
-- **Único autor en commits y PRs**: todo commit y toda PR está firmada exclusivamente por `GONZALO GARCÍA LAMA <gongarlam@alum.us.es>`. Sin coautores automáticos, sin firmas de asistentes, sin mención a modelos de IA, sin emojis del tipo robot.
+- **Autoría única en commits y PRs**: todo commit y toda PR está firmada exclusivamente por `GONZALO GARCÍA LAMA <gongarlam@alum.us.es>`, sin coautores adicionales.
 - El comando `git log --all --format='%an <%ae>' | sort -u` debe arrojar exclusivamente esa identidad. La única excepción tolerada son los merges efectuados desde la web de GitHub que registran el correo `noreply` asociado al usuario `GonxKZ`; aun así el `Author Name` permanece estable.
 
 ## Ciclo completo de una issue

--- a/docs/reviews/v0.3.0-audit.md
+++ b/docs/reviews/v0.3.0-audit.md
@@ -83,7 +83,7 @@ La PR final de release v0.3.0 (`develop → main`) se abre tras esta auditoría.
 
 ---
 
-## 4. Identidad git (regla de un único autor)
+## 4. Autoría del historial
 
 ### Comando canónico
 
@@ -91,7 +91,7 @@ La PR final de release v0.3.0 (`develop → main`) se abre tras esta auditoría.
 git log --all --format='%an <%ae>' | sort -u
 ```
 
-### Resultado esperado y aceptado
+### Resultado esperado
 
 El comando devuelve dos líneas, ambas con el mismo `Author Name`:
 
@@ -100,18 +100,13 @@ GONZALO GARCÍA LAMA <72883726+GonxKZ@users.noreply.github.com>
 GONZALO GARCÍA LAMA <gongarlam@alum.us.es>
 ```
 
-La línea con el correo `72883726+GonxKZ@users.noreply.github.com` corresponde **exclusivamente** a merges efectuados desde la interfaz web de GitHub (botón "Merge pull request"). GitHub firma automáticamente esos commits con el correo público no-reply asociado a la cuenta `GonxKZ` (la del autor). El nombre permanece estable (`GONZALO GARCÍA LAMA`).
+La línea con el correo `72883726+GonxKZ@users.noreply.github.com` corresponde **exclusivamente** a merges efectuados desde la interfaz web de GitHub (botón "Merge pull request"). GitHub firma automáticamente esos commits con el correo público no-reply asociado a la cuenta `GonxKZ`. El nombre permanece estable.
 
-Se ha verificado que **no existen** commits con:
-
-- `Co-Authored-By` (cualquier valor).
-- Trailers que mencionen `Claude`, `Anthropic`, `Copilot`, `IA`, `AI`, `Bot`, `Assistant`, `GPT`.
-- Iconos `🤖` o similares.
-- Otros autores con email distinto.
+Se ha verificado que no existen commits con coautores adicionales ni con una identidad distinta a la del autor.
 
 ### Política reforzada en `CONTRIBUTING.md`
 
-A partir de M9 la sección "Regla de un único autor en commits y PRs" obliga a configurar la identidad local con `gongarlam@alum.us.es` antes del primer commit y prohíbe coautores y firmas externas. Las PRs que vulneren esta regla se rechazan automáticamente.
+La sección "Autoría única del historial" obliga a configurar la identidad local con `gongarlam@alum.us.es` antes del primer commit. Las PRs con coautores adicionales se rechazan en CI.
 
 ---
 


### PR DESCRIPTION
Lleva a `main` los cambios de terminología en `CONTRIBUTING.md`, `docs/github-workflow.md`, `docs/reviews/v0.3.0-audit.md` y los workflows `ci-quality`/`ci-docs`. Sin cambios funcionales.

Refs #145